### PR TITLE
fix(plugin): make manifest `repository` a string so Claude Code accepts it

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -27,8 +27,5 @@
     "prompt-native",
     "interactive"
   ],
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/serenakeyitan/tdoc"
-  }
+  "repository": "https://github.com/serenakeyitan/tdoc"
 }


### PR DESCRIPTION
Thanks for the lightning-fast turnaround on #36, #37, and #38 — all three closed within a couple of days. Here's one more small one in the same spirit.

### The problem
When tdoc is installed as a Claude Code plugin/skill, Claude Code throws a manifest validation error on **every startup**:

```
Plugin tdoc has an invalid manifest file at ~/.claude/skills/tdoc/.claude-plugin/plugin.json.
Validation errors: repository: Invalid input: expected string, received object
```

Claude Code's plugin schema expects `repository` to be a **string** URL, but the manifest currently uses the npm-style object form:

```json
"repository": {
  "type": "git",
  "url": "https://github.com/serenakeyitan/tdoc"
}
```

The error flashes by quickly at launch, so it's easy to miss — but it fails validation each time.

### The fix
Flatten `repository` to the string URL form the schema accepts (same destination):

```json
"repository": "https://github.com/serenakeyitan/tdoc"
```

One line, `plugin.json` still valid JSON. Verified locally that this clears the startup error.