### PR TITLE
fix: Fable audit — v0.8.0 pins bugs, data-fold correctness, test coverage

### DIFF
--- a/server/overlay.js
+++ b/server/overlay.js
@@ -1429,12 +1429,23 @@
       const submitReply = async () => {
         const text = replyTa.value.trim();
         if (!text) return;
-        const r = await fetch('/api/comments', {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ slug, parent_id: comment.id, text, version })
-        });
+        let r;
+        try {
+          r = await fetch('/api/comments', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ slug, parent_id: comment.id, text, version })
+          });
+        } catch (e) {
+          alert('Could not post reply: network error'); // keep the text — don't clear
+          return;
+        }
         if (r.status === 401) { startDeviceFlow(); return; }
+        if (!r.ok) {
+          const err = await r.json().catch(() => ({}));
+          alert('Could not post reply: ' + (err.error || err.message || `HTTP ${r.status}`));
+          return; // preserve the typed reply so it isn't silently lost
+        }
         replyTa.value = '';
         replyForm.classList.remove('open');
         await refreshComments();
@@ -1610,7 +1621,7 @@
       return;
     }
     // Wide mode: render PINS, not a card stack. Each comment becomes a pin at
-    // its Y; pins within CLUSTER_GAP px merge into one count badge. The floating
+    // its Y; pins within SAME_LINE_GAP px merge into one count badge. The floating
     // card (hover/click) is positioned separately by openFloatingCard().
     renderPins();
     // Keep any currently-open floating card glued to its pin on scroll/resize.
@@ -1628,10 +1639,15 @@
   const SAME_LINE_GAP = 12;          // px: true co-location threshold
   const PIN_MIN_GAP = PIN_SIZE + 4;  // 32px: min spacing between spread pins
 
