### PR TITLE
fix(publish,doctor): resolve wrangler token across config locations (#37)

### DIFF
--- a/bin/tdoc-doctor
+++ b/bin/tdoc-doctor
@@ -13,6 +13,7 @@
 #   TDOC_MOCK_NO_CF_LOGIN=1         # wrangler not logged in
 #   TDOC_MOCK_NO_SUBDOMAIN=1        # workers.dev subdomain not claimed
 #   TDOC_MOCK_NO_R2=1               # R2 not enabled
+#   TDOC_MOCK_NO_PUBLISH_TOKEN=1    # logged in but stored OAuth token unreadable
 #   TDOC_MOCK_NOT_PUBLISHED=1       # no ~/.tdoc/published.json
 #
 # Exit code is always 0; consumers read the JSON.
@@ -24,6 +25,33 @@ CONFIG_FILE="${TDOC_CONFIG_FILE:-$HOME/.tdoc/published.json}"
 
 # --- helpers ---
 # (Removed unused have() helper — dead code from an abandoned rewrite.)
+
+# Resolve the Cloudflare credential wrangler stored at login. Mirrors
+# wrangler's own getGlobalWranglerConfigPath (xdg-app-paths): legacy
+# ~/.wrangler dir FIRST if it exists, else the xdg location
+# (~/Library/Preferences/.wrangler on macOS, ${XDG_CONFIG_HOME:-~/.config}/
+# .wrangler on Linux, %APPDATA%/xdg.config/.wrangler on Windows). Also honors
+# an explicit CLOUDFLARE_API_TOKEN / CF_API_TOKEN. Must stay in sync with the
+# copy in bin/tdoc-publish. Prints the token + returns 0 if found, else 1.
+resolve_wrangler_oauth_token() {
+  local v
+  for v in "${CLOUDFLARE_API_TOKEN:-}" "${CF_API_TOKEN:-}"; do
+    [ -n "$v" ] && { printf '%s' "$v"; return 0; }
+  done
+  local legacy="$HOME/.wrangler" xdg cands=() base d tok
+  case "$(uname -s)" in
+    Darwin) xdg="${XDG_CONFIG_HOME:-$HOME/Library/Preferences}/.wrangler" ;;
+    MINGW*|MSYS*|CYGWIN*) xdg="${APPDATA:-$HOME/AppData/Roaming}/xdg.config/.wrangler" ;;
+    *)      xdg="${XDG_CONFIG_HOME:-$HOME/.config}/.wrangler" ;;
+  esac
+  if [ -d "$legacy" ]; then cands=("$legacy" "$xdg"); else cands=("$xdg" "$legacy"); fi
+  for base in "${cands[@]}"; do
+    d="$base/config/default.toml"
+    tok="$(grep -E '^oauth_token' "$d" 2>/dev/null | sed -E 's/.*"([^"]+)".*/\1/')"
+    [ -n "$tok" ] && { printf '%s' "$tok"; return 0; }
+  done
+  return 1
+}
 
 # Use jq if available to assemble JSON properly; fall back to manual emission.
 HAS_JQ=0
@@ -57,13 +85,17 @@ cf_account_id=""
 cf_subdomain=""
 cf_subdomain_ok=false
 cf_r2_enabled=false
-cf_publish_token=""
+cf_publish_token_ok=false
 
 if $wrangler_ok && [ -z "${TDOC_MOCK_NO_CF_LOGIN:-}" ]; then
   if wrangler whoami >/dev/null 2>&1; then
     cf_logged_in=true
     cf_account_id="$(wrangler whoami 2>/dev/null | grep -Eo '[a-f0-9]{32}' | head -1 || true)"
-    oauth_token="$(grep -E '^oauth_token' "$HOME/.wrangler/config/default.toml" 2>/dev/null | sed -E 's/.*"([^"]+)".*/\1/' || true)"
+    oauth_token="$(resolve_wrangler_oauth_token || true)"
+    # TDOC_MOCK_NO_PUBLISH_TOKEN: simulate "logged in (whoami works) but the
+    # stored OAuth token can't be read from any wrangler config location".
+    [ -n "${TDOC_MOCK_NO_PUBLISH_TOKEN:-}" ] && oauth_token=""
+    [ -n "$oauth_token" ] && cf_publish_token_ok=true
     if [ -n "$cf_account_id" ] && [ -n "$oauth_token" ]; then
       # Probe subdomain
       if [ -z "${TDOC_MOCK_NO_SUBDOMAIN:-}" ]; then
@@ -101,7 +133,7 @@ fi
 
 # --- ready_to_publish derived flag ---
 ready_to_publish=false
-if $node_ok && $wrangler_ok && $jq_ok && $cf_logged_in && $cf_subdomain_ok && $cf_r2_enabled; then
+if $node_ok && $wrangler_ok && $jq_ok && $cf_logged_in && $cf_publish_token_ok && $cf_subdomain_ok && $cf_r2_enabled; then
   ready_to_publish=true
 fi
 
@@ -117,6 +149,12 @@ if $jq_ok; then
   $jq_ok || cmds="$cmds | . + [{id:\"jq\",label:\"Install jq\",kind:\"install\",cmd:\"brew install jq\"}]"
   if ! $cf_logged_in; then
     cmds="$cmds | . + [{id:\"cf_login\",label:\"Log into Cloudflare\",kind:\"login\",cmd:\"wrangler login\"}]"
+  elif ! $cf_publish_token_ok; then
+    # Logged in (wrangler whoami works) but we couldn't read the stored OAuth
+    # token from any known wrangler config location. Re-login rewrites it, or
+    # the user can supply CLOUDFLARE_API_TOKEN. Without this, doctor used to
+    # silently fall through to "claim subdomain" — misattributing the cause.
+    cmds="$cmds | . + [{id:\"cf_token\",label:\"Re-run wrangler login (could not read stored Cloudflare token)\",kind:\"login\",cmd:\"wrangler login\"}]"
   else
     if ! $cf_subdomain_ok; then
       cmds="$cmds | . + [{id:\"cf_subdomain\",label:\"Claim your free workers.dev subdomain\",kind:\"click\",cmd:\"https://dash.cloudflare.com/$cf_account_id/workers/onboarding\"}]"
@@ -138,6 +176,7 @@ if $jq_ok; then
     --argjson jq_ok "$jq_ok" \
     --argjson gh_ok "$gh_ok" \
     --argjson cf_logged_in "$cf_logged_in" \
+    --argjson cf_publish_token_ok "$cf_publish_token_ok" \
     --arg cf_account_id "$cf_account_id" \
     --argjson cf_subdomain_ok "$cf_subdomain_ok" \
     --arg cf_subdomain "$cf_subdomain" \
@@ -152,7 +191,8 @@ if $jq_ok; then
               wrangler: { ok: $wrangler_ok, version: $wrangler_ver },
               jq: { ok: $jq_ok },
               gh: { ok: $gh_ok } },
-      cloudflare: { logged_in: $cf_logged_in, account_id: $cf_account_id,
+      cloudflare: { logged_in: $cf_logged_in, publish_token_ok: $cf_publish_token_ok,
+                    account_id: $cf_account_id,
                     subdomain: { ok: $cf_subdomain_ok, name: $cf_subdomain },
                     r2_enabled: $cf_r2_enabled },
       published: { ok: $published, subdomain: $publish_subdomain, worker: $publish_worker },

--- a/bin/tdoc-publish
+++ b/bin/tdoc-publish
@@ -61,6 +61,50 @@ cf_api() {
   printf '%s' "$payload"
 }
 
+# Resolve the Cloudflare credential wrangler stored at login.
+#
+# History: this used to hardcode "$HOME/.wrangler/config/default.toml", which
+# broke on a clean modern-wrangler (4.x) macOS install. Wrangler resolves its
+# global config dir via xdg-app-paths (getGlobalWranglerConfigPath): it uses
+# the LEGACY ~/.wrangler dir FIRST if it already exists, otherwise the xdg
+# location — ~/Library/Preferences/.wrangler on macOS, ${XDG_CONFIG_HOME:-
+# ~/.config}/.wrangler on Linux, %APPDATA%/xdg.config/.wrangler on Windows.
+# Honor XDG_CONFIG_HOME on every platform (wrangler does). Also accept an
+# explicit API token from the environment (CI / token-auth users have no
+# default.toml at all).
+#
+# Prints the token on stdout and returns 0 if found; returns 1 otherwise.
+resolve_wrangler_oauth_token() {
+  # 1. Explicit API token from the env wins — these users have no default.toml.
+  local v
+  for v in "${CLOUDFLARE_API_TOKEN:-}" "${CF_API_TOKEN:-}"; do
+    [ -n "$v" ] && { printf '%s' "$v"; return 0; }
+  done
+
+  # 2. Build candidate config dirs in wrangler's own precedence order.
+  local legacy="$HOME/.wrangler" xdg cands=() base d tok
+  case "$(uname -s)" in
+    Darwin) xdg="${XDG_CONFIG_HOME:-$HOME/Library/Preferences}/.wrangler" ;;
+    MINGW*|MSYS*|CYGWIN*) xdg="${APPDATA:-$HOME/AppData/Roaming}/xdg.config/.wrangler" ;;
+    *)      xdg="${XDG_CONFIG_HOME:-$HOME/.config}/.wrangler" ;;
+  esac
+  if [ -d "$legacy" ]; then
+    cands=("$legacy" "$xdg")   # legacy-if-exists first, mirroring wrangler
+  else
+    cands=("$xdg" "$legacy")
+  fi
+
+  # 3. First default.toml that actually contains an oauth_token wins. Scanning
+  #    for the token (not just first-existing-dir) is robust on machines where
+  #    multiple config dirs exist but only one holds a live token.
+  for base in "${cands[@]}"; do
+    d="$base/config/default.toml"
+    tok="$(grep -E '^oauth_token' "$d" 2>/dev/null | sed -E 's/.*"([^"]+)".*/\1/')"
+    [ -n "$tok" ] && { printf '%s' "$tok"; return 0; }
+  done
+  return 1
+}
+
 # When publishing fails for a setup reason (missing dep, R2 not enabled,
 # wrangler logged out), we emit a paste-into-agent prompt instead of a
 # cryptic shell error. The publish modal surfaces stderr to the user, so
@@ -137,9 +181,9 @@ first_time_setup() {
   # 2. auto-detect account id + workers.dev subdomain via Cloudflare API
   echo "[tdoc] detecting account + subdomain..."
   local oauth_token account_id
-  oauth_token="$(grep -E '^oauth_token' "$HOME/.wrangler/config/default.toml" 2>/dev/null | sed -E 's/.*"([^"]+)".*/\1/')"
+  oauth_token="$(resolve_wrangler_oauth_token || true)"
   if [ -z "$oauth_token" ]; then
-    echo "[tdoc] could not read wrangler OAuth token. Re-run 'wrangler login'." >&2
+    echo "[tdoc] could not read a Cloudflare credential. Run 'wrangler login', or set CLOUDFLARE_API_TOKEN." >&2
     exit 1
   fi
   account_id="$(wrangler whoami 2>/dev/null | grep -Eo '[a-f0-9]{32}' | head -1)"

--- a/test/onboarding.test.js
+++ b/test/onboarding.test.js
@@ -82,6 +82,32 @@ function getStep(report, id) {
     if (step.cmd !== 'wrangler login') throw new Error(`expected 'wrangler login', got "${step.cmd}"`);
   });
 
+  await t('Scenario E2: logged in but token unreadable → cf_token step, publish_token_ok false, not ready', () => {
+    const r = runDoctor({ TDOC_MOCK_NO_PUBLISH_TOKEN: '1' });
+    // The token read happens only inside the "wrangler whoami succeeds" block,
+    // so this scenario can only exercise the real elif branch when the host is
+    // actually logged into Cloudflare. On a logged-out box (typical CI), the
+    // mock has nothing to override — assert the logged-out invariant instead,
+    // so the test is deterministic everywhere rather than environment-flaky.
+    if (!r.cloudflare.logged_in) {
+      if (!getStep(r, 'cf_login')) throw new Error('logged-out host should still surface cf_login');
+      return; // can't simulate logged-in-but-no-token without a real login
+    }
+    // Logged-in host: this is the real #37 regression guard. whoami works but
+    // the stored OAuth token can't be read; doctor used to report
+    // logged_in:true and then silently fall through to "claim subdomain",
+    // misattributing the cause.
+    if (r.cloudflare.publish_token_ok) throw new Error('publish_token_ok should be false when token unreadable');
+    if (r.ready_to_publish) throw new Error('cannot be ready without a usable token');
+    const step = getStep(r, 'cf_token');
+    if (!step) throw new Error('cf_token step missing when token unreadable');
+    if (step.kind !== 'login') throw new Error(`cf_token should be kind:login, got ${step.kind}`);
+    // And it must NOT misattribute to subdomain/r2 when the real cause is the token.
+    if (getStep(r, 'cf_subdomain') || getStep(r, 'cf_r2')) {
+      throw new Error('token failure must not surface as subdomain/r2 steps');
+    }
+  });
+
   await t('Scenario F: never published → published.ok is false but does not appear in missing_steps', () => {
     const r = runDoctor({ TDOC_MOCK_NOT_PUBLISHED: '1' });
     if (r.published.ok) throw new Error('published.ok should be false');


### PR DESCRIPTION
## Problem

On a clean **modern-wrangler (4.x) macOS** install, `/tdoc publish` aborts with:

```
[tdoc] could not read wrangler OAuth token. Re-run 'wrangler login'.
```

…even though `wrangler login` just succeeded. And `/tdoc doctor` reports `logged_in: true` while the token read silently fails — misattributing the cause to "claim subdomain / enable R2".

**Root cause:** `bin/tdoc-publish` and `bin/tdoc-doctor` both hardcoded `$HOME/.wrangler/config/default.toml`. Modern wrangler resolves its global config via **xdg-app-paths** (`getGlobalWranglerConfigPath`): legacy `~/.wrangler` dir **first if it exists**, else the xdg location (`~/Library/Preferences/.wrangler` on macOS, `${XDG_CONFIG_HOME:-~/.config}/.wrangler` on Linux, `%APPDATA%/xdg.config/.wrangler` on Windows).

## Fix

- Shared `resolve_wrangler_oauth_token` helper (duplicated in both scripts — they share no lib):
  1. `CLOUDFLARE_API_TOKEN` / `CF_API_TOKEN` win (CI / token-auth users have no `default.toml`).
  2. Scan candidate config dirs in **wrangler's own precedence** (legacy-if-exists first), pick the first `default.toml` that actually contains an `oauth_token`. Honors `XDG_CONFIG_HOME` on every platform.
- `doctor`: surface `cloudflare.publish_token_ok`, fold into `ready_to_publish`, and emit an explicit `cf_token` step when logged-in-but-token-unreadable, so diagnosis stops misattributing.
- Add `TDOC_MOCK_NO_PUBLISH_TOKEN` + onboarding **Scenario E2** regression guard (robust on logged-in and logged-out hosts).

> ⚠️ Note on the reporter's suggested fix: it (and an earlier draft) assumed wrangler uses `env-paths` with `~/.wrangler` **last**. Reading the installed wrangler 4.x source showed it uses **xdg-app-paths with legacy *first***. Getting precedence backwards would pick a **stale token** on machines where both dirs exist. This PR mirrors the real precedence.

## Verification

- Resolver unit-tested across 7 scenarios (env-token, macOS xdg-only, both-dirs→legacy-wins, legacy-empty→scan-to-xdg, Linux XDG, none→fail).
- Exercised on a real logged-in machine: resolver finds the token; `doctor` shows `publish_token_ok: true`, `ready_to_publish: true`.
- Full offline suite green (14/14, Node 22); onboarding 10/10 including new Scenario E2.

Reported by @drbill-orbit. Fixes #37.

🤖 Generated with [Claude Code](https://claude.com/claude-code)