### PR TITLE
fix: dual-engine code audit (Codex + Claude) — reaction data-loss, injection, traversal

### DIFF
--- a/bin/tdoc-publish
+++ b/bin/tdoc-publish
@@ -21,6 +21,14 @@ if [ -z "$SLUG" ]; then
   echo "usage: tdoc-publish <slug>" >&2
   exit 1
 fi
+# Validate the slug BEFORE it becomes a filesystem path or a URL query value.
+# Same kebab-case rule tdoc-new enforces. Without this a `..` slug escapes
+# TDOC_DIR (read/publish an arbitrary dir) and an unsafe slug injects into the
+# Cloudflare API query string.
+if ! printf '%s' "$SLUG" | grep -Eq '^[a-z0-9]([a-z0-9-]*[a-z0-9])?$'; then
+  echo "[tdoc] invalid slug '$SLUG' — must be lowercase kebab-case (a-z, 0-9, -)." >&2
+  exit 1
+fi
 
 SKILL_DIR="$HOME/.claude/skills/tdoc"
 TDOC_DIR="${TDOC_DIR:-$HOME/tdocs}"
@@ -285,16 +293,22 @@ first_time_setup() {
   echo "[tdoc] setting TDOC_UPLOAD_TOKEN secret..."
   (cd "$WORKER_DIR" && echo "$token" | wrangler secret put TDOC_UPLOAD_TOKEN)
 
-  # 9. save config
-  jq -n \
-    --arg sub "$SUBDOMAIN" \
-    --arg tok "$token" \
-    --arg kv "$kv_id" \
-    --arg worker "$worker_name" \
-    --arg host "$PUBLIC_HOST" \
-    --arg custom "$CUSTOM_DOMAIN" \
-    '{subdomain:$sub, upload_token:$tok, kv_id:$kv, worker:$worker, public_host:$host, custom_domain:$custom, created: now | todate}' \
-    > "$CONFIG_FILE"
+  # 9. save config. Create it 0600 FROM THE START (umask 077 in a subshell) — a
+  # plain `> "$CONFIG_FILE"` under the default umask 022 would briefly leave the
+  # file (which holds TDOC_UPLOAD_TOKEN) world-readable until the chmod ran. The
+  # explicit chmod 600 stays as belt-and-suspenders for a pre-existing file.
+  (
+    umask 077
+    jq -n \
+      --arg sub "$SUBDOMAIN" \
+      --arg tok "$token" \
+      --arg kv "$kv_id" \
+      --arg worker "$worker_name" \
+      --arg host "$PUBLIC_HOST" \
+      --arg custom "$CUSTOM_DOMAIN" \
+      '{subdomain:$sub, upload_token:$tok, kv_id:$kv, worker:$worker, public_host:$host, custom_domain:$custom, created: now | todate}' \
+      > "$CONFIG_FILE"
+  )
   chmod 600 "$CONFIG_FILE"
 
   if [ -n "$CUSTOM_DOMAIN" ]; then

--- a/bin/tdoc-pull
+++ b/bin/tdoc-pull
@@ -12,6 +12,14 @@ set -euo pipefail
 
 SLUG="${1:-}"
 if [ -z "$SLUG" ]; then echo "usage: tdoc-pull <slug>" >&2; exit 1; fi
+# Validate before $SLUG becomes a filesystem path (OUT="$TDOC_DIR/$SLUG/…") or a
+# raw query value in the Cloudflare API URL. A `..` slug would write
+# comments.json outside TDOC_DIR. Same kebab-case rule as tdoc-new; the allowed
+# charset [a-z0-9-] is also URL-safe, so no extra encoding is needed.
+if ! printf '%s' "$SLUG" | grep -Eq '^[a-z0-9]([a-z0-9-]*[a-z0-9])?$'; then
+  echo "[tdoc] invalid slug '$SLUG' — must be lowercase kebab-case (a-z, 0-9, -)." >&2
+  exit 1
+fi
 
 CONFIG_FILE="$HOME/.tdoc/published.json"
 TDOC_DIR="${TDOC_DIR:-$HOME/tdocs}"

--- a/bin/tdoc-unpublish
+++ b/bin/tdoc-unpublish
@@ -6,6 +6,12 @@ set -euo pipefail
 
 SLUG="${1:-}"
 if [ -z "$SLUG" ]; then echo "usage: tdoc-unpublish <slug>" >&2; exit 1; fi
+# Validate before $SLUG goes into the Cloudflare API DELETE query. Same
+# kebab-case rule as tdoc-new; [a-z0-9-] is URL-safe.
+if ! printf '%s' "$SLUG" | grep -Eq '^[a-z0-9]([a-z0-9-]*[a-z0-9])?$'; then
+  echo "[tdoc] invalid slug '$SLUG' — must be lowercase kebab-case (a-z, 0-9, -)." >&2
+  exit 1
+fi
 
 CONFIG_FILE="$HOME/.tdoc/published.json"
 if [ ! -f "$CONFIG_FILE" ]; then

--- a/bin/tdoc-update
+++ b/bin/tdoc-update
@@ -64,7 +64,8 @@ git --no-pager log --oneline "$LOCAL..$REMOTE" | sed 's/^/  /'
 echo
 
 if [ "$CHECK" = "1" ]; then
-  echo "[tdoc-update] --check: not applying. ${#} commit(s) ahead."
+  # ${#} would be the CLI arg count (1 for `--check`), not the commit count.
+  echo "[tdoc-update] --check: not applying. $(git rev-list --count "$LOCAL..$REMOTE") commit(s) ahead."
   exit 0
 fi
 
@@ -125,8 +126,14 @@ if [ -f "$CONFIG_FILE" ]; then
   fi
   echo
   if [ "$YES" = "1" ]; then
-    echo "[tdoc-update] --yes: redeploying worker (and uploading $PUBLISHED_SLUG)..."
-    "$SKILL_DIR/bin/tdoc-publish" "${PUBLISHED_SLUG:-}" || true
+    if [ -n "$PUBLISHED_SLUG" ]; then
+      echo "[tdoc-update] --yes: redeploying worker (and uploading $PUBLISHED_SLUG)..."
+      "$SKILL_DIR/bin/tdoc-publish" "$PUBLISHED_SLUG" || true
+    else
+      # No local doc to re-publish — calling tdoc-publish with an empty slug
+      # would just hit its usage error (silently, via || true). Skip cleanly.
+      echo "[tdoc-update] --yes: code updated, but no local doc found to redeploy; skipping upload."
+    fi
   else
     echo "[tdoc-update] you have a published worker. To pick up code changes, redeploy with:"
     echo "    $SKILL_DIR/bin/tdoc-publish ${PUBLISHED_SLUG:-<slug>}"

--- a/server/overlay.js
+++ b/server/overlay.js
@@ -1063,6 +1063,18 @@
     while (i < min && a[i] === b[i]) i++;
     return i;
   }
