### PR TITLE
test(ci): validate plugin.json + marketplace.json against Claude Code schema

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,6 +21,13 @@ jobs:
       # bash + jq). Runs with no Cloudflare secrets.
       - name: Run offline tests
         run: npm test
+      # Manifest schema guard: plugin.json + marketplace.json must match the
+      # field types Claude Code validates at load/install time. This class of
+      # bug shipped to users 4x (#36 owner, #42 repository) — keep it pinned.
+      # (npm test already runs this; the explicit step makes CI logs self-
+      # documenting and survives a runner restructure.)
+      - name: Validate plugin/marketplace manifests
+        run: node test/manifest.test.js
       # Static guard: the bundled worker must not still contain the overlay
       # placeholder, and worker/server/overlay must parse.
       - name: Syntax check

--- a/test/manifest.test.js
+++ b/test/manifest.test.js
@@ -1,0 +1,154 @@
+// Manifest schema tests.
+//
+// Guards the two JSON manifests Claude Code validates at load/install time
+// against the field types its schema actually enforces. This whole class of
+// bug has already shipped to users FOUR times — every one would have been
+// caught here:
+//   #36  marketplace.json missing required `owner` object
+//   #42  plugin.json `repository` as npm {type,url} object, not a string URL
+//   (plus two version-drift incidents where plugin.json fell behind VERSION)
+//
+// These run offline with zero dependencies (pure node + fs), like the rest of
+// the suite — no network, no secrets, no schema-validator package. The rules
+// below are transcribed from the official references:
+//   plugin.json    -> https://code.claude.com/docs/en/plugins-reference  (Metadata fields)
+//   marketplace.json-> https://code.claude.com/docs/en/plugin-marketplaces (Required fields)
+//
+// Run:
+//   node test/manifest.test.js
+//
+// Exit code: 0 if all pass, 1 otherwise.
+
+const fs = require('fs');
+const path = require('path');
+
+const ROOT = path.join(__dirname, '..');
+const PLUGIN = path.join(ROOT, '.claude-plugin/plugin.json');
+const MARKET = path.join(ROOT, '.claude-plugin/marketplace.json');
+const VERSION_FILE = path.join(ROOT, 'VERSION');
+
+let pass = 0, fail = 0;
+function ok(name) { console.log(`  ✓ ${name}`); pass++; }
+function bad(name, err) { console.log(`  ✗ ${name}\n    ${err}`); fail++; }
+function t(name, fn) { try { fn(); ok(name); } catch (e) { bad(name, e.message); } }
+
+function readJson(p) {
+  const raw = fs.readFileSync(p, 'utf8');
+  try { return JSON.parse(raw); }
+  catch (e) { throw new Error(`${path.basename(p)} is not valid JSON: ${e.message}`); }
+}
+function isObject(v) { return v !== null && typeof v === 'object' && !Array.isArray(v); }
+
+console.log('--- plugin.json (Claude Code plugin manifest schema) ---');
+
+const plugin = (() => { try { return readJson(PLUGIN); } catch (e) { bad('plugin.json parses', e.message); return null; } })();
+
+if (plugin) {
+  t('plugin.json parses as JSON', () => {});
+
+  t('name is a string', () => {
+    if (typeof plugin.name !== 'string' || !plugin.name) throw new Error(`name must be a non-empty string, got ${JSON.stringify(plugin.name)}`);
+  });
+
+  // #42: the schema types `repository` as a string URL. The npm convention
+  // ({ type, url }) is a load error ("repository: expected string, received object").
+  t('repository is a STRING url, not an npm {type,url} object (#42)', () => {
+    if (!('repository' in plugin)) return; // optional field; absent is fine
+    if (typeof plugin.repository !== 'string') {
+      throw new Error(`repository must be a string URL, got ${isObject(plugin.repository) ? 'an object (npm {type,url} form — this is the #42 bug)' : typeof plugin.repository}`);
+    }
+    if (!/^https?:\/\//.test(plugin.repository)) throw new Error(`repository should be a URL, got "${plugin.repository}"`);
+  });
+
+  t('homepage, if present, is a string', () => {
+    if ('homepage' in plugin && typeof plugin.homepage !== 'string') {
+      throw new Error(`homepage must be a string, got ${typeof plugin.homepage}`);
+    }
+  });
+
+  // The schema types `author` as an object (name/email/url) — the inverse of
+  // repository. A bare string here would also mismatch.
+  t('author, if present, is an object (name/email/url)', () => {
+    if ('author' in plugin && !isObject(plugin.author)) {
+      throw new Error(`author must be an object, got ${Array.isArray(plugin.author) ? 'an array' : typeof plugin.author}`);
+    }
+    if (isObject(plugin.author) && typeof plugin.author.name !== 'string') {
+      throw new Error('author.name must be a string');
+    }
+  });
+
+  t('version, if present, is a string', () => {
+    if ('version' in plugin && typeof plugin.version !== 'string') {
+      throw new Error(`version must be a string, got ${typeof plugin.version}`);
+    }
+  });
+
+  // Drift guard: we shipped plugin.json behind the VERSION file twice. They
+  // must agree so the published plugin version matches what we tag/release.
+  t('plugin.json version matches the VERSION file (drift guard)', () => {
+    if (!fs.existsSync(VERSION_FILE)) throw new Error('VERSION file missing');
+    const v = fs.readFileSync(VERSION_FILE, 'utf8').trim();
+    if (plugin.version !== v) {
+      throw new Error(`plugin.json version (${plugin.version}) != VERSION file (${v}) — bump both together`);
+    }
+  });
+}
+
+console.log('\n--- marketplace.json (Claude Code marketplace schema) ---');
+
+const market = (() => { try { return readJson(MARKET); } catch (e) { bad('marketplace.json parses', e.message); return null; } })();
+
+if (market) {
+  t('marketplace.json parses as JSON', () => {});
+
+  t('name is a string', () => {
+    if (typeof market.name !== 'string' || !market.name) throw new Error(`name must be a non-empty string, got ${JSON.stringify(market.name)}`);
+  });
+
+  // #36: `owner` is a REQUIRED top-level object with a required `name`. Its
+  // absence is the exact "owner: expected object, received undefined" error
+  // that blocked `/plugin marketplace add`.
+  t('owner is a required object with a name (#36)', () => {
+    if (!('owner' in market)) throw new Error('owner is REQUIRED and missing — this is the #36 bug (/plugin marketplace add fails schema validation)');
+    if (!isObject(market.owner)) throw new Error(`owner must be an object, got ${typeof market.owner}`);
+    if (typeof market.owner.name !== 'string' || !market.owner.name) throw new Error('owner.name must be a non-empty string');
+  });
+
+  // The owner schema defines only name + email — no `url`. Catching a stray
+  // url here stops us "fixing" #36 with an invalid field (a tempting mistake).
+  t('owner has no invalid `url` field (only name/email are defined)', () => {
+    if (isObject(market.owner) && 'url' in market.owner) {
+      throw new Error('owner.url is not a defined field; the owner schema is name + email only');
+    }
+  });
+
+  t('plugins is a non-empty array', () => {
+    if (!Array.isArray(market.plugins) || market.plugins.length === 0) {
+      throw new Error('plugins must be a non-empty array');
+    }
+  });
+
+  t('each plugin entry has name + source (string)', () => {
+    market.plugins.forEach((p, i) => {
+      if (!isObject(p)) throw new Error(`plugins[${i}] must be an object`);
+      if (typeof p.name !== 'string' || !p.name) throw new Error(`plugins[${i}].name must be a non-empty string`);
+      if (typeof p.source !== 'string' || !p.source) throw new Error(`plugins[${i}].source must be a non-empty string`);
+    });
+  });
+
+  // #36 follow-on: a per-plugin `version` pin only updates when the string
+  // changes, so it silently freezes users on a stale version (it was stuck at
+  // 0.1.44 while the plugin was 0.7.x). plugin.json's version is the source of
+  // truth; the marketplace entry should not also pin one.
+  t('no stale per-plugin version pin in marketplace entries (#36)', () => {
+    market.plugins.forEach((p, i) => {
+      if ('version' in p) {
+        throw new Error(`plugins[${i}] sets version="${p.version}"; remove it so plugin.json's version is the single source of truth (a marketplace pin goes stale silently)`);
+      }
+    });
+  });
+}
+
+console.log('');
+if (fail) { console.log(`${pass} passed, ${fail} failed.`); process.exit(1); }
+console.log(`${pass} passed, 0 failed.`);

--- a/test/run.js
+++ b/test/run.js
@@ -15,6 +15,7 @@ const { spawnSync } = require('child_process');
 const path = require('path');
 
 const OFFLINE = [
+  'manifest.test.js',         // plugin.json / marketplace.json schema (#36, #42)
   'comment-history.test.js',  // event-log fold + cross-version pull
   'event-convergence.test.js',// eid dedup convergence + fold ordering
   'reconcile.test.js',        // anchor reconcile branches + compaction


### PR DESCRIPTION
## Why

This class of manifest-schema bug has shipped to users **four times** — and CI never touched the manifests. Every one would have been caught by this test:

| Bug | What broke |
|---|---|
| [#36](https://github.com/serenakeyitan/tdoc/issues/36) | `marketplace.json` missing required `owner` object → `/plugin marketplace add` fails |
| [#42](https://github.com/serenakeyitan/tdoc/pull/42) | `plugin.json` `repository` as npm `{type,url}` object → startup validation error |
| (×2) | version drift — `plugin.json` fell behind the `VERSION` file |

## What

`test/manifest.test.js` — offline, **zero dependencies** (pure node + fs, like the rest of the suite; no schema-validator package, no secrets). Asserts the field types Claude Code enforces at load/install time:

- **plugin.json**: `repository`=string (not npm object), `homepage`=string, `author`=object, `version`=string, and `version == VERSION` (drift guard).
- **marketplace.json**: `owner`=object with `name` (required), `owner` has no invalid `url`, `plugins`=non-empty array of `{name,source}`, no stale per-plugin `version` pin.

Wired into `test/run.js` (so `npm test` / CI run it) and added an explicit **"Validate plugin/marketplace manifests"** step to `.github/workflows/test.yml` for self-documenting CI logs.

## Verification

- Real manifests pass **14/14**; full offline suite **15/15** green.
- **Regression-proven**: re-introducing each of 5 historical bug variants (object-form `repository`, missing `owner`, stale version pin, version drift, invalid `owner.url`) makes the test fail; restore is byte-clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)