### PR TITLE
ci: finish action major bumps (setup-node v6, codeql-action v4)

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -33,12 +33,14 @@ jobs:
       security-events: write
       contents: read
     steps:
-      # Actions pinned to commit SHAs (see test.yml for why). github/codeql-action
-      # v3 -> codeql-bundle-v2.25.6.
+      # Actions pinned to commit SHAs (see test.yml for why). The init and
+      # analyze steps MUST stay on the same codeql-action version/SHA — a
+      # mismatch fails the run ("Not all workflow steps … use the same
+      # version"), which is why these bump together, never one at a time.
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@dd903d2e4f5405488e5ef1422510ee31c8b32357 # v3
+        uses: github/codeql-action/init@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
         with:
           languages: javascript
       - name: Perform CodeQL analysis
-        uses: github/codeql-action/analyze@dd903d2e4f5405488e5ef1422510ee31c8b32357 # v3
+        uses: github/codeql-action/analyze@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,7 +24,7 @@ jobs:
       # code in our PR-triggered pipeline. The trailing comment records the
       # human-readable version the SHA corresponds to; bump both together.
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: '20'
       # jq is needed by the CLI tests that drive bin/tdoc-* hermetically.


### PR DESCRIPTION
Dependabot's first run opened one PR per outdated action (#49–#52). [#49](https://github.com/serenakeyitan/tdoc/pull/49) (checkout v7) already merged clean. This finishes the rest **in a single PR** because two of them must move together.

## What

- `actions/setup-node` 4.4.0 → 6.4.0 (was #50)
- `github/codeql-action/init` v3 → v4.36.2 (was #51)
- `github/codeql-action/analyze` v3 → v4.36.2 (was #52)

## Why one PR

#51 and #52 **failed on their own**: Dependabot bumped `init` and `analyze` in separate PRs, leaving the two `codeql-action` steps on mismatched versions, which fails the run:

> Not all workflow steps that use `github/codeql-action` actions use the same version.

They have to move to the same SHA together. Done here, with a comment in `codeql.yml` documenting the invariant so a future split bump doesn't regress it. (#50 conflicted with #49 only because both touch adjacent lines in `test.yml`; folded in here too.)

## Verification

CI on this PR exercises the new versions directly — `offline test suite` (setup-node v6) and `analyze javascript` (codeql v4) both run here. Merging only after they're green.

Closes #50, #51, #52.

🤖 Generated with [Claude Code](https://claude.com/claude-code)