-  function renderPins() {
-    const geo = gutterGeometry();
-    // Y-sorted list of placeable comments.
-    const rows = state.activeComments.map(c => commentY(c, geo)).filter(Boolean);
+  // PURE layout core (steps 0-2), extracted so it's unit-testable without a DOM
+  // (see test/pins-layout.test.js). Takes Y-positioned rows [{y, el, elTop,
+  // elHeight, c}], the gutter geometry {articleTop, articleHeight}, and the
+  // spacing constants; returns the placed clusters [{y, items:[row,...]}].
+  // MUTATES row.y (same-element spread) — callers pass rows they own.
+  // Invariant: no placed cluster's y exceeds articleTop+articleHeight once at
+  // least one cluster is placed (the overflow tail folds into the last pin).
+  function layoutPins(rows, geo, consts) {
+    const { PIN_SIZE, PIN_MIN_GAP, SAME_LINE_GAP } = consts;
 
     // 0) Spread comments that share the SAME element anchor down that element's
     //    height. Element anchors all resolve to the element's TOP edge, so N
@@ -1645,7 +1661,7 @@
       if (!byEl.has(r.el)) byEl.set(r.el, []);
       byEl.get(r.el).push(r);
     }
-    for (const [el, group] of byEl) {
+    for (const [, group] of byEl) {
       if (group.length < 2) continue;
       const top = group[0].elTop, h = group[0].elHeight || 0;
       const usable = Math.max(0, h - PIN_SIZE);
@@ -1678,7 +1694,7 @@
     const placed = [];
     let prevY = -Infinity;
     for (const cl of clusters) {
-      let y = Math.max(cl.y, prevY + PIN_MIN_GAP);
+      const y = Math.max(cl.y, prevY + PIN_MIN_GAP);
       if (y > bottomLimit && placed.length) {
         // No room: merge this cluster's items into the last placed pin (overflow).
         const tail = placed[placed.length - 1];
@@ -1689,6 +1705,14 @@
       placed.push(cl);
       prevY = y;
     }
+    return placed;
+  }
+
+  function renderPins() {
+    const geo = gutterGeometry();
+    // Y-sorted list of placeable comments.
+    const rows = state.activeComments.map(c => commentY(c, geo)).filter(Boolean);
+    const placed = layoutPins(rows, geo, { PIN_SIZE, PIN_MIN_GAP, SAME_LINE_GAP });
 
     // 3) Reconcile pin elements: stable pin per cluster keyed by member ids.
     const seen = new Set();
@@ -1769,8 +1793,8 @@
   function positionFloatingCard(id) {
     const card = state.cardEls.get(id);
     if (!card) return;
-    const row = commentY(state.activeComments.find(c => c.id === id), gutterGeometry());
     const geo = gutterGeometry();
+    const row = commentY(state.activeComments.find(c => c.id === id), geo);
     let y = row ? row.y : geo.articleTop;
     card.style.left = geo.cardLeft + 'px';
     // Flip up if the card would run past the bottom of the viewport.
@@ -1943,7 +1967,6 @@
     const repos = () => positionOutlineAround(outline, el);
     repos();
     outline._reposition = repos;
-    outline._targetEl = el;
     outline.style.pointerEvents = 'none';
     return { el: outline, targetEl: el };
   }
@@ -2036,7 +2059,19 @@
       } else if (kind === 'element') {
         const out = outlineElement(comment);
         if (out) {
-          out.targetEl.addEventListener('click', (e) => { e.stopPropagation(); setActiveComment(comment.id); });
+          // Bind the click handler ONCE per target element. targetEl is a stable
+          // live artifact (matched by data-tdoc-aid), so re-adding an anonymous
+          // listener every refresh leaked handlers and made one click fire
+          // setActiveComment N times. Store the current comment id on the element
+          // and let a single bound handler read it.
+          out.targetEl.dataset.tdocAnchorComment = comment.id;
+          if (!out.targetEl._tdocAnchorClickBound) {
+            out.targetEl._tdocAnchorClickBound = true;
+            out.targetEl.addEventListener('click', (e) => {
+              const cid = e.currentTarget.dataset.tdocAnchorComment;
+              if (cid) { e.stopPropagation(); setActiveComment(cid); }
+            });
+          }
           if (out.targetEl.style) out.targetEl.style.cursor = 'pointer';
           state.anchorMarks.set(comment.id, { kind: 'element', el: out.el, targetEl: out.targetEl });
         }
@@ -2053,9 +2088,11 @@
       // and we're in wide (pins) mode. Runs after repositionCards so the pin
       // elements exist to mark active.
       if (keepPinnedId && !state.narrow && state.cardEls.has(keepPinnedId)) {
-        state.pinnedId = keepPinnedId;
-        showCard(keepPinnedId);
-        markPinActive(keepPinnedId, true);
+        // Use setActiveComment (not the manual pin/show/mark trio) so the
+        // card's .active class, anchor highlight, activeId, AND the pin state
+        // are all re-established together. The manual version desynced activeId
+        // and lost the card's .active state (+ the "move anchor" affordance).
+        setActiveComment(keepPinnedId);
       }
     });
   }
@@ -2417,11 +2454,22 @@
             // Fingerprint is the legacy fallback for any pre-aid docs.
             fingerprint: anchor._el ? elementFingerprint(anchor._el) : null,
             fallback };
-      const r = await fetch('/api/comments', {
-        method: 'POST', headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ slug, version, anchor: sendAnchor, text })
-      });
+      let r;
+      try {
+        r = await fetch('/api/comments', {
+          method: 'POST', headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ slug, version, anchor: sendAnchor, text })
+        });
+      } catch (e) {
+        alert('Could not post comment: network error'); // keep popup + text
+        return;
+      }
       if (r.status === 401) { closePopup(); startDeviceFlow(); return; }
+      if (!r.ok) {
+        const err = await r.json().catch(() => ({}));
+        alert('Could not post comment: ' + (err.error || err.message || `HTTP ${r.status}`));
+        return; // leave the popup + typed text so the comment isn't lost
+      }
       await r.json().catch(() => null);
       closePopup();
       await refreshComments();

