### PR TITLE
docs(governance): SECURITY.md, CODEOWNERS, issue/PR templates, CodeQL

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,27 @@
+# Code owners for tdoc.
+#
+# CI can't catch a *semantically* malicious change — an overlay tweak that
+# exfiltrates reader data, a worker change that weakens auth, a CLI change that
+# leaks the Cloudflare token. Only a human can. These paths are the code that,
+# if poisoned, runs in every reader's browser or touches every publisher's
+# Cloudflare account, so they require the maintainer's review on every PR.
+# (Pair this with "Require review from Code Owners" in branch protection.)
+
+# Default owner for everything not matched more specifically below.
+*                       @serenakeyitan
+
+# The browser overlay — bundled into the worker and executed in every reader's
+# browser. Highest-risk surface.
+/server/overlay.js      @serenakeyitan
+
+# The Cloudflare Worker — handles untrusted request bodies + auth.
+/worker/                @serenakeyitan
+
+# The CLIs — read Cloudflare OAuth tokens and run on the user's machine.
+/bin/                   @serenakeyitan
+
+# CI, security policy, and ownership itself — a PR must not be able to weaken
+# its own gates.
+/.github/               @serenakeyitan
+/SECURITY.md            @serenakeyitan
+/.claude-plugin/        @serenakeyitan

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,45 @@
+name: Bug report
+description: Something in tdoc doesn't work as expected
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for filing a bug. If this is a **security** issue (a way to inject
+        script into a reader's page, leak a Cloudflare token, or bypass auth),
+        please **don't** use this form — report it privately per
+        [SECURITY.md](../blob/main/SECURITY.md).
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: What did you do, what did you expect, what happened instead?
+      placeholder: "Ran `/tdoc publish foo`, expected a URL, got ..."
+    validations:
+      required: true
+  - type: textarea
+    id: repro
+    attributes:
+      label: Steps to reproduce
+      placeholder: |
+        1. /tdoc new "..."
+        2. /tdoc publish
+        3. ...
+    validations:
+      required: true
+  - type: textarea
+    id: doctor
+    attributes:
+      label: "`/tdoc doctor` output"
+      description: Paste the JSON from `bin/tdoc-doctor` (it redacts secrets). This pins down deps + Cloudflare state fast.
+      render: json
+    validations:
+      required: false
+  - type: input
+    id: env
+    attributes:
+      label: Environment
+      description: OS, Node version (`node --version`), and how you installed tdoc (git clone vs plugin marketplace).
+      placeholder: "macOS 14, Node 20.11, plugin marketplace"
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Security vulnerability
+    url: https://github.com/serenakeyitan/tdoc/security/advisories/new
+    about: Report security issues privately here, not as a public issue.
+  - name: Question / how-to
+    url: https://github.com/serenakeyitan/tdoc/issues
+    about: Search existing issues first; open a new one with the "question" label if needed.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,25 @@
+name: Feature request
+description: Suggest an idea for tdoc
+labels: ["enhancement"]
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: What problem does this solve?
+      description: Describe the use case, not just the feature. What can't you do today?
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+      description: What would you like tdoc to do?
+    validations:
+      required: false
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Anything you've tried or other approaches you weighed.
+    validations:
+      required: false

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,25 @@
+<!-- Thanks for contributing to tdoc! Please fill this in — it's short. -->
+
+## What & why
+
+<!-- One or two sentences. Link the issue this addresses: "Fixes #123". -->
+
+## Checklist
+
+- [ ] `npm test` passes locally (offline suite).
+- [ ] If I touched anything browser-facing (`server/overlay.js`, `server/server.js`)
+      or the worker (`worker/worker.js`), I ran `npm run test:all` with Playwright
+      installed (`npm i -D playwright && npx playwright install chromium`).
+- [ ] If I edited `SKILL.md`, I copied it to `skills/tdoc/SKILL.md` so the two
+      stay in sync (`cp SKILL.md skills/tdoc/SKILL.md`). They must match — the
+      plugin-mode install reads the copy.
+- [ ] If I changed the version, I bumped `VERSION` **and** `.claude-plugin/plugin.json`
+      together (the manifest test enforces this).
+
+## Security note
+
+<!-- Required if you touched overlay.js / worker.js / bin/*. These run in
+     readers' browsers or handle Cloudflare tokens. Briefly: what untrusted
+     input does your change touch, and how did you make sure it can't inject
+     script / leak a token / bypass auth? Write "n/a" if your change doesn't
+     touch those paths. -->

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,44 @@
+name: codeql
+
+# Static taint analysis for the JavaScript surface. The overlay
+# (server/overlay.js) renders untrusted comment text into every reader's
+# browser, and the worker (worker.js) handles untrusted request bodies — the
+# repo's two highest-risk files. The hand-written security tests cover KNOWN
+# XSS/escaping cases; CodeQL catches NEW injection sinks a contributor
+# introduces (a fresh innerHTML/eval/sink the fixed-case tests don't know to
+# look for).
+#
+# JavaScript only — the bash CLIs are covered by shellcheck in test.yml;
+# CodeQL doesn't analyze shell.
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    # Weekly, so a sink that lands without a PR (or a new CodeQL query) still
+    # gets caught. Monday 07:00 UTC.
+    - cron: '0 7 * * 1'
+
+permissions:
+  contents: read
+
+jobs:
+  analyze:
+    name: analyze javascript
+    runs-on: ubuntu-latest
+    permissions:
+      # CodeQL needs to write its findings to the Security tab.
+      security-events: write
+      contents: read
+    steps:
+      # Actions pinned to commit SHAs (see test.yml for why). github/codeql-action
+      # v3 -> codeql-bundle-v2.25.6.
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@dd903d2e4f5405488e5ef1422510ee31c8b32357 # v3
+        with:
+          languages: javascript
+      - name: Perform CodeQL analysis
+        uses: github/codeql-action/analyze@dd903d2e4f5405488e5ef1422510ee31c8b32357 # v3

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,61 @@
+# Security Policy
+
+## Reporting a vulnerability
+
+**Please report security issues privately — do not open a public issue.**
+
+Use GitHub's [private vulnerability reporting](https://github.com/serenakeyitan/tdoc/security/advisories/new)
+(Security → Advisories → "Report a vulnerability"). That keeps the report
+confidential until a fix is available.
+
+You'll get an acknowledgement as soon as the maintainer sees it. tdoc is a
+solo-maintained, agent-authored project, so please allow a little time — but a
+real vulnerability will always take priority.
+
+## What's in scope
+
+tdoc has three components worth thinking about as an attacker would:
+
+1. **The browser overlay** (`server/overlay.js`) is bundled into the worker at
+   publish time and runs in **every reader's browser** on every published doc.
+   It renders untrusted input (comment text, author names, avatars). A way to
+   get script execution into a reader's page (stored XSS, an injection sink,
+   an escaping bypass) is the highest-severity class here.
+2. **The Cloudflare Worker** (`worker/worker.js`) accepts untrusted request
+   bodies (comments, reactions, uploads) and gates writes behind an upload
+   token + GitHub sign-in. Auth bypass, injection, or a way to corrupt/forge
+   another author's comments are in scope.
+3. **The CLIs** (`bin/tdoc-*`) read your Cloudflare OAuth token from disk and
+   call the Cloudflare API with it. They run on your machine. A way to make a
+   CLI leak the token, run unexpected commands, or write outside its expected
+   paths is in scope.
+
+## Trust model (so you know what tdoc does and doesn't do with your data)
+
+- **Your Cloudflare token never leaves your machine except to Cloudflare.** The
+  CLIs read it locally and send it only to `api.cloudflare.com`. The tdoc
+  maintainer runs no central server and never sees your token or your docs.
+- **You publish to your own Cloudflare Worker.** Your published docs live in
+  your account, not a shared host.
+- **Published docs require a one-time GitHub sign-in to comment** (Device Flow,
+  scope `read:user`). Local docs comment anonymously with no auth.
+- **Untrusted text is HTML-escaped on render** — comment bodies, author names,
+  and avatar URLs — so a comment can't inject script into the page. (If you
+  find a case where it can, that's exactly the kind of report this policy is
+  for.)
+- **Telemetry never includes your doc content, prompts, or file paths.** See
+  the Telemetry section of the README for the full field list and opt-out.
+
+## Out of scope
+
+- Vulnerabilities in Cloudflare, GitHub, Node, or other upstream dependencies —
+  report those to the respective project.
+- The `telemetry/` directory's Supabase edge functions (operational tooling,
+  not part of the installed skill).
+- Social-engineering, physical access, or anything requiring a
+  already-compromised machine.
+
+## Supported versions
+
+tdoc ships from `main`; the latest tagged release is the supported version.
+Fixes land on `main` and go out in the next release.


### PR DESCRIPTION
## Why

OSS-practice hardening focused on this repo's **real** risk profile: tdoc injects a browser overlay into every reader's page, handles Cloudflare OAuth tokens in `bin/*`, and now takes community PRs. These are the PR-safety + disclosure gaps an audit surfaced.

## What

- **`SECURITY.md`** — private vulnerability reporting channel + an explicit trust model (token never leaves your machine except to Cloudflare; overlay runs in readers' browsers; untrusted text is escaped). Stops a real vuln from becoming a public 0-day issue.
- **`.github/CODEOWNERS`** — makes @serenakeyitan the required reviewer on the paths CI can't vet *semantically*: `overlay.js`, `worker/`, `bin/`, `.github/` (so a PR can't weaken its own gates), `.claude-plugin/`. Pair with "require Code Owner review" in branch protection.
- **PR template** — repo-specific safety checklist: run `test:all` when touching the overlay/worker, keep `SKILL.md` ↔ `skills/tdoc/SKILL.md` in sync, bump `VERSION` + `plugin.json` together — plus a security note for overlay/worker/bin changes.
- **Issue templates** (bug/feature) + config routing security reports to private advisories.
- **CodeQL** (JavaScript only; SHA-pinned; PR + weekly) — static taint analysis on the overlay + worker to catch **new** injection sinks the fixed-case `security.test.js` can't. Bash is covered by shellcheck, not CodeQL.

## Verification

- All YAML (issue templates + CodeQL workflow) validated.
- No `bin/*` or app code touched; offline suite still 15/15.
- CodeQL will run for the first time on this PR — its result appears as a separate (non-blocking) check; the required gate remains `offline test suite`.

> Note: the **private vulnerability reporting** toggle and **"require Code Owner review"** are repo *settings* I'll enable separately (they're not files).

Part of the DevOps hardening pass (P0/P1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)