+  // Find the element whose data-tdoc-aid EQUALS `aid`, without ever putting the
+  // (untrusted, commenter-supplied) aid into a selector string. Returns the
+  // first match or null.
+  function matchByAid(aid) {
+    if (aid == null) return null;
+    const target = String(aid);
+    const all = document.querySelectorAll('[data-tdoc-aid]');
+    for (let i = 0; i < all.length; i++) {
+      if (all[i].getAttribute('data-tdoc-aid') === target) return all[i];
+    }
+    return null;
+  }
   function findElement(anchor) {
     if (!anchor) return null;
     // Server-side reconciliation may have marked the anchor as lost — the
@@ -1084,7 +1096,13 @@
     if (fromSelector && !aidCandidates.includes(fromSelector)) aidCandidates.push(fromSelector);
     if (aidCandidates.length) {
       for (const aid of aidCandidates) {
-        const byAid = document.querySelector(`[data-tdoc-aid="${aid}"]`);
+        // Match by attribute EQUALITY, never by interpolating the aid into a
+        // selector string. `aid` is server-stored anchor data a commenter can
+        // craft; building `[data-tdoc-aid="${aid}"]` lets a value like
+        // `x"], body, [...` break out of the attribute selector (anchor onto
+        // the wrong element) or throw an uncaught SyntaxError that aborts
+        // refreshComments for every viewer. Equality match can do neither.
+        const byAid = matchByAid(aid);
         if (byAid) return byAid;
       }
       // Recorded aid(s), none present in this DOM → unanchored, never fallback.
@@ -1320,11 +1338,7 @@
         e.stopPropagation();
         if (isFork) return; // read-only mode
         if (isPublished && !identity) { startDeviceFlow(); return; }
-        await fetch('/api/reactions', {
-          method: 'POST', headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ slug, comment_id: chip.dataset.targetId, emoji: chip.dataset.emoji, version })
-        });
-        await refreshComments();
+        if (await postReaction(chip.dataset.targetId, chip.dataset.emoji)) await refreshComments();
       };
     });
     card.querySelectorAll('.tdoc-react-add').forEach(addBtn => {
@@ -1337,6 +1351,30 @@
 
     card.addEventListener('click', (e) => { e.stopPropagation(); setActiveComment(comment.id); });
     return card;
+  }
+
+  // Submit a reaction toggle. Centralizes error handling the two call sites
+  // (react chip + emoji picker) were missing: on an expired session the server
+  // returns 401 — re-auth instead of silently dropping the click; on network
+  // failure, swallow rather than leaving an unhandled promise rejection.
+  // Returns true if the caller should refresh.
+  async function postReaction(targetId, emoji) {
+    try {
+      const r = await fetch('/api/reactions', {
+        method: 'POST', headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ slug, comment_id: targetId, emoji, version }),
+      });
+      if (r.status === 401) { if (isPublished) startDeviceFlow(); return false; }
+      if (!r.ok) {
+        const err = await r.json().catch(() => ({}));
+        alert('Could not react: ' + (err.error || err.message || `HTTP ${r.status}`));
+        return false;
+      }
+      return true;
+    } catch (e) {
+      alert('Could not react: network error');
+      return false;
+    }
   }
 
   // ========== Emoji picker ==========
