### PR TITLE
ci: dependabot for github-actions only (keep SHA pins fresh)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,21 @@
+version: 2
+updates:
+  # GitHub Actions ONLY. The npm ecosystem is intentionally omitted: tdoc has
+  # zero runtime/dev dependencies (Playwright is an optional peer for gated
+  # tests), so there is nothing to lock or update there — a dependabot npm
+  # config would only generate noise.
+  #
+  # We DO pin actions to commit SHAs (see .github/workflows/*.yml), which means
+  # they never auto-update. This is the mechanism that updates those pins:
+  # dependabot opens a PR bumping the SHA (and the # vX.Y.Z comment) when an
+  # action ships a new release, so the pinned-SHA security posture stays
+  # current instead of going stale.
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "ci"
+    labels:
+      - "dependencies"


### PR DESCRIPTION
## Why

PR #44 pinned the GitHub Actions to commit SHAs — which means they now never auto-update. This config is the **mechanism that keeps those pins current**: dependabot opens a weekly PR bumping the SHA (and `# vX.Y.Z` comment) when an action ships a release.

**npm ecosystem is deliberately omitted** — tdoc has zero runtime/dev deps (Playwright is an optional peer for gated tests), so an npm dependabot config would only generate noise. This is the one Dependabot slice that earns its keep here.

## Verification

- `dependabot.yml` is valid YAML.
- Only file added; offline suite unaffected.

Final item of the DevOps hardening pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)