--- a/server/server.js
+++ b/server/server.js
@@ -75,6 +75,9 @@ function isLocalMutation(req) {
 // can't outlive the new outcome (e.g. an "applied" ✅ after a later
 // "question" outcome on the same comment).
 const AGENT_STATUS_EMOJI = { applied: '✅', partial: '🟡', question: '❓' };
+// The emoji set the agent uses as a verdict marker — used by the per-version
+// fold to strip a stale verdict off snapshots where the comment reads 'open'.
+const AGENT_VERDICT_EMOJI = new Set(Object.values(AGENT_STATUS_EMOJI));
 function setAgentReaction(target, status) {
   if (!target.reactions) target.reactions = {};
   for (const emoji of Object.keys(target.reactions)) {
@@ -142,10 +145,25 @@ function foldCommentsAtVersion(comments, version) {
     if (createdIn > V) continue; // didn't exist yet at version V
     const appliedIn = c.applied_in != null ? Number(c.applied_in) : null;
     const resolvedByV = c.status === 'applied' && appliedIn != null && appliedIn <= V;
+    // Reactions are stored flat (no per-reaction version), so spreading `...c`
+    // would carry the CURRENT reactions — including the agent verdict emoji
+    // (✅/🟡/❓ written by setAgentReaction) — onto every past snapshot. On a
+    // version where the comment folds to 'open' that's a contradictory
+    // "resolved" emoji, so drop the tdoc-agent verdict there.
+    let reactions = c.reactions;
+    if (!resolvedByV && reactions) {
+      const filtered = {};
+      for (const [emoji, users] of Object.entries(reactions)) {
+        const rest = Array.isArray(users) ? users.filter(u => !(u === 'tdoc-agent' && AGENT_VERDICT_EMOJI.has(emoji))) : users;
+        if (rest && rest.length) filtered[emoji] = rest;
+      }
+      reactions = filtered;
+    }
     const snap = {
       ...c,
       status: resolvedByV ? 'applied' : 'open',
       applied_in: resolvedByV ? appliedIn : undefined,
+      reactions,
       replies: Array.isArray(c.replies)
         ? c.replies.filter(r => (Number(r.version != null ? r.version : createdIn) || createdIn) <= V)
         : [],
@@ -240,7 +258,11 @@ const server = http.createServer(async (req, res) => {
       const parent = comments.find(c => c.id === parent_id);
       if (!parent) return json(res, 404, { error: 'parent_not_found' });
       if (!Array.isArray(parent.replies)) parent.replies = [];
-      const reply = { id: `r_${Date.now()}`, parent_id, text, author: null, created, reactions: {} };
+      // Persist the version the reply was made at so foldCommentsAtVersion can
+      // scope it — without this the reply record has no `version` and the fold's
+      // `r.version` check falls back to the parent's created_in, so replies were
+      // never hidden on older versions (diverging from the worker).
+      const reply = { id: `r_${Date.now()}`, parent_id, text, version: Number(version) || 1, author: null, created, reactions: {} };
       parent.replies.push(reply);
       writeJson(file, comments);
       return json(res, 200, reply);
@@ -285,6 +307,9 @@ const server = http.createServer(async (req, res) => {
       id: `r_${Date.now()}`,
       parent_id,
       text,
+      // Scope the agent reply to the version it was applied at (falls back to
+      // the request version, then 1) so the fold can hide it on earlier ones.
+      version: Number(applied_in != null ? applied_in : body.version) || 1,
       author: { kind: 'agent', login: 'tdoc-agent', name: 'tdoc-agent', avatar_url: null },
       agent_status: ['applied', 'partial', 'question'].includes(agentStatus) ? agentStatus : null,
       created: new Date().toISOString(),

--- a/test/pins-layout.test.js
+++ b/test/pins-layout.test.js
@@ -1,0 +1,115 @@
+// Pins layout tests (v0.8.0 pins-in-margin feature).
+//
+// The 0.8.0 release replaced the margin card-stack with pins whose placement is
+// decided by a pure clustering/spreading/overflow algorithm: layoutPins() in
+// server/overlay.js. That math had ZERO automated coverage — a regression in
+// the thresholds or the overflow-fold would ship green. This VM-extracts the
+// pure function (same pattern as overlay-pure.test.js) and pins its invariants:
+//   - same-line comments (within SAME_LINE_GAP) merge into one cluster
+//   - comments just outside SAME_LINE_GAP spread (>= PIN_MIN_GAP apart)
+//   - multiple comments on ONE tall element distribute down it; on a SHORT
+//     element they cluster
+//   - the overflow-fold guarantees no placed pin exceeds articleTop+articleHeight
+//
+// Run with: node test/pins-layout.test.js
+
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+
+let pass = 0, fail = 0;
+function ok(n) { console.log(`  ✓ ${n}`); pass++; }
+function bad(n, e) { console.log(`  ✗ ${n}\n    ${e}`); fail++; }
+function t(n, fn) { try { fn(); ok(n); } catch (e) { bad(n, e.message); } }
+function assert(c, m) { if (!c) throw new Error(m || 'assertion failed'); }
+
+const src = fs.readFileSync(path.join(__dirname, '..', 'server', 'overlay.js'), 'utf8');
+function sliceFn(name) {
+  const start = src.indexOf(`function ${name}(`);
+  if (start === -1) throw new Error(`fn ${name} not found in overlay.js`);
+  let i = src.indexOf('{', start), depth = 0;
+  for (; i < src.length; i++) {
+    if (src[i] === '{') depth++;
+    else if (src[i] === '}') { depth--; if (depth === 0) { i++; break; } }
+  }
+  return src.slice(start, i);
+}
+
+const box = {};
+vm.createContext(box);
+vm.runInContext(sliceFn('layoutPins'), box);
+const { layoutPins } = box;
+
+// The real constants from overlay.js (PIN_SIZE=28 → PIN_MIN_GAP=32, SAME_LINE_GAP=12).
+const CONSTS = { PIN_SIZE: 28, PIN_MIN_GAP: 32, SAME_LINE_GAP: 12 };
+const GEO = { articleTop: 0, articleHeight: 10000 }; // roomy by default
+// Build a placeable row (mirrors commentY output shape).
+const row = (id, y, extra = {}) => ({ c: { id }, y, el: null, elTop: 0, elHeight: 0, ...extra });
+
+console.log('pins-layout (v0.8.0 pins core)');
+
+// ---- same-line clustering ----
+t('two comments within SAME_LINE_GAP merge into ONE cluster', () => {
+  const placed = layoutPins([row('a', 100), row('b', 108)], GEO, CONSTS); // 8px apart < 12
+  assert(placed.length === 1, `expected 1 cluster, got ${placed.length}`);
+  assert(placed[0].items.length === 2, 'both comments should be in the cluster');
+});
+
+t('two comments just OUTSIDE SAME_LINE_GAP stay separate and spread >= PIN_MIN_GAP', () => {
+  const placed = layoutPins([row('a', 100), row('b', 120)], GEO, CONSTS); // 20px apart > 12
+  assert(placed.length === 2, `expected 2 clusters, got ${placed.length}`);
+  const gap = placed[1].y - placed[0].y;
+  assert(gap >= CONSTS.PIN_MIN_GAP, `pins must be >= PIN_MIN_GAP apart, got ${gap}`);
+});
+
+t('overlapping-but-not-same-line pins are pushed down to PIN_MIN_GAP', () => {
+  // 100 and 118: 18px apart (> SAME_LINE_GAP so separate, < PIN_MIN_GAP so must spread)
+  const placed = layoutPins([row('a', 100), row('b', 118)], GEO, CONSTS);
+  assert(placed.length === 2, 'should be two separate pins');
+  assert(placed[1].y - placed[0].y >= CONSTS.PIN_MIN_GAP, 'second pin pushed down to min gap');
+});
+
+// ---- same-element spread vs cluster ----
+t('multiple comments on ONE TALL element distribute down it (individual pins)', () => {
+  const el = {}; // identity token for "same element"
+  const rows = [
+    row('a', 200, { el, elTop: 200, elHeight: 300 }),
+    row('b', 200, { el, elTop: 200, elHeight: 300 }),
+    row('c', 200, { el, elTop: 200, elHeight: 300 }),
+  ];
+  const placed = layoutPins(rows, GEO, CONSTS);
+  assert(placed.length === 3, `tall element should spread to 3 pins, got ${placed.length}`);
+});
+
+t('multiple comments on a SHORT element cluster into one badge', () => {
+  const el = {};
+  const rows = [
+    row('a', 200, { el, elTop: 200, elHeight: 20 }), // usable < PIN_MIN_GAP → no spread
+    row('b', 200, { el, elTop: 200, elHeight: 20 }),
+  ];
+  const placed = layoutPins(rows, GEO, CONSTS);
+  assert(placed.length === 1, `short element should cluster, got ${placed.length}`);
+  assert(placed[0].items.length === 2, 'both comments in one cluster');
+});
+
+// ---- overflow-fold invariant ----
+t('OVERFLOW: no placed pin exceeds articleTop+articleHeight (tail folds in)', () => {
+  const tight = { articleTop: 0, articleHeight: 100 }; // only ~3 pins fit at 32px gap
+  const rows = [];
+  for (let i = 0; i < 10; i++) rows.push(row('c' + i, i * 40)); // 10 pins, way past 100px
+  const placed = layoutPins(rows, tight, CONSTS);
+  const limit = tight.articleTop + tight.articleHeight;
+  for (const cl of placed) {
+    assert(cl.y <= limit, `pin at y=${cl.y} exceeds bottom limit ${limit}`);
+  }
+  // every comment is still accounted for (folded into a cluster, never dropped)
+  const total = placed.reduce((n, cl) => n + cl.items.length, 0);
+  assert(total === 10, `all 10 comments must be placed, got ${total}`);
+});
+
+t('empty input yields no clusters', () => {
+  assert(layoutPins([], GEO, CONSTS).length === 0, 'empty rows → no pins');
+});
+
+console.log(`\n${pass} passed, ${fail} failed`);
+process.exit(fail ? 1 : 0);

--- a/test/run.js
+++ b/test/run.js
@@ -25,6 +25,7 @@ const OFFLINE = [
   'no-drift.test.js',         // duplicated-helper drift guard
   'coverage.test.js',         // migration, bundle inlining, pull-merge, rich fold
   'overlay-pure.test.js',     // overlay pure helpers (escape/normalize/prefix)
+  'pins-layout.test.js',      // v0.8.0 pins clustering/spread/overflow-fold core
   'comment-upload.test.js',   // local→worker comment merge (non-destructive)
   'comment-ops.test.js',      // #34 DO-serialized mutation ops
   'p3-hardening.test.js',     // #33 safeParseList + escapeHtml

--- a/worker/worker.js
+++ b/worker/worker.js
@@ -1449,7 +1449,10 @@ export class CommentsStore {
       // Corrupt stored value → reject the write, preserve the bytes. 409 so the
       // caller knows it's a recoverable conflict, not a transient 500.
       if (e && /corrupt/.test(e.message || '')) {
-        return Response.json({ status: 409, error: 'comments_store_corrupt', message: 'stored comments are corrupt; manual recovery required' });
+        // Mirror the success path's {status, body} shape — the caller reads
+        // res.body, so a flat {error} here would reach the client as an empty
+        // 409 body and the reason would be silently lost.
+        return Response.json({ status: 409, body: { error: 'comments_store_corrupt', message: 'stored comments are corrupt; manual recovery required' } });
       }
       throw e;
     }
@@ -1534,10 +1537,12 @@ export default {
 
       const rawList = await readComments(env, slug);
       ensureMigrated(rawList);
-      // Snapshot the comments AS OF this exported version, then keep the
-      // ones that are still actionable (not deleted, not resolved).
-      const comments = snapshotList(rawList, Number(vStr));
-      const openComments = comments.filter(c => c.status !== 'resolved');
+      // Snapshot the comments AS OF this exported version. snapshotList only
+      // ever yields status 'open' or 'applied' (never 'resolved'), so the old
+      // `!== 'resolved'` filter here was a no-op. We intentionally export ALL
+      // snapshotted comments — including agent-applied ones — so the fork/export
+      // carries the full resolution history, not just still-open items.
+      const openComments = snapshotList(rawList, Number(vStr));
 
       // 1. Build the agent-readable banner.
       const reactionsText = (rs) => {
@@ -1758,7 +1763,7 @@ export default {
       const target = authList.find(c => c.id === id);
       if (!target) return json({ error: 'not_found' }, { status: 404 });
       if (!canMutate(target, s, env)) return json({ error: 'not_author' }, { status: 403 });
-      const V = Number(version) || target.created_in || 1;
+      const V = coerceBodyVersion(version, target.created_in || 1);
       const res = await mutateComments(env, slug, {
         kind: 'patch_anchor', slug, id, anchor, reset_status: true, version: V, actor: { login: s.login },
       });
@@ -1873,7 +1878,7 @@ export default {
       if (!parent) return json({ error: 'parent_not_found' }, { status: 404 });
 
       const verdict = ['applied', 'partial', 'question'].includes(agentStatus) ? agentStatus : null;
-      const V = Number(applied_in) || parent.created_in || 1;
+      const V = coerceBodyVersion(applied_in, parent.created_in || 1);
       const now = new Date().toISOString();
       const replyId = `r_${Date.now()}_${rand(4)}`;
 


### PR DESCRIPTION
A full-codebase audit + optimize pass with **Fable** (fresh engine — different blind spots than the prior Codex+Claude round), weighted to the un-audited v0.8.0 "comment pins-in-margin" feature (~571 new lines). Every finding was adversarially verified before fixing: **16 confirmed, 6 rejected**. Started from a real-browser E2E baseline (app healthy, zero console errors, per-version fold correct).

## Data correctness (`server.js` — local dev server, diverged from worker)
- **Replies had no `version`** → the per-version fold never hid them on older versions. Both user + agent reply paths now persist it.
- **Agent verdict emoji (✅/🟡/❓) leaked onto old snapshots** — an "open" version showed a contradictory "resolved" emoji. Stripped on snapshots that fold to open. *Verified across v1/v2/v3 on a hermetic fixture.*

## Overlay bugs
- **Element-anchor click listener leaked + multi-fired** — a new listener stacked on the target element every `refreshComments()`; one click fired `setActiveComment` N times. Bound once now. *Browser-verified: 10 bind attempts → 1 listener.*
- **Reply/comment submit swallowed failures** (400/404/409/500/network), clearing the input as if it succeeded → user text lost silently. Now surfaces the error and preserves the text.
- Restored pinned card after refresh desynced `activeId`/`.active`; now uses `setActiveComment`.
- Perf: `positionFloatingCard` computed `gutterGeometry()` twice → once.

## Test coverage (P1)
- The v0.8.0 pins clustering/spread/**overflow-fold** core had **zero tests** — a threshold regression would ship green. Extracted the pure math into `layoutPins(rows, geo, consts)` and added `test/pins-layout.test.js` (7 cases: same-line merge vs spread, tall-vs-short element distribution, never-exceed-bottom invariant).

## Worker P3 cleanups
- DO corrupt-store 409 now carries its error in `body` (was reaching the client empty).
- `patch_anchor` / agent-reply version coercion unified on `coerceBodyVersion` (preserves version 0).
- Removed a dead `status !== 'resolved'` export filter + a dead `outline._targetEl` field + a stale comment.

## Verification
Full offline suite **16/16 green** (new pins-layout suite registered). Real-browser E2E of the overlay fixes + fold fixes. The audit's `test.yml` bundle-sync finding was **not actioned** — `_worker.bundled.js` is gitignored (nothing to drift-check) and `coverage.test.js` already reproduces + syntax-checks the bundle in CI.

Rejected findings (6) were adversarially refuted (e.g. an "overflow can still overflow" claim, slug-regex inconsistency that's actually intentional per-tier).

🤖 Generated with [Claude Code](https://claude.com/claude-code)