### PR TITLE
fix: replace stale Cloudflare /workers/onboarding link (404) (#38)

### DIFF
--- a/ONBOARDING.md
+++ b/ONBOARDING.md
@@ -102,7 +102,7 @@ Always re-run `bin/tdoc-doctor` between steps. State changes — what was missin
 
 **The two `click` steps you'll encounter most:**
 
-1. **Claim a workers.dev subdomain** — one-time pick. URL: `https://dash.cloudflare.com/<account_id>/workers/onboarding`. User chooses any name (typically their handle). Free.
+1. **Claim a workers.dev subdomain** — one-time pick. URL: `https://dash.cloudflare.com/?to=/:account/workers-and-pages`. On the Workers & Pages page Cloudflare prompts for a subdomain; user chooses any name (typically their handle). Free.
 2. **Enable R2** — one-time click. URL: `https://dash.cloudflare.com/<account_id>/r2`. Free tier is 10 GB. Requires acknowledging Cloudflare's pricing page.
 
 Don't surprise the user — explain briefly *why* before you ask them to click.

--- a/bin/tdoc-doctor
+++ b/bin/tdoc-doctor
@@ -157,7 +157,7 @@ if $jq_ok; then
     cmds="$cmds | . + [{id:\"cf_token\",label:\"Re-run wrangler login (could not read stored Cloudflare token)\",kind:\"login\",cmd:\"wrangler login\"}]"
   else
     if ! $cf_subdomain_ok; then
-      cmds="$cmds | . + [{id:\"cf_subdomain\",label:\"Claim your free workers.dev subdomain\",kind:\"click\",cmd:\"https://dash.cloudflare.com/$cf_account_id/workers/onboarding\"}]"
+      cmds="$cmds | . + [{id:\"cf_subdomain\",label:\"Claim your free workers.dev subdomain\",kind:\"click\",cmd:\"https://dash.cloudflare.com/?to=/:account/workers-and-pages\"}]"
     fi
     if ! $cf_r2_enabled; then
       cmds="$cmds | . + [{id:\"cf_r2\",label:\"Enable R2 on your Cloudflare account (one click, free up to 10GB)\",kind:\"click\",cmd:\"https://dash.cloudflare.com/$cf_account_id/r2\"}]"

--- a/bin/tdoc-publish
+++ b/bin/tdoc-publish
@@ -201,7 +201,7 @@ first_time_setup() {
 
   if [ -z "$SUBDOMAIN" ] || [ "$SUBDOMAIN" = "null" ]; then
     fail_with_agent_prompt "no workers.dev subdomain claimed on Cloudflare account $account_id" \
-      "The user hasn't claimed a workers.dev subdomain yet — tdoc can't publish without one. Open this URL in their browser: https://dash.cloudflare.com/$account_id/workers/onboarding. Ask them to pick any name (usually their handle) and confirm. It's free and one-time. After they say done, run '/tdoc publish $SLUG' again."
+      "The user hasn't claimed a workers.dev subdomain yet — tdoc can't publish without one. Open this URL in their browser: https://dash.cloudflare.com/?to=/:account/workers-and-pages. On the Workers & Pages page, Cloudflare prompts them to pick a workers.dev subdomain (any name, usually their handle). It's free and one-time. After they say done, run '/tdoc publish $SLUG' again."
   fi
   echo "[tdoc] subdomain: ${SUBDOMAIN}.workers.dev"
 

--- a/test/onboarding.test.js
+++ b/test/onboarding.test.js
@@ -70,7 +70,7 @@ function getStep(report, id) {
     const step = getStep(r, 'cf_subdomain');
     if (!step) throw new Error('cf_subdomain step missing');
     if (step.kind !== 'click') throw new Error('cf_subdomain should be kind:click');
-    if (!step.cmd.includes('/workers/onboarding')) throw new Error(`expected onboarding URL, got "${step.cmd}"`);
+    if (!step.cmd.includes('/workers-and-pages')) throw new Error(`expected workers-and-pages URL, got "${step.cmd}"`);
   });
 
   await t('Scenario E: not logged into Cloudflare → cf_login step (login kind)', () => {


### PR DESCRIPTION
## Problem

`https://dash.cloudflare.com/<account_id>/workers/onboarding` now **404s** — Cloudflare moved subdomain claiming into the Workers & Pages dashboard. This dead link blocks first-time setup. The Workers subdomain API's own error message points to the new location:

> Please go to `https://dash.cloudflare.com/?to=/:account/workers-and-pages`. Opening the Workers & Pages landing page for the first time will create a workers.dev subdomain automatically.

## Fix

Replaced the stale URL with Cloudflare's canonical `?to=/:account/workers-and-pages` deep link at **all three** emit sites (the issue listed two — `bin/tdoc-publish` was the missed third, and it's the user-facing publish-flow prompt):

- `bin/tdoc-doctor` — `cf_subdomain` click step
- `bin/tdoc-publish` — "no subdomain claimed" agent prompt
- `ONBOARDING.md` — documented click step

Plus `test/onboarding.test.js` Scenario D, which pinned the old `/workers/onboarding` substring and would otherwise fail.

> Note: I used `?to=/:account/workers-and-pages` (account-independent, routes through Cloudflare's account selector) rather than the issue's `/<account_id>/workers-and-pages` alternative — it drops the dependency on the 32-hex account-id scrape. An earlier draft mistakenly wrote `?to=/:account/workers/workers-and-pages` (extra `/workers/` segment); that's **not** a real dashboard path and is not used here.

R2 and generic-nav dashboard links are unaffected and left untouched.

## Verification

- No `/workers/onboarding` remains anywhere in the repo; new URL present at all 3 sites; R2 links intact.
- Both scripts syntax-valid; onboarding 10/10 (Scenario D asserts the new URL); full offline suite 14/14 (Node 22).

Reported by @drbill-orbit. Fixes #38.

🤖 Generated with [Claude Code](https://claude.com/claude-code)