@@ -1367,11 +1405,7 @@
         e.stopPropagation();
         const emoji = b.dataset.emoji;
         closeEmojiPicker();
-        await fetch('/api/reactions', {
-          method: 'POST', headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ slug, comment_id: targetId, emoji, version })
-        });
-        await refreshComments();
+        if (await postReaction(targetId, emoji)) await refreshComments();
       };
     });
   }
@@ -1594,17 +1628,21 @@
     } else {
       try {
         const r = await fetch(`/api/comments?slug=${encodeURIComponent(slug)}&version=${version}`);
-        list = await r.json();
+        // The endpoint returns an array on success but an error ENVELOPE
+        // ({error:...}) on 4xx/5xx. Guard the shape so a non-array body can't
+        // throw on .filter() below and abort all comment rendering.
+        const body = r.ok ? await r.json() : null;
+        list = Array.isArray(body) ? body : [];
       } catch { list = []; }
     }
-    state.activeComments = list.filter(c => c.status !== 'resolved');
+    state.activeComments = (Array.isArray(list) ? list : []).filter(c => c && c.status !== 'resolved');
     document.body.classList.toggle('tdoc-has-comments', state.activeComments.length > 0);
     document.body.dataset.tdocReady = '1';
 
     const fabCount = document.getElementById('tdoc-fab-count');
     if (fabCount) fabCount.textContent = state.activeComments.length;
 
-    const textCache = state.activeComments.some(c => (c.anchor?.kind || (c.anchor?.text ? 'text' : null)) === 'text')
+    let textCache = state.activeComments.some(c => (c.anchor?.kind || (c.anchor?.text ? 'text' : null)) === 'text')
       ? collectTextNodes() : null;
     for (const comment of state.activeComments) {
       const kind = comment.anchor?.kind || (comment.anchor?.text ? 'text' : null);
@@ -1619,6 +1657,11 @@
               span.addEventListener('click', (e) => { e.stopPropagation(); setActiveComment(comment.id); });
               span.style.cursor = 'pointer';
               state.anchorMarks.set(comment.id, { kind: 'text', el: span });
+              // surroundContents() split the text node, invalidating the cached
+              // node list — recompute so later text comments don't anchor
+              // against stale nodes. (HIGHLIGHT_API path doesn't mutate the DOM,
+              // so it can keep sharing one cache.)
+              textCache = collectTextNodes();
             }
           }
         }
