### PR TITLE
fix(marketplace): add required owner field; drop stale version pins (#36)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,12 +1,13 @@
 {
   "name": "serenakeyitan-tdoc",
-  "version": "0.1.44",
+  "owner": {
+    "name": "Serena Keyitan"
+  },
   "description": "Single-plugin marketplace hosting tdoc.",
   "plugins": [
     {
       "name": "tdoc",
       "source": "github:serenakeyitan/tdoc",
-      "version": "0.1.44",
       "description": "Prompt-native interactive HTML docs. Open-source community implementation of Jesse Pollak's bdocs idea.",
       "homepage": "https://github.com/serenakeyitan/tdoc"
     }


### PR DESCRIPTION
## Problem

`/plugin marketplace add serenakeyitan/tdoc` — the install path documented in the README and CONTRIBUTING.md — fails schema validation:

```
owner: Invalid input: expected object, received undefined
```

`.claude-plugin/marketplace.json` had no top-level `owner` object, which the current Claude Code marketplace schema requires (`name` + `owner` + `plugins`). It was also frozen at a stale `version: 0.1.44` (plugin is at 0.7.9).

## Fix

- **Add** top-level `"owner": { "name": "Serena Keyitan" }`. The owner schema defines only `name` (required) + `email`; there is no `url` field, so I did not add one (the issue's suggested `url` would itself be invalid).
- **Remove** the stale top-level `version` and the per-plugin `version` (both `0.1.44`). `plugin.json`'s version takes precedence per the docs, and a stale manifest version can mask it — dropping the pin lets the plugin track the real `0.7.9`.

## Verification

- `marketplace.json` parses as valid JSON; `owner` present with `name`; both stale version fields removed; all three required top-level keys present.
- Full offline test suite green (14/14 under Node 22).

Reported by @drbill-orbit. Fixes #36.

🤖 Generated with [Claude Code](https://claude.com/claude-code)