@@ -1689,13 +1732,33 @@
   let pollInterval = 5;
   async function startDeviceFlow() {
     if (!isPublished) return;
-    const r = await fetch('/api/auth/device/start', { method: 'POST' });
-    const data = await r.json();
-    if (data.error) { alert('Sign-in error: ' + (data.message || data.error)); return; }
+    let data;
+    try {
+      const r = await fetch('/api/auth/device/start', { method: 'POST' });
+      if (!r.ok) throw new Error('HTTP ' + r.status);
+      data = await r.json();
+    } catch (e) {
+      // Network failure or a non-JSON edge error (e.g. an HTML 502) must not
+      // leave an unhandled promise rejection with no feedback.
+      alert('Sign-in error: could not reach the sign-in service. Please try again.');
+      return;
+    }
+    if (!data || data.error || !data.user_code || !data.verification_uri) {
+      alert('Sign-in error: ' + ((data && (data.message || data.error)) || 'unexpected response'));
+      return;
+    }
     showDeviceModal(data);
-    window.open(data.verification_uri, '_blank');
+    // Only open the verification URL if it's an https GitHub URL — never window.open an
+    // arbitrary string from the response.
+    if (isGithubHttpsUrl(data.verification_uri)) window.open(data.verification_uri, '_blank');
     pollInterval = Math.max(5, data.interval || 5);
     schedulePoll(data.device_code);
+  }
+  function isGithubHttpsUrl(u) {
+    try {
+      const url = new URL(String(u));
+      return url.protocol === 'https:' && /(^|\.)github\.com$/.test(url.hostname);
+    } catch { return false; }
   }
   function schedulePoll(device_code) {
     pollTimer = setTimeout(() => pollDevice(device_code), pollInterval * 1000);
@@ -1708,8 +1771,8 @@
       <div class="tdoc-modal">
         <h3>Sign in with GitHub</h3>
         <div class="step"><span class="n">1</span><span>Copy this code:</span></div>
-        <div class="code" id="tdoc-user-code">${data.user_code}</div>
-        <div class="step"><span class="n">2</span><span>Paste it at <b>${data.verification_uri}</b> (opened in a new tab) and approve.</span></div>
+        <div class="code" id="tdoc-user-code">${escapeHtml(data.user_code)}</div>
+        <div class="step"><span class="n">2</span><span>Paste it at <b>${escapeHtml(data.verification_uri)}</b> (opened in a new tab) and approve.</span></div>
         <div class="step"><span class="n">3</span><span class="status" id="tdoc-poll-status">Waiting for you to approve…</span></div>
         <div class="actions"><button id="tdoc-modal-cancel">Cancel</button></div>
       </div>`;

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -92,5 +92,29 @@ t('tdoc-new --force preserves the existing doc when new HTML is INVALID [the bug
   }
 });
 
+// ---- slug validation (audit: path traversal via unvalidated slug) ----
+// tdoc-publish/pull/unpublish used $SLUG in filesystem paths and curl URLs
+// without validation, so a `..` slug escaped TDOC_DIR. Each must now reject a
+// non-kebab-case slug BEFORE any side effect.
+t('publish/pull/unpublish reject traversal + non-kebab slugs', () => {
+  const env = { ...process.env, TDOC_DIR: '/tmp/tdoc-slugtest-nonexistent', HOME: '/tmp/tdoc-slugtest-home' };
+  const bad = ['../private', 'a/../b', 'UPPER', 'has space', 'trailing-', '-leading', 'with/slash'];
+  for (const cli of ['tdoc-publish', 'tdoc-pull', 'tdoc-unpublish']) {
+    for (const slug of bad) {
+      const r = spawnSync(path.join(BIN, cli), [slug], { env, encoding: 'utf8', timeout: 15000 });
+      assert(r.status !== 0, `${cli} accepted bad slug '${slug}' (exit 0)`);
+      assert(/invalid slug/i.test(r.stderr || ''), `${cli} '${slug}': expected 'invalid slug' rejection, got stderr: ${r.stderr}`);
+    }
+  }
+});
+
+t('publish accepts a valid kebab-case slug (passes validation, fails later on missing doc)', () => {
+  const env = { ...process.env, TDOC_DIR: '/tmp/tdoc-slugtest-nonexistent' };
+  const r = spawnSync(path.join(BIN, 'tdoc-publish'), ['valid-slug-123'], { env, encoding: 'utf8', timeout: 15000 });
+  // It should get PAST slug validation (no 'invalid slug') and fail on the
+  // missing doc instead — proving valid slugs aren't over-rejected.
+  assert(!/invalid slug/i.test(r.stderr || ''), `valid slug was wrongly rejected: ${r.stderr}`);
+});
+
 console.log(`\n${pass} passed, ${fail} failed`);
 process.exit(fail ? 1 : 0);

--- a/test/coverage.test.js
+++ b/test/coverage.test.js
@@ -86,6 +86,55 @@ t('FOLD: reaction add then remove nets to no reaction', () => {
     'reaction should be gone after add+remove');
 });
 
+// Regression (audit, Codex+Claude agreed): add→remove→add must converge to
+// "reacted", not silently vanish. Old eventEid put the event KIND in the eid,
+// so add and remove lived in two independent dedup slots and folded to a stale
+// "removed" even though the user's last action was add. Now both kinds share
+// one (emoji,by,at_version) eid so the last toggle wins.
+t('FOLD: reaction add→remove→add converges to PRESENT (no data loss)', () => {
+  const c = { id: 'c4b', author: {login:'a'}, created: 't0', created_in: 1, events: [
+    { kind: 'created', at_version: 1, at: 't0', text: 'x', anchor: null },
+    { kind: 'reaction_added',   at_version: 1, at: 't1', emoji: '👍', by: 'u' },
+    { kind: 'reaction_removed', at_version: 1, at: 't2', emoji: '👍', by: 'u' },
+    { kind: 'reaction_added',   at_version: 1, at: 't3', emoji: '👍', by: 'u' },
+  ]};
+  box.backfillEids(c.events);
+  const snap = snapshotAt(c, Infinity);
+  assert(snap.reactions['👍'] && snap.reactions['👍'].includes('u'),
+    'after add→remove→add the reaction must be PRESENT');
+});
+
+// Regression (audit): a reaction on v1 and a different toggle on v3 must NOT
+// clobber each other — snapshots are immutable per version. Old eid omitted
+// at_version, so same emoji/user across versions collided into one slot.
+t('FOLD: same reaction across versions stays independent (snapshot immutability)', () => {
+  const c = { id: 'c4c', author: {login:'a'}, created: 't0', created_in: 1, events: [
+    { kind: 'created', at_version: 1, at: 't0', text: 'x', anchor: null },
+    { kind: 'reaction_added',   at_version: 1, at: 't1', emoji: '🔥', by: 'u' }, // on v1
+    { kind: 'reaction_removed', at_version: 3, at: 't2', emoji: '🔥', by: 'u' }, // un-react on v3
+  ]};
+  box.backfillEids(c.events);
+  // At v1 the reaction is still present; the v3 removal must not reach back.
+  const v1 = snapshotAt(c, 1);
+  assert(v1.reactions['🔥'] && v1.reactions['🔥'].includes('u'),
+    'v1 reaction must survive a later-version removal');
+  // At v3 it is removed.
+  const v3 = snapshotAt(c, 3);
+  assert(!v3.reactions['🔥'] || !v3.reactions['🔥'].includes('u'),
+    'v3 must reflect the removal');
+});
+
+// Regression (audit): backfillEids must MIGRATE a stored old-format reaction
+// eid to the new format, not leave it stale — otherwise reactions created
+// before the fix never converge.
+t('MIGRATE: stale old-format reaction eid is recomputed by backfillEids', () => {
+  const e = { kind: 'reaction_added', at_version: 2, at: 't1', emoji: '🎉', by: 'bob',
+    eid: 'reaction_added:🎉:bob' /* OLD format: kind-in-eid, no at_version */ };
+  box.backfillEids([e]);
+  assert(e.eid === 'reaction:🎉:bob:2',
+    `old-format eid should be migrated; got ${e.eid}`);
+});
+
 t('FOLD: text_edited overrides created text', () => {
   const c = { id: 'c5', author: {login:'a'}, created: 't0', created_in: 1, events: [
     { kind: 'created', at_version: 1, at: 't0', text: 'orig', anchor: null },

--- a/test/overlay-pure.test.js
+++ b/test/overlay-pure.test.js
@@ -36,14 +36,15 @@ function sliceFn(name) {
   return src.slice(start, i);
 }
 
-const box = {};
+// isGithubHttpsUrl uses the global URL constructor; expose it in the sandbox.
+const box = { URL };
 vm.createContext(box);
 vm.runInContext([
   'escapeHtml', 'normalizeNeedle', 'normalizeContext', 'normalizeQuery',
-  'commonPrefixLen', 'commonSuffixLen',
+  'commonPrefixLen', 'commonSuffixLen', 'isGithubHttpsUrl',
 ].map(sliceFn).join('\n\n'), box);
 const { escapeHtml, normalizeNeedle, normalizeContext, normalizeQuery,
-        commonPrefixLen, commonSuffixLen } = box;
+        commonPrefixLen, commonSuffixLen, isGithubHttpsUrl } = box;
 
 console.log('overlay-pure (#23 testable surface)');
 
@@ -89,6 +90,21 @@ t('commonSuffixLen counts the shared trailing run', () => {
 t('prefix/suffix handle no-overlap', () => {
   assert(commonPrefixLen('abc', 'xyz') === 0);
   assert(commonSuffixLen('abc', 'xyz') === 0);
+});
+
+// isGithubHttpsUrl — audit fix: startDeviceFlow only window.open()s the
+// verification URL if it's an https github.com URL, never an arbitrary string.
+t('isGithubHttpsUrl accepts https github.com URLs', () => {
+  assert(isGithubHttpsUrl('https://github.com/login/device') === true);
+  assert(isGithubHttpsUrl('https://github.com') === true);
+});
+t('isGithubHttpsUrl rejects non-github / non-https / junk', () => {
+  assert(isGithubHttpsUrl('http://github.com/login/device') === false, 'http rejected');
+  assert(isGithubHttpsUrl('https://evil.com/login') === false, 'other host rejected');
+  assert(isGithubHttpsUrl('https://github.com.evil.com') === false, 'suffix-spoof rejected');
+  assert(isGithubHttpsUrl('javascript:alert(1)') === false, 'js scheme rejected');
+  assert(isGithubHttpsUrl('not a url') === false, 'garbage rejected');
+  assert(isGithubHttpsUrl(null) === false, 'null rejected');
 });
 
 console.log(`\n${pass} passed, ${fail} failed`);

--- a/worker/worker.js
+++ b/worker/worker.js
@@ -778,9 +778,29 @@ function legacyToEvents(c) {
 // returns true if anything changed. This guarantees dedupEvents (the
 // convergence point) always has an eid to key on.
 function backfillEids(events) {
+  // Reaction/state kinds whose eid is DETERMINISTIC (no random component). Their
+  // eid format changed (kind dropped, at_version added — see eventEid), so
+  // events stored under an old-format eid must be RECOMPUTED, not just filled
+  // when missing. Recomputing is safe because these eids are pure functions of
+  // the event's own fields; one-shot kinds (which embed Math.random) are never
+  // recomputed, only backfilled when absent. Kept inside the function so the
+  // test harness's per-function VM extraction stays self-contained.
+  const DETERMINISTIC_EID_KINDS = new Set([
+    'reaction_added', 'reaction_removed',
+    'reply_reaction_added', 'reply_reaction_removed',
+    'marked_applied', 'marked_open', 'deleted',
+  ]);
   let changed = false;
   if (!Array.isArray(events)) return false;
-  for (const e of events) { if (e && !e.eid) { e.eid = eventEid(e); changed = true; } }
+  for (const e of events) {
+    if (!e) continue;
+    if (!e.eid) { e.eid = eventEid(e); changed = true; continue; }
+    // Migrate events whose deterministic eid format has since changed.
+    if (DETERMINISTIC_EID_KINDS.has(e.kind)) {
+      const want = eventEid(e);
+      if (e.eid !== want) { e.eid = want; changed = true; }
+    }
+  }
   return changed;
 }
 
@@ -986,15 +1006,28 @@ function ensureMigrated(list) {
 // instead of corrupting: every event carries an `eid`, and the fold dedups by
 // it (see dedupEvents). Some events are *naturally idempotent* and get a
 // DETERMINISTIC eid so a concurrent duplicate collapses to one:
-//   reaction_added/removed → reaction:<kind>:<emoji>:<by>   (toggle converges)
+//   reaction add/remove → reaction:<emoji>:<by>:<at_version>      (toggle converges)
+//   reply reaction      → rreaction:<reply_id>:<emoji>:<by>:<at_version>
 //   marked_applied/open/deleted → <kind>:<at_version>       (state, not history)
 // One-shot events (created, reply_added, text_edited, anchor_changed) get a
 // unique eid so each is preserved.
+//
+// Reaction eids deliberately DROP the add-vs-remove kind and INCLUDE at_version:
+//   - dropping kind makes a toggle converge: [add, remove, add] collapses to one
+//     slot whose LAST event (add) wins, instead of add and remove living in two
+//     independent slots that fold to a stale "removed" (the add→remove→add
+//     data-loss bug).
+//   - including at_version keeps each version's reaction independent, so a
+//     reaction on v1 and a different toggle on v3 don't clobber each other
+//     (snapshots stay immutable).
 function eventEid(e) {
   switch (e.kind) {
     case 'reaction_added':
     case 'reaction_removed':
-      return `${e.kind}:${e.emoji}:${e.by}`;
+      return `reaction:${e.emoji}:${e.by}:${e.at_version}`;
+    case 'reply_reaction_added':
+    case 'reply_reaction_removed':
+      return `rreaction:${e.reply_id}:${e.emoji}:${e.by}:${e.at_version}`;
     case 'marked_applied':
     case 'marked_open':
     case 'deleted':
@@ -1059,6 +1092,27 @@ function parseVersionParam(url) {
   return Number.isFinite(n) && n >= 0 ? n : Infinity;
 }
 
+// Coerce a version from a request body to a non-negative integer, defaulting to
+// `fallback` (1) for missing/invalid input. Unlike `Number(version) || 1`, this
+// preserves a legitimate 0 — matching parseVersionParam's accept rule — so a
+// body-driven write can't silently land on the wrong snapshot.
+function coerceBodyVersion(version, fallback = 1) {
+  const n = Number(version);
+  return Number.isFinite(n) && n >= 0 ? n : fallback;
+}
+
+// Slugs are used as R2/KV key segments and Durable Object names. Constrain them
+// to a strict kebab-case allowlist so a request body can't escape the intended
+// `docs/<slug>/…` keyspace or inject odd characters into a storage key.
+function isValidSlug(slug) {
+  return typeof slug === 'string' && /^[a-z0-9][a-z0-9-]{0,63}$/.test(slug);
+}
+
+// Object keys that, if accepted as a reaction emoji, would resolve to inherited
+// Object.prototype members when used as a reaction bucket key — throwing or
+// polluting the fold. Rejected at the /api/reactions boundary.
+const RESERVED_OBJECT_KEYS = new Set(['__proto__', 'prototype', 'constructor', 'hasOwnProperty', 'toString', 'valueOf', 'isPrototypeOf', 'propertyIsEnumerable', 'toLocaleString']);
+
 // ---- GitHub helpers ----
 
 async function ghPost(path, formObj) {
@@ -1096,10 +1150,27 @@ async function ghUser(token) {
   return r.json();
 }
 
-function requireUploadAuth(req, env) {
+// Constant-time string compare. Hashes both sides with SHA-256 and XOR-folds
+// the digests, so it neither short-circuits on the first differing byte nor
+// leaks length — removing the (theoretical, network-noise-dominated) timing
+// side channel of a raw `===` on the shared secret.
+async function timingSafeEqual(a, b) {
+  if (typeof a !== 'string' || typeof b !== 'string') return false;
+  const enc = new TextEncoder();
+  const [ha, hb] = await Promise.all([
+    crypto.subtle.digest('SHA-256', enc.encode(a)),
+    crypto.subtle.digest('SHA-256', enc.encode(b)),
+  ]);
+  const va = new Uint8Array(ha), vb = new Uint8Array(hb);
+  let diff = 0;
+  for (let i = 0; i < va.length; i++) diff |= va[i] ^ vb[i];
+  return diff === 0;
+}
+
+async function requireUploadAuth(req, env) {
   const auth = req.headers.get('authorization') || '';
   const m = auth.match(/^Bearer\s+(.+)$/);
-  if (!m || !env.TDOC_UPLOAD_TOKEN || m[1] !== env.TDOC_UPLOAD_TOKEN) {
+  if (!m || !env.TDOC_UPLOAD_TOKEN || !(await timingSafeEqual(m[1], env.TDOC_UPLOAD_TOKEN))) {
     return json({ error: 'unauthorized' }, { status: 401 });
   }
   return null;
@@ -1655,9 +1726,10 @@ export default {
       try { body = await req.json(); } catch {}
       const { slug, version, anchor, text: commentText, parent_id } = body;
       if (!slug || !commentText) return json({ error: 'slug and text required' }, { status: 400 });
+      if (!isValidSlug(slug)) return json({ error: 'invalid_slug' }, { status: 400 });
       const author = { login: s.login, avatar_url: s.avatar_url, name: s.name };
       const created = new Date().toISOString();
-      const V = Number(version) || 1;
+      const V = coerceBodyVersion(version);
       // Serialized through the per-slug DO (mutation logic lives once in
       // applyCommentOp). create + reply are both id-stamped here so the
       // response is deterministic regardless of where the write runs.
@@ -1699,7 +1771,7 @@ export default {
     // tenant so this is safe). Triggered by ?all=1 on DELETE /api/comments.
     if (p === '/api/comments' && method === 'DELETE'
         && url.searchParams.get('all') === '1') {
-      const unauth = requireUploadAuth(req, env);
+      const unauth = await requireUploadAuth(req, env);
       if (unauth) return unauth;
       const slug = url.searchParams.get('slug');
       if (!slug) return json({ error: 'slug required' }, { status: 400 });
@@ -1760,8 +1832,13 @@ export default {
       try { body = await req.json(); } catch {}
       const { slug, comment_id, emoji, version } = body;
       if (!slug || !comment_id || !emoji) return json({ error: 'slug, comment_id, emoji required' }, { status: 400 });
-      if (emoji.length > 8 || emoji.length === 0) return json({ error: 'invalid_emoji' }, { status: 400 });
-      const V = Number(version) || 1;
+      if (!isValidSlug(slug)) return json({ error: 'invalid_slug' }, { status: 400 });
+      if (typeof emoji !== 'string' || emoji.length > 8 || emoji.length === 0) return json({ error: 'invalid_emoji' }, { status: 400 });
+      // `emoji` is used as an object key in the reaction fold; reject keys that
+      // would resolve to Object.prototype members (e.g. `valueOf`, `toString`,
+      // `__proto__`) and throw or pollute when read as a reaction bucket.
+      if (RESERVED_OBJECT_KEYS.has(emoji)) return json({ error: 'invalid_emoji' }, { status: 400 });
+      const V = coerceBodyVersion(version);
       // No upstream read: the toggle (add vs remove) is decided inside the
       // serialized write so concurrent toggles can't both add. Any signed-in
       // user may react, so there's no author check to do here.
@@ -1779,7 +1856,7 @@ export default {
     // a visible badge on the reply and also flips the parent comment's
     // status to 'applied' / 'open' so the dashboard reflects it.
     if (p === '/api/agent/reply' && method === 'POST') {
-      const unauth = requireUploadAuth(req, env);
+      const unauth = await requireUploadAuth(req, env);
       if (unauth) return unauth;
       let body = {};
       try { body = await req.json(); } catch {}
@@ -1827,7 +1904,7 @@ export default {
 
     // ---- admin upload (from `tdoc publish`) ----
     if (p === '/api/upload' && method === 'POST') {
-      const unauth = requireUploadAuth(req, env);
+      const unauth = await requireUploadAuth(req, env);
       if (unauth) return unauth;
       let body = {};
       try { body = await req.json(); } catch {}
@@ -1836,12 +1913,18 @@ export default {
       // html must be a string — a non-string doc would throw inside stampAids()
       // and surface as a generic 500 (Codex P3).
       if (typeof doc !== 'string') return json({ error: 'html must be a string' }, { status: 400 });
+      // slug + version become R2/KV key segments and the DO name. Validate them
+      // (even though this route is upload-token-gated) so a malformed body can't
+      // escape the `docs/<slug>/v<N>/` keyspace or build a junk storage key.
+      if (!isValidSlug(slug)) return json({ error: 'invalid_slug' }, { status: 400 });
+      const verNum = Number(version);
+      if (!Number.isInteger(verNum) || verNum < 1) return json({ error: 'invalid_version' }, { status: 400 });
       // Identity-stamp every commentable artifact with a content-hashed
       // data-tdoc-aid. The SAME artifact in a different version has the
       // SAME aid — so a comment anchored by aid resolves identity-first
       // and cannot drift onto a different artifact.
       const { html: stampedHtml, aids } = stampAids(doc);
-      const r2Key = `docs/${slug}/v${version}/index.html`;
+      const r2Key = `docs/${slug}/v${verNum}/index.html`;
       try {
         await env.DOCS.put(r2Key, stampedHtml, {
           httpMetadata: { contentType: 'text/html; charset=utf-8' },
@@ -1884,18 +1967,18 @@ export default {
         // merge is non-destructive (add-by-id-if-absent; never overwrite/delete
         // worker comments), mirroring tdoc-pull so round-trips converge.
         const res = await mutateComments(env, slug, {
-          kind: 'publish_merge', slug, localComments: localComments || [], aids, version,
+          kind: 'publish_merge', slug, localComments: localComments || [], aids, version: verNum,
         });
         mergedLocal = (res.body && res.body.mergedComments) || 0;
       } catch (e) {
         console.error('[upload] comment merge/reconcile failed (non-fatal):', e.message);
       }
-      return json({ ok: true, url: `/d/${slug}/v/${version}`, size: verify.size, aids: aids.length, mergedComments: mergedLocal });
+      return json({ ok: true, url: `/d/${slug}/v/${verNum}`, size: verify.size, aids: aids.length, mergedComments: mergedLocal });
     }
 
     // ---- admin delete ----
     if (p === '/api/doc' && method === 'DELETE') {
-      const unauth = requireUploadAuth(req, env);
+      const unauth = await requireUploadAuth(req, env);
       if (unauth) return unauth;
       const slug = url.searchParams.get('slug');
       if (!slug) return json({ error: 'slug required' }, { status: 400 });


### PR DESCRIPTION
Full security + correctness audit of the tdoc source (worker / overlay / CLIs) run **twice independently** — by Codex (whole-repo, high reasoning effort) and by a fan-out of Claude subagents (one per component+lens), each finding adversarially verified by skeptics before any fix. **Both engines independently flagged the same top cluster** (reaction-eid data loss, aid→selector injection, CLI slug traversal), which is the highest-confidence signal.

3 commits, grouped by component. All findings were confirmed against live source before fixing; speculative/already-mitigated findings were dropped.

## `fix(worker)` — reaction data loss + input hardening
- **P1 data loss (both engines):** `eventEid` put the event *kind* in a reaction's eid, so `reaction_added`/`reaction_removed` landed in separate dedup slots — a normal **add→remove→add toggle folded to a stale "removed"** and the reaction silently vanished. The eid also omitted `at_version`, so the same emoji/user across versions collided (snapshot-immutability violation, **P2**). Fixed with one version-scoped eid shared by add+remove. `backfillEids` now **migrates** stale old-format eids (else pre-existing reactions never converge).
- Hardening (defense-in-depth on token-gated/authed paths): `isValidSlug` allowlist on upload/comments/reactions before a slug becomes an R2/KV key or DO name; upload validates version is a positive int; `/api/reactions` rejects reserved object keys as emoji (`valueOf`, `__proto__`); `requireUploadAuth` uses a constant-time token compare.

## `fix(overlay)` — selector injection + error handling
- **P2 injection (both engines), browser-verified:** `findElement` built `[data-tdoc-aid="${aid}"]` from a commenter-controllable aid. A crafted aid **hijacked the anchor onto `<body>`**; a malformed one **threw and aborted all comment rendering**. Replaced with `matchByAid()` (attribute-equality, no string interpolation). *Verified in a real browser: old code hijacked to `<body>` / threw SyntaxError; fix returns `null` safely and legit aids still resolve.*
- `refreshComments` now guards `r.ok` + `Array.isArray` (a non-array error envelope used to throw and break rendering); reaction sinks centralized in `postReaction` (401 re-auth, errors surfaced, no unhandled rejection); `startDeviceFlow` wrapped in try/catch; device modal escapes `user_code`/`verification_uri` and only opens https github.com URLs; text-node cache recomputed after fallback DOM mutation.

## `fix(cli)` — slug traversal + token perms
- **P2 traversal (both engines):** `tdoc-publish/pull/unpublish` used `$SLUG` raw in filesystem paths and curl URLs — a `..` slug escaped `TDOC_DIR`. Added the kebab-case allowlist `tdoc-new` already uses, before any side effect.
- `published.json` (holds the upload token) now created `0600` from the start (`umask 077`), closing the world-readable window before `chmod`. `tdoc-update --check` reports the real commit count (was `${#}`); `--yes` with no local doc skips cleanly instead of calling publish with an empty slug.

## Tests
Regression coverage added for every behavioral fix: add→remove→add convergence, cross-version reaction independence, old-eid migration, `isGithubHttpsUrl` accept/reject (incl. suffix-spoof / `javascript:`), and CLI slug rejection/acceptance. **Full offline suite 15/15.** The aid-injection fix was additionally verified in a real browser.

Deferred (documented): the theoretical half-deploy reorder in `first_time_setup` — fixing it risks destabilizing a working deploy path for a "just re-run publish" outcome.

🤖 Generated with [Claude Code](https://claude.com/claude-code)