### PR TITLE
Add Vercel as a second publish target

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,12 @@ worker/wrangler.toml
 # Wrangler local cache (created by `wrangler deploy`) — never commit
 worker/.wrangler/
 
+# Vercel local artifacts (project link + generated bundle) — the real deploy
+# runs from ~/.tdoc/vercel-app, but guard against a stray `vercel` run here
+vercel/.vercel/
+vercel/_worker.bundled.js
+vercel/node_modules/
+
 # Editor / OS junk
 .DS_Store
 .vscode/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,23 @@ All notable changes to tdoc are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/); versions follow the `VERSION`
 file and `.claude-plugin/plugin.json`.
 
+## [Unreleased]
+
+### Added — Vercel as a second publish target
+
+`/tdoc publish --platform vercel <slug>` deploys the same worker to a Vercel
+Function instead of a Cloudflare Worker. The bundled worker runs unmodified;
+only the storage bindings are swapped (`vercel/lib/`): docs go to Vercel Blob,
+metadata + comments go to Upstash Redis (Vercel Marketplace). `tdoc-pull` and
+`tdoc-unpublish` resolve the API base from the configured platform. The
+platform is chosen once, on the first publish, and persisted in
+`~/.tdoc/published.json`; existing Cloudflare users are unaffected (default
+unchanged). Known differences on Vercel — no per-doc comment-write
+serialization (the worker's documented KV fallback is used instead of a
+Durable Object) and a ~4.5 MB per-doc upload cap — are documented in
+`vercel/README.md`. Shims are covered by a new offline suite
+(`test/vercel-shim.test.js`).
+
 ## [0.8.1] - 2026-07-07
 
 Fable code audit of the v0.8.0 pins release (fresh engine, every finding

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ What is *not* yet first-class on Codex: native slash-command registration (`/tdo
 |---|---|
 | `/tdoc new <prompt>` | Generate a new doc + open locally |
 | `/tdoc edit <slug>` | New version from open comments; replies on each with ✅/🟡/❓ status |
-| `/tdoc publish <slug>` | Deploy to your Cloudflare Worker, get a public URL |
+| `/tdoc publish <slug>` | Deploy to your Cloudflare Worker (or Vercel, `--platform vercel`), get a public URL |
 | `/tdoc pull <slug>` | Sync comments from the published doc back to local |
 | `/tdoc fork <slug>` | Copy a doc to a new slug |
 | `/tdoc unpublish <slug>` | Remove a published doc from your Worker |
@@ -76,7 +76,22 @@ What is *not* yet first-class on Codex: native slash-command registration (`/tdo
 
 ## Cost
 
-**$0 for normal use.** Cloudflare Workers + R2 + KV all have generous free tiers that personal usage will never come close to. You own your account; nobody else (including the maintainer) sees your traffic or pays your bills.
+**$0 for normal use.** Cloudflare Workers + R2 + KV all have generous free tiers that personal usage will never come close to. The same goes for the Vercel target (Functions + Blob + Upstash Redis free tiers). You own your account; nobody else (including the maintainer) sees your traffic or pays your bills.
+
+## Hosting targets
+
+Publishing deploys the **same worker code** to a host you own; pick one on your
+first publish and it sticks (saved in `~/.tdoc/published.json`):
+
+- **Cloudflare (default)** — Worker + R2 + KV, with a Durable Object
+  serializing concurrent comment writes. The most battle-tested target.
+- **Vercel** — `/tdoc publish --platform vercel <slug>` deploys a catch-all
+  Vercel Function backed by Vercel Blob (docs) and Upstash Redis (metadata +
+  comments, from the Vercel Marketplace). Same URLs, same commenting, same
+  GitHub sign-in. Two caveats vs. Cloudflare: concurrent comment writes are
+  not serialized (no Durable Object equivalent), and uploads are capped at
+  ~4.5 MB per doc by Vercel's request limit. Details in
+  [vercel/README.md](vercel/README.md).
 
 ## How comments work
 
@@ -109,9 +124,10 @@ This is the "edit history" half of the Google-Docs feeling: nothing you write �
 ## Requirements
 
 - Node 18+
-- `wrangler` (for publishing)
 - `jq` (for publishing)
-- A free Cloudflare account with R2 enabled
+- For publishing, ONE of:
+  - `wrangler` + a free Cloudflare account with R2 enabled (default), or
+  - `vercel` CLI + a free Vercel account (`/tdoc publish --platform vercel <slug>`)
 
 `/tdoc onboard` checks and installs these for you.
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -393,7 +393,7 @@ echo "tdoc server: http://localhost:7878"
 pkill -f "$SKILL_DIR/server/server.js"
 ```
 
-### `/tdoc publish <slug>` — publish to your Cloudflare Worker
+### `/tdoc publish <slug>` — publish to your Cloudflare Worker (or Vercel)
 
 Publishes the latest version of `<slug>` to a public URL.
 
@@ -401,6 +401,16 @@ Local always stays $0/anonymous; publishing is opt-in. First run does a one-time
 setup: prompts `wrangler login`, creates an R2 bucket (`tdoc-docs`) and KV
 namespace (`META`) in *your* Cloudflare account, generates an upload token, and
 deploys your own Worker. Config is saved to `~/.tdoc/published.json`.
+
+**Alternative host — Vercel**: `tdoc-publish --platform vercel <slug>` (first
+publish only; the choice is persisted). Needs the `vercel` CLI (`npm i -g
+vercel`). First run links a Vercel project named `tdoc`, then asks you (via an
+agent prompt) to connect a **Blob** store and an **Upstash Redis** store in the
+Vercel dashboard's Storage tab — both free tier, ~2 clicks each — and deploys.
+Subsequent publishes and all other commands (`pull`, `unpublish`, comments,
+GitHub sign-in) work identically on either host. Caveats: no per-doc write
+serialization (Cloudflare uses a Durable Object for that) and a ~4.5 MB upload
+cap per doc (Vercel request limit).
 
 Subsequent runs upload the latest version of `<slug>`. The script also detects
 when `server/overlay.js` or `worker/worker.js` is newer than the bundled file
@@ -410,13 +420,15 @@ Set `TDOC_SKIP_WORKER_DEPLOY=1` to skip the redeploy (useful for batch uploads).
 On published docs, viewers sign in with GitHub (Device Flow, shared OAuth App
 `Ov23liZ1UAGOchvKPmlS`, scope `read:user`) before commenting.
 
-Requires `wrangler` (`npm i -g wrangler`) and `jq`.
+Requires `jq`, plus `wrangler` (`npm i -g wrangler`) for the Cloudflare
+target or `vercel` (`npm i -g vercel`) for the Vercel target.
 
 ```bash
 "$SKILL_DIR/bin/tdoc-publish" <slug>
 ```
 
-Prints the published URL: `https://<worker>.<subdomain>.workers.dev/d/<slug>/v/<N>`.
+Prints the published URL: `https://<worker>.<subdomain>.workers.dev/d/<slug>/v/<N>`
+(Cloudflare) or `https://tdoc-<scope>.vercel.app/d/<slug>/v/<N>` (Vercel).
 
 ### `/tdoc pull <slug>` — pull comments from the published doc
 

--- a/bin/tdoc-publish
+++ b/bin/tdoc-publish
@@ -1,9 +1,16 @@
 #!/usr/bin/env bash
-# tdoc-publish — first-time setup + upload doc to user's Cloudflare Worker.
+# tdoc-publish — first-time setup + upload doc to the user's own hosting.
 #
-# Usage: tdoc-publish <slug>
+# Usage: tdoc-publish [--platform cloudflare|vercel] <slug>
 #
-# First run:
+# Two publish targets share one flow (the worker code and the /api/upload
+# contract are identical on both):
+#   cloudflare (default) — wrangler deploy to a Worker + R2 + KV
+#   vercel               — vercel deploy of the vercel/ template + Blob + Upstash KV
+# The platform is chosen ONCE, on the first publish (flag or TDOC_PLATFORM
+# env), then persisted in ~/.tdoc/published.json and read from there.
+#
+# First run (cloudflare):
 #   1. Verify wrangler installed + logged in
 #   2. Create R2 bucket, KV namespace
 #   3. Generate TDOC_UPLOAD_TOKEN, set as Worker secret
@@ -11,15 +18,28 @@
 #   5. Deploy Worker
 #   6. Save config to ~/.tdoc/published.json
 #
+# First run (vercel): see first_time_setup_vercel below.
+#
 # Subsequent runs:
 #   Just upload the requested slug via /api/upload.
 
 set -euo pipefail
 
-SLUG="${1:-}"
+usage() { echo "usage: tdoc-publish [--platform cloudflare|vercel] <slug>" >&2; exit 1; }
+
+SLUG=""
+PLATFORM_FLAG="${TDOC_PLATFORM:-}"
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --platform)   PLATFORM_FLAG="${2:-}"; [ -n "$PLATFORM_FLAG" ] || usage; shift 2 ;;
+    --platform=*) PLATFORM_FLAG="${1#--platform=}"; [ -n "$PLATFORM_FLAG" ] || usage; shift ;;
+    # Anything else is treated as the slug — including dash-leading junk,
+    # which the kebab-case validator below rejects with a precise message.
+    *)  [ -z "$SLUG" ] || usage; SLUG="$1"; shift ;;
+  esac
+done
 if [ -z "$SLUG" ]; then
-  echo "usage: tdoc-publish <slug>" >&2
-  exit 1
+  usage
 fi
 # Validate the slug BEFORE it becomes a filesystem path or a URL query value.
 # Same kebab-case rule tdoc-new enforces. Without this a `..` slug escapes
@@ -36,6 +56,11 @@ DOC_DIR="$TDOC_DIR/$SLUG"
 CONFIG_DIR="$HOME/.tdoc"
 CONFIG_FILE="$CONFIG_DIR/published.json"
 WORKER_DIR="$SKILL_DIR/worker"
+# Vercel deploys run from a work dir OUTSIDE the skill checkout so the
+# `vercel` CLI's .vercel/ project link and the generated bundle never dirty
+# the skill install (mirrors how wrangler.toml is generated, but vercel also
+# writes a link dir, so we isolate the whole app).
+VERCEL_APP_DIR="$CONFIG_DIR/vercel-app"
 
 mkdir -p "$CONFIG_DIR"
 
@@ -134,11 +159,20 @@ EOF
   exit 1
 }
 
-# Deps
-if ! command -v wrangler >/dev/null 2>&1; then
-  fail_with_agent_prompt "wrangler is not installed" \
-    "Install Cloudflare wrangler globally so tdoc can publish: run 'npm i -g wrangler' (or 'pnpm add -g wrangler'). After it's installed, run '/tdoc publish $SLUG' again."
-fi
+# Deps. Platform CLIs (wrangler / vercel) are checked inside their platform
+# branches — only jq + node are needed on every path.
+require_wrangler() {
+  if ! command -v wrangler >/dev/null 2>&1; then
+    fail_with_agent_prompt "wrangler is not installed" \
+      "Install Cloudflare wrangler globally so tdoc can publish: run 'npm i -g wrangler' (or 'pnpm add -g wrangler'). After it's installed, run '/tdoc publish $SLUG' again."
+  fi
+}
+require_vercel() {
+  if ! command -v vercel >/dev/null 2>&1; then
+    fail_with_agent_prompt "the vercel CLI is not installed" \
+      "Install the Vercel CLI globally so tdoc can publish: run 'npm i -g vercel' (or 'pnpm add -g vercel'). After it's installed, run '/tdoc publish $SLUG' again."
+  fi
+}
 if ! command -v jq >/dev/null 2>&1; then
   fail_with_agent_prompt "jq is not installed" \
     "Install jq so tdoc can build its publish payload. On macOS: 'brew install jq'. On Debian/Ubuntu: 'sudo apt-get install -y jq'. Then run '/tdoc publish $SLUG' again."
@@ -154,9 +188,12 @@ if [ ! -d "$DOC_DIR" ]; then
 fi
 
 # --- bundle overlay.js into worker source ---
+# Writes _worker.bundled.js into $1 (defaults to the wrangler worker dir; the
+# vercel path passes its own app dir).
 bundle_worker() {
-  local out="$WORKER_DIR/_worker.bundled.js"
-  node -e '
+  local out_dir="${1:-$WORKER_DIR}"
+  local out="$out_dir/_worker.bundled.js"
+  OUT_DIR="$out_dir" node -e '
     const fs = require("fs");
     const path = require("path");
     const skill = process.env.SKILL_DIR;
@@ -171,13 +208,14 @@ bundle_worker() {
       console.error("bundle: failed to find OVERLAY_JS placeholder");
       process.exit(1);
     }
-    fs.writeFileSync(path.join(skill, "worker/_worker.bundled.js"), replaced);
+    fs.writeFileSync(path.join(process.env.OUT_DIR, "_worker.bundled.js"), replaced);
   '
   echo "bundled: $out"
 }
 
 first_time_setup() {
-  echo "[tdoc] first-time publish setup"
+  echo "[tdoc] first-time publish setup (cloudflare)"
+  require_wrangler
 
   # 1. wrangler login (idempotent — does nothing if already logged in)
   echo "[tdoc] checking wrangler auth..."
@@ -328,61 +366,238 @@ first_time_setup() {
   fi
 }
 
-if [ ! -f "$CONFIG_FILE" ]; then
-  SKILL_DIR="$SKILL_DIR" first_time_setup
-fi
+# ---- vercel platform ----
 
-SUBDOMAIN="$(jq -r .subdomain "$CONFIG_FILE")"
-TOKEN="$(jq -r .upload_token "$CONFIG_FILE")"
-WORKER_NAME="$(jq -r .worker "$CONFIG_FILE")"
-# Validate the config rather than letting a missing field become the literal
-# string "null" → "https://null.null.workers.dev" + "Bearer null". A corrupt or
-# partial published.json should fail loudly, not publish to a bogus host.
-for _f in SUBDOMAIN:subdomain TOKEN:upload_token WORKER_NAME:worker; do
-  _var="${_f%%:*}"; _key="${_f##*:}"; _val="$(eval "printf '%s' \"\$$_var\"")"
-  if [ -z "$_val" ] || [ "$_val" = "null" ]; then
-    echo "[tdoc] $CONFIG_FILE is missing or has a null '$_key'. Delete it and re-run /tdoc publish to re-setup." >&2
+# Assemble the deployable app at $VERCEL_APP_DIR: copy the vercel/ template
+# from the skill checkout, then bundle the worker (with overlay inlined) into
+# it. Idempotent; run before every deploy so template + worker edits ship.
+sync_vercel_app() {
+  if [ ! -d "$SKILL_DIR/vercel/api" ]; then
+    echo "[tdoc] $SKILL_DIR/vercel is missing — re-install/update the tdoc skill." >&2
     exit 1
   fi
-done
-PUBLIC_HOST="$(jq -r '.public_host // empty' "$CONFIG_FILE")"
-CUSTOM_DOMAIN="$(jq -r '.custom_domain // empty' "$CONFIG_FILE")"
-# Fallback for configs created before the domain choice was added
-if [ -z "$PUBLIC_HOST" ]; then PUBLIC_HOST="${SUBDOMAIN}.workers.dev"; fi
-# Upload always hits the workers.dev URL (custom domain binding may not be active yet);
-# the public-facing link we show the user is PUBLIC_HOST.
-UPLOAD_BASE="https://${WORKER_NAME}.${SUBDOMAIN}.workers.dev"
-PUBLIC_BASE="https://${PUBLIC_HOST}"
+  mkdir -p "$VERCEL_APP_DIR/api" "$VERCEL_APP_DIR/lib"
+  cp "$SKILL_DIR/vercel/api/"*.js "$VERCEL_APP_DIR/api/"
+  cp "$SKILL_DIR/vercel/lib/"*.js "$VERCEL_APP_DIR/lib/"
+  cp "$SKILL_DIR/vercel/vercel.json" "$SKILL_DIR/vercel/package.json" "$VERCEL_APP_DIR/"
+  SKILL_DIR="$SKILL_DIR" bundle_worker "$VERCEL_APP_DIR"
+}
 
-# --- redeploy worker if overlay.js / worker.js is newer than the bundled file ---
-# Skipped via TDOC_SKIP_WORKER_DEPLOY=1 (useful for batch uploads in tests).
-BUNDLED="$WORKER_DIR/_worker.bundled.js"
-if [ "${TDOC_SKIP_WORKER_DEPLOY:-0}" != "1" ]; then
-  if [ ! -f "$BUNDLED" ] \
-    || [ "$SKILL_DIR/server/overlay.js" -nt "$BUNDLED" ] \
-    || [ "$SKILL_DIR/worker/worker.js" -nt "$BUNDLED" ]; then
-    echo "[tdoc] worker code changed locally — redeploying..."
-    # Backfill TDOC_OWNER into an existing wrangler.toml that predates the
-    # owner-only catalog feature, so redeploys don't lose the setting.
-    if [ -f "$WORKER_DIR/wrangler.toml" ] \
-      && ! grep -q '^TDOC_OWNER' "$WORKER_DIR/wrangler.toml"; then
-      _ol=""
-      command -v gh >/dev/null 2>&1 && _ol="$(gh api user --jq .login 2>/dev/null || true)"
-      if grep -q '^\[vars\]' "$WORKER_DIR/wrangler.toml"; then
-        # insert right after the [vars] header
-        awk -v ol="$_ol" '
-          {print}
-          /^\[vars\]/ && !done {print "TDOC_OWNER = \"" ol "\""; done=1}
-        ' "$WORKER_DIR/wrangler.toml" > "$WORKER_DIR/wrangler.toml.tmp" \
-          && mv "$WORKER_DIR/wrangler.toml.tmp" "$WORKER_DIR/wrangler.toml"
-      else
-        printf '\n[vars]\nTDOC_OWNER = "%s"\n' "$_ol" >> "$WORKER_DIR/wrangler.toml"
-      fi
-      [ -n "$_ol" ] && echo "[tdoc] backfilled TDOC_OWNER=$_ol into wrangler.toml" \
-        || echo "[tdoc] TDOC_OWNER left empty (catalog stays private)."
+# Deploy $VERCEL_APP_DIR to production. Prints the deployment URL on stdout
+# (the vercel CLI prints exactly that; its progress goes to stderr).
+vercel_deploy_prod() {
+  local out
+  out="$( (cd "$VERCEL_APP_DIR" && vercel deploy --prod --yes) | tail -n1 )" || {
+    echo "[tdoc] vercel deploy failed (see output above)." >&2; return 1; }
+  case "$out" in
+    https://*) printf '%s' "$out" ;;
+    *) echo "[tdoc] vercel deploy did not return a deployment URL (got: $out)" >&2; return 1 ;;
+  esac
+}
+
+first_time_setup_vercel() {
+  echo "[tdoc] first-time publish setup (vercel)"
+  require_vercel
+
+  # 1. vercel login (idempotent — whoami succeeds when already logged in)
+  echo "[tdoc] checking vercel auth..."
+  if ! vercel whoami >/dev/null 2>&1; then
+    echo "[tdoc] running vercel login (browser will open)..."
+    vercel login
+  fi
+
+  # 2. assemble the app dir + link/create the project
+  sync_vercel_app
+  echo "[tdoc] linking Vercel project 'tdoc'..."
+  if ! (cd "$VERCEL_APP_DIR" && vercel link --yes --project tdoc >/dev/null); then
+    fail_with_agent_prompt "could not link/create the Vercel project" \
+      "Run 'cd $VERCEL_APP_DIR && vercel link --yes --project tdoc' and resolve whatever the CLI reports (usually a scope/team choice: add '--scope <team>'). Then run '/tdoc publish $SLUG' again."
+  fi
+
+  # 3. storage must be connected BEFORE the first deploy — the function reads
+  #    BLOB_READ_WRITE_TOKEN + KV/UPSTASH env vars that Vercel injects when a
+  #    store is connected to the project. Both are dashboard clicks (like
+  #    enabling R2 on the cloudflare path), so we hand the user an agent
+  #    prompt instead of failing cryptically at runtime.
+  local envs
+  envs="$( (cd "$VERCEL_APP_DIR" && vercel env ls production 2>/dev/null) || true )"
+  if ! printf '%s' "$envs" | grep -q 'BLOB_READ_WRITE_TOKEN'; then
+    fail_with_agent_prompt "no Vercel Blob store is connected to project 'tdoc'" \
+      "tdoc stores published docs in Vercel Blob. Open https://vercel.com/dashboard → project 'tdoc' → Storage tab → Create Database → Blob → create a store (any name) and CONNECT it to the project (all environments). It's free tier. After the user says done, run '/tdoc publish $SLUG' again."
+  fi
+  if ! printf '%s' "$envs" | grep -Eq 'KV_REST_API_URL|UPSTASH_REDIS_REST_URL'; then
+    fail_with_agent_prompt "no Redis/KV store is connected to project 'tdoc'" \
+      "tdoc stores doc metadata + comments in a Redis-compatible KV. Open https://vercel.com/dashboard → project 'tdoc' → Storage tab → Create Database → Upstash for Redis (Marketplace) → create the free store and CONNECT it to the project (all environments). After the user says done, run '/tdoc publish $SLUG' again."
+  fi
+
+  # 4. upload token → env var (rm first so re-setup after a lost config works)
+  local token
+  token="$(node -e 'console.log(require("crypto").randomBytes(32).toString("hex"))')"
+  echo "[tdoc] setting TDOC_UPLOAD_TOKEN env..."
+  (cd "$VERCEL_APP_DIR" && vercel env rm TDOC_UPLOAD_TOKEN production --yes >/dev/null 2>&1 || true)
+  (cd "$VERCEL_APP_DIR" && printf '%s' "$token" | vercel env add TDOC_UPLOAD_TOKEN production >/dev/null)
+
+  # 5. owner login for the private /me catalog (same semantics as cloudflare:
+  #    empty = catalog fully private, link-only docs)
+  local owner_login=""
+  if command -v gh >/dev/null 2>&1; then
+    owner_login="$(gh api user --jq .login 2>/dev/null || true)"
+  fi
+  if [ -n "$owner_login" ]; then
+    echo "[tdoc] worker owner (will see 'My docs'): $owner_login"
+    (cd "$VERCEL_APP_DIR" && vercel env rm TDOC_OWNER production --yes >/dev/null 2>&1 || true)
+    (cd "$VERCEL_APP_DIR" && printf '%s' "$owner_login" | vercel env add TDOC_OWNER production >/dev/null)
+  else
+    echo "[tdoc] no GitHub login detected — doc catalog stays private (link-only)."
+  fi
+
+  # 6. deploy + smoke-check
+  echo "[tdoc] deploying to Vercel..."
+  local deploy_url
+  deploy_url="$(vercel_deploy_prod)" || exit 1
+  local ping
+  ping="$(curl -sS --connect-timeout 10 --max-time 30 "$deploy_url/api/ping" 2>/dev/null || true)"
+  if ! printf '%s' "$ping" | grep -q '"ok"'; then
+    fail_with_agent_prompt "the deployed function does not answer /api/ping" \
+      "The tdoc Vercel deployment at $deploy_url is not healthy. Run 'cd $VERCEL_APP_DIR && vercel logs $deploy_url' to see the error (most often the Blob/KV store is connected to the wrong environment — it must include Production). Fix and run '/tdoc publish $SLUG' again."
+  fi
+
+  # 7. prefer the stable per-scope alias over the per-deployment URL for the
+  #    links we show. `<project>-<scope>.vercel.app` is reserved to the scope
+  #    by Vercel, so probing it can't adopt someone else's deployment.
+  local scope public_host
+  scope="$(vercel whoami 2>/dev/null | tail -n1 | tr -d '[:space:]')"
+  public_host="${deploy_url#https://}"
+  if [ -n "$scope" ]; then
+    local alias_ping
+    alias_ping="$(curl -sS --connect-timeout 10 --max-time 30 "https://tdoc-${scope}.vercel.app/api/ping" 2>/dev/null || true)"
+    if printf '%s' "$alias_ping" | grep -q '"ok"'; then
+      public_host="tdoc-${scope}.vercel.app"
     fi
-    SKILL_DIR="$SKILL_DIR" bundle_worker
-    (cd "$WORKER_DIR" && wrangler deploy)
+  fi
+
+  # 8. save config. 0600 from the start (umask 077) — it holds the token.
+  (
+    umask 077
+    jq -n \
+      --arg tok "$token" \
+      --arg base "$deploy_url" \
+      --arg host "$public_host" \
+      '{platform:"vercel", upload_token:$tok, base:$base, public_host:$host, created: now | todate}' \
+      > "$CONFIG_FILE"
+  )
+  chmod 600 "$CONFIG_FILE"
+  echo "[tdoc] setup done. tdoc is live at: https://${public_host}"
+}
+
+if [ ! -f "$CONFIG_FILE" ]; then
+  case "${PLATFORM_FLAG:-cloudflare}" in
+    cloudflare) SKILL_DIR="$SKILL_DIR" first_time_setup ;;
+    vercel)     SKILL_DIR="$SKILL_DIR" first_time_setup_vercel ;;
+    *) echo "[tdoc] unknown platform '${PLATFORM_FLAG}' — use 'cloudflare' or 'vercel'." >&2; exit 1 ;;
+  esac
+fi
+
+# The platform is whatever the config says from here on. A conflicting
+# --platform flag is ignored loudly rather than half-migrating state.
+PLATFORM="$(jq -r '.platform // "cloudflare"' "$CONFIG_FILE")"
+if [ -n "$PLATFORM_FLAG" ] && [ "$PLATFORM_FLAG" != "$PLATFORM" ]; then
+  echo "[tdoc] already set up for '$PLATFORM' — ignoring '--platform $PLATFORM_FLAG'. To switch platforms, delete $CONFIG_FILE and publish again." >&2
+fi
+
+TOKEN="$(jq -r .upload_token "$CONFIG_FILE")"
+
+if [ "$PLATFORM" = "vercel" ]; then
+  BASE="$(jq -r '.base // empty' "$CONFIG_FILE")"
+  # Validate like the cloudflare branch below: a corrupt or partial
+  # published.json must fail loudly, not publish to "null".
+  for _f in TOKEN:upload_token BASE:base; do
+    _var="${_f%%:*}"; _key="${_f##*:}"; _val="$(eval "printf '%s' \"\$$_var\"")"
+    if [ -z "$_val" ] || [ "$_val" = "null" ]; then
+      echo "[tdoc] $CONFIG_FILE is missing or has a null '$_key'. Delete it and re-run /tdoc publish to re-setup." >&2
+      exit 1
+    fi
+  done
+  PUBLIC_HOST="$(jq -r '.public_host // empty' "$CONFIG_FILE")"
+  CUSTOM_DOMAIN=""
+  [ -n "$PUBLIC_HOST" ] || PUBLIC_HOST="${BASE#https://}"
+
+  # --- redeploy if worker/overlay/template is newer than the bundled file ---
+  # Skipped via TDOC_SKIP_WORKER_DEPLOY=1 (useful for batch uploads in tests).
+  BUNDLED="$VERCEL_APP_DIR/_worker.bundled.js"
+  if [ "${TDOC_SKIP_WORKER_DEPLOY:-0}" != "1" ]; then
+    if [ ! -f "$BUNDLED" ] \
+      || [ "$SKILL_DIR/server/overlay.js" -nt "$BUNDLED" ] \
+      || [ "$SKILL_DIR/worker/worker.js" -nt "$BUNDLED" ] \
+      || [ -n "$(find "$SKILL_DIR/vercel" -type f -newer "$BUNDLED" 2>/dev/null | head -1)" ]; then
+      require_vercel
+      echo "[tdoc] worker code changed locally — redeploying to Vercel..."
+      sync_vercel_app
+      NEW_BASE="$(vercel_deploy_prod)" || exit 1
+      if [ "$NEW_BASE" != "$BASE" ]; then
+        # Persist the fresh deployment URL as the upload base. Old deployment
+        # URLs keep serving, so previously shared links stay live either way.
+        jq --arg base "$NEW_BASE" '.base = $base' "$CONFIG_FILE" > "$CONFIG_FILE.tmp" \
+          && mv "$CONFIG_FILE.tmp" "$CONFIG_FILE" && chmod 600 "$CONFIG_FILE"
+        BASE="$NEW_BASE"
+      fi
+    fi
+  fi
+  UPLOAD_BASE="$BASE"
+  PUBLIC_BASE="https://${PUBLIC_HOST}"
+else
+  SUBDOMAIN="$(jq -r .subdomain "$CONFIG_FILE")"
+  WORKER_NAME="$(jq -r .worker "$CONFIG_FILE")"
+  # Validate the config rather than letting a missing field become the literal
+  # string "null" → "https://null.null.workers.dev" + "Bearer null". A corrupt or
+  # partial published.json should fail loudly, not publish to a bogus host.
+  for _f in SUBDOMAIN:subdomain TOKEN:upload_token WORKER_NAME:worker; do
+    _var="${_f%%:*}"; _key="${_f##*:}"; _val="$(eval "printf '%s' \"\$$_var\"")"
+    if [ -z "$_val" ] || [ "$_val" = "null" ]; then
+      echo "[tdoc] $CONFIG_FILE is missing or has a null '$_key'. Delete it and re-run /tdoc publish to re-setup." >&2
+      exit 1
+    fi
+  done
+  PUBLIC_HOST="$(jq -r '.public_host // empty' "$CONFIG_FILE")"
+  CUSTOM_DOMAIN="$(jq -r '.custom_domain // empty' "$CONFIG_FILE")"
+  # Fallback for configs created before the domain choice was added
+  if [ -z "$PUBLIC_HOST" ]; then PUBLIC_HOST="${SUBDOMAIN}.workers.dev"; fi
+  # Upload always hits the workers.dev URL (custom domain binding may not be active yet);
+  # the public-facing link we show the user is PUBLIC_HOST.
+  UPLOAD_BASE="https://${WORKER_NAME}.${SUBDOMAIN}.workers.dev"
+  PUBLIC_BASE="https://${PUBLIC_HOST}"
+
+  # --- redeploy worker if overlay.js / worker.js is newer than the bundled file ---
+  # Skipped via TDOC_SKIP_WORKER_DEPLOY=1 (useful for batch uploads in tests).
+  BUNDLED="$WORKER_DIR/_worker.bundled.js"
+  if [ "${TDOC_SKIP_WORKER_DEPLOY:-0}" != "1" ]; then
+    if [ ! -f "$BUNDLED" ] \
+      || [ "$SKILL_DIR/server/overlay.js" -nt "$BUNDLED" ] \
+      || [ "$SKILL_DIR/worker/worker.js" -nt "$BUNDLED" ]; then
+      require_wrangler
+      echo "[tdoc] worker code changed locally — redeploying..."
+      # Backfill TDOC_OWNER into an existing wrangler.toml that predates the
+      # owner-only catalog feature, so redeploys don't lose the setting.
+      if [ -f "$WORKER_DIR/wrangler.toml" ] \
+        && ! grep -q '^TDOC_OWNER' "$WORKER_DIR/wrangler.toml"; then
+        _ol=""
+        command -v gh >/dev/null 2>&1 && _ol="$(gh api user --jq .login 2>/dev/null || true)"
+        if grep -q '^\[vars\]' "$WORKER_DIR/wrangler.toml"; then
+          # insert right after the [vars] header
+          awk -v ol="$_ol" '
+            {print}
+            /^\[vars\]/ && !done {print "TDOC_OWNER = \"" ol "\""; done=1}
+          ' "$WORKER_DIR/wrangler.toml" > "$WORKER_DIR/wrangler.toml.tmp" \
+            && mv "$WORKER_DIR/wrangler.toml.tmp" "$WORKER_DIR/wrangler.toml"
+        else
+          printf '\n[vars]\nTDOC_OWNER = "%s"\n' "$_ol" >> "$WORKER_DIR/wrangler.toml"
+        fi
+        [ -n "$_ol" ] && echo "[tdoc] backfilled TDOC_OWNER=$_ol into wrangler.toml" \
+          || echo "[tdoc] TDOC_OWNER left empty (catalog stays private)."
+      fi
+      SKILL_DIR="$SKILL_DIR" bundle_worker
+      (cd "$WORKER_DIR" && wrangler deploy)
+    fi
   fi
 fi
 

--- a/bin/tdoc-pull
+++ b/bin/tdoc-pull
@@ -30,9 +30,20 @@ if [ ! -f "$CONFIG_FILE" ]; then
 fi
 if ! command -v jq >/dev/null 2>&1; then echo "needs jq" >&2; exit 1; fi
 
-SUBDOMAIN="$(jq -r .subdomain "$CONFIG_FILE")"
-WORKER_NAME="$(jq -r .worker "$CONFIG_FILE")"
-BASE="https://${WORKER_NAME}.${SUBDOMAIN}.workers.dev"
+# Resolve the API base for the configured platform: vercel configs store the
+# deployment URL directly in `.base`; cloudflare configs derive workers.dev.
+PLATFORM="$(jq -r '.platform // "cloudflare"' "$CONFIG_FILE")"
+if [ "$PLATFORM" = "vercel" ]; then
+  BASE="$(jq -r '.base // empty' "$CONFIG_FILE")"
+  if [ -z "$BASE" ] || [ "$BASE" = "null" ]; then
+    echo "[tdoc] $CONFIG_FILE has no '.base' — delete it and re-run /tdoc publish to re-setup." >&2
+    exit 1
+  fi
+else
+  SUBDOMAIN="$(jq -r .subdomain "$CONFIG_FILE")"
+  WORKER_NAME="$(jq -r .worker "$CONFIG_FILE")"
+  BASE="https://${WORKER_NAME}.${SUBDOMAIN}.workers.dev"
+fi
 
 OUT="$TDOC_DIR/$SLUG/comments.json"
 mkdir -p "$(dirname "$OUT")"

--- a/bin/tdoc-unpublish
+++ b/bin/tdoc-unpublish
@@ -20,11 +20,22 @@ if [ ! -f "$CONFIG_FILE" ]; then
 fi
 if ! command -v jq >/dev/null 2>&1; then echo "needs jq" >&2; exit 1; fi
 
-SUBDOMAIN="$(jq -r .subdomain "$CONFIG_FILE")"
-WORKER_NAME="$(jq -r .worker "$CONFIG_FILE")"
 TOKEN="$(jq -r .upload_token "$CONFIG_FILE")"
-BASE="https://${WORKER_NAME}.${SUBDOMAIN}.workers.dev"
+# Resolve the API base for the configured platform: vercel configs store the
+# deployment URL directly in `.base`; cloudflare configs derive workers.dev.
+PLATFORM="$(jq -r '.platform // "cloudflare"' "$CONFIG_FILE")"
+if [ "$PLATFORM" = "vercel" ]; then
+  BASE="$(jq -r '.base // empty' "$CONFIG_FILE")"
+  if [ -z "$BASE" ] || [ "$BASE" = "null" ]; then
+    echo "[tdoc] $CONFIG_FILE has no '.base' — delete it and re-run /tdoc publish to re-setup." >&2
+    exit 1
+  fi
+else
+  SUBDOMAIN="$(jq -r .subdomain "$CONFIG_FILE")"
+  WORKER_NAME="$(jq -r .worker "$CONFIG_FILE")"
+  BASE="https://${WORKER_NAME}.${SUBDOMAIN}.workers.dev"
+fi
 
-curl -sS -X DELETE "$BASE/api/doc?slug=$SLUG" \
+curl -sS --connect-timeout 10 --max-time 60 -X DELETE "$BASE/api/doc?slug=$SLUG" \
   -H "Authorization: Bearer $TOKEN" | jq .
 echo "Unpublished $SLUG."

--- a/skills/tdoc/SKILL.md
+++ b/skills/tdoc/SKILL.md
@@ -170,10 +170,13 @@ sharing, with GitHub auth gating comments.
     comments.json      # [{ id, version, anchor, text, status }]
 ```
 
-Server runs at `http://localhost:7878` and serves:
+Server runs at `http://localhost:7878` (override with `TDOC_PORT`) and serves:
 - `/` — index of all docs
 - `/d/<slug>/v/<n>` — a specific version (injects comment overlay)
 - `/api/comments` GET/POST — comment persistence
+- `/api/ping` — health check; responds `{"ok":true,"service":"tdoc"}`. The
+  `service` field is the identity marker — a foreign service answering 200 on
+  the port must NOT pass as tdoc.
 
 ## Setup check
 
@@ -190,13 +193,23 @@ done
 SKILL_DIR="${SKILL_DIR:-$HOME/.claude/skills/tdoc}"
 mkdir -p "$TDOC_DIR"
 
-# Check server is running
-if curl -sf http://localhost:7878/api/ping >/dev/null 2>&1; then
+# Check server is running. Identity-check the body — 200 alone is not proof
+# the answerer is tdoc; another local service can squat the port.
+TDOC_PORT="${TDOC_PORT:-7878}"
+PING_BODY=$(curl -sf --max-time 2 "http://localhost:${TDOC_PORT}/api/ping" 2>/dev/null || true)
+if printf '%s' "$PING_BODY" | grep -q '"service" *: *"tdoc"'; then
   echo "SERVER_OK"
+elif [ -n "$PING_BODY" ]; then
+  echo "PORT_FOREIGN"   # something else answers on the port — do NOT use it
 else
   echo "SERVER_DOWN"
 fi
 ```
+
+If `PORT_FOREIGN`: another service holds port ${TDOC_PORT}. If `pgrep -f
+"$SKILL_DIR/server/server.js"` finds a process, it's an outdated tdoc server —
+restart it. Otherwise tell the user which process holds the port (`lsof -i
+:${TDOC_PORT}`) and either free it or set `TDOC_PORT` to a free port.
 
 If server is down, start it:
 ```bash
@@ -380,7 +393,7 @@ echo "tdoc server: http://localhost:7878"
 pkill -f "$SKILL_DIR/server/server.js"
 ```
 
-### `/tdoc publish <slug>` — publish to your Cloudflare Worker
+### `/tdoc publish <slug>` — publish to your Cloudflare Worker (or Vercel)
 
 Publishes the latest version of `<slug>` to a public URL.
 
@@ -388,6 +401,16 @@ Local always stays $0/anonymous; publishing is opt-in. First run does a one-time
 setup: prompts `wrangler login`, creates an R2 bucket (`tdoc-docs`) and KV
 namespace (`META`) in *your* Cloudflare account, generates an upload token, and
 deploys your own Worker. Config is saved to `~/.tdoc/published.json`.
+
+**Alternative host — Vercel**: `tdoc-publish --platform vercel <slug>` (first
+publish only; the choice is persisted). Needs the `vercel` CLI (`npm i -g
+vercel`). First run links a Vercel project named `tdoc`, then asks you (via an
+agent prompt) to connect a **Blob** store and an **Upstash Redis** store in the
+Vercel dashboard's Storage tab — both free tier, ~2 clicks each — and deploys.
+Subsequent publishes and all other commands (`pull`, `unpublish`, comments,
+GitHub sign-in) work identically on either host. Caveats: no per-doc write
+serialization (Cloudflare uses a Durable Object for that) and a ~4.5 MB upload
+cap per doc (Vercel request limit).
 
 Subsequent runs upload the latest version of `<slug>`. The script also detects
 when `server/overlay.js` or `worker/worker.js` is newer than the bundled file
@@ -397,13 +420,15 @@ Set `TDOC_SKIP_WORKER_DEPLOY=1` to skip the redeploy (useful for batch uploads).
 On published docs, viewers sign in with GitHub (Device Flow, shared OAuth App
 `Ov23liZ1UAGOchvKPmlS`, scope `read:user`) before commenting.
 
-Requires `wrangler` (`npm i -g wrangler`) and `jq`.
+Requires `jq`, plus `wrangler` (`npm i -g wrangler`) for the Cloudflare
+target or `vercel` (`npm i -g vercel`) for the Vercel target.
 
 ```bash
 "$SKILL_DIR/bin/tdoc-publish" <slug>
 ```
 
-Prints the published URL: `https://<worker>.<subdomain>.workers.dev/d/<slug>/v/<N>`.
+Prints the published URL: `https://<worker>.<subdomain>.workers.dev/d/<slug>/v/<N>`
+(Cloudflare) or `https://tdoc-<scope>.vercel.app/d/<slug>/v/<N>` (Vercel).
 
 ### `/tdoc pull <slug>` — pull comments from the published doc
 
@@ -494,6 +519,7 @@ When the user reports a problem, check these first:
 - **`/api/publish` 404, or "string did not match the expected pattern" in the Publish modal** → the running server is stale (old process, doesn't have current routes). Restart it: `pkill -f "$SKILL_DIR/server/server.js" && nohup node "$SKILL_DIR/server/server.js" > "$TDOC_DIR/.server.log" 2>&1 &`. `/tdoc update` now auto-restarts, but a server that was started before the update is still running stale code until restarted.
 - **Comment popup doesn't appear when selecting text** → ensure overlay.js has the fix where a drag-without-artifact-intersection falls through to the text-selection branch (regression test: `ui.test.js` "Drag-to-select TEXT in a `<p>` opens the comment popup"). If the test fails, check `overlay.js` mouseup handler: the `if (dragged) { ... return; }` block must only `return` when an artifact was actually hit.
 - **Publish modal hangs forever** → check `~/tdocs/.server.log`; usually `wrangler login` is waiting for browser auth or R2 isn't enabled.
+- **Local doc URLs show the wrong content / weird JSON, or the server "is up" but docs 404** → another local service may be squatting the tdoc port (seen in the wild: a daemon from another product bound 7878). Run `curl -s http://localhost:7878/api/ping` — if the body lacks `"service":"tdoc"`, the answerer is not tdoc. Identify the squatter with `lsof -i :7878`, then free the port or run tdoc on another port via `TDOC_PORT=<port>` (the bin scripts and server all honor it).
 
 ## HTML generation rules
 

--- a/test/run.js
+++ b/test/run.js
@@ -30,6 +30,7 @@ const OFFLINE = [
   'comment-ops.test.js',      // #34 DO-serialized mutation ops
   'p3-hardening.test.js',     // #33 safeParseList + escapeHtml
   'stampaids.test.js',        // aid-stamp regex hardening (equivalence + edges)
+  'vercel-shim.test.js',      // vercel storage shims (KV/R2 contract, rewrite URL)
   'api.test.js',              // hermetic: spawns its own server in a temp dir
 ];
 

--- a/test/vercel-shim.test.js
+++ b/test/vercel-shim.test.js
@@ -1,0 +1,186 @@
+// Vercel storage shims (vercel/lib/*). Offline: the KV shim takes an
+// injectable fetchImpl and the Blob shim takes an injectable SDK, so nothing
+// here needs @vercel/blob installed or any network. What this guards:
+//
+//   - the KV shim speaks the worker's KV contract EXACTLY (get→string|null,
+//     list→{keys:[{name}],cursor,list_complete}) over Upstash REST commands
+//   - the Blob shim speaks the worker's R2 contract (get→{text()}|null,
+//     head→{size}|null, list→{objects,truncated,cursor}) and — critically —
+//     resolves keys by EXACT pathname, not prefix (docs/a/v1 must never
+//     resolve to docs/a/v11's blob)
+//   - the rewrite-URL helper reconstructs the original path + query behind
+//     the vercel.json catch-all, since the worker routes on pathname
+//
+// vercel/ is an ESM package (type: module); this CJS suite loads it via
+// dynamic import. Run with: node test/vercel-shim.test.js
+
+const path = require('path');
+
+let pass = 0, fail = 0;
+function ok(n) { console.log(`  ✓ ${n}`); pass++; }
+function bad(n, e) { console.log(`  ✗ ${n}\n    ${e}`); fail++; }
+async function t(n, fn) { try { await fn(); ok(n); } catch (e) { bad(n, e.message); } }
+function assert(c, m) { if (!c) throw new Error(m || 'assertion failed'); }
+function eq(a, b, m) { assert(JSON.stringify(a) === JSON.stringify(b), `${m || 'eq'}: ${JSON.stringify(a)} !== ${JSON.stringify(b)}`); }
+
+const LIB = (f) => path.join(__dirname, '..', 'vercel', 'lib', f);
+
+// Minimal Upstash REST fake: replies per-command, records every request body.
+function fakeUpstash(replies) {
+  const calls = [];
+  const fetchImpl = async (url, init) => {
+    const args = JSON.parse(init.body);
+    calls.push({ url, auth: init.headers.Authorization, args });
+    const r = replies.shift();
+    if (r && r.httpError) return { ok: false, status: r.httpError, json: async () => ({ error: 'boom' }) };
+    return { ok: true, status: 200, json: async () => ({ result: r === undefined ? null : r.result }) };
+  };
+  return { calls, fetchImpl };
+}
+
+(async () => {
+  console.log('vercel shims');
+  const { createKvStore, globEscape } = await import(LIB('upstash-kv.js'));
+  const { createDocsStore } = await import(LIB('blob-r2.js'));
+  const { originalRequestUrl } = await import(LIB('request-url.js'));
+
+  // ---- upstash-kv ----
+  await t('kv.get returns the string, null for a missing key, and sends GET', async () => {
+    const f = fakeUpstash([{ result: '{"a":1}' }, { result: null }]);
+    const kv = createKvStore({ url: 'https://kv.example/', token: 'tok', fetchImpl: f.fetchImpl });
+    eq(await kv.get('meta:x'), '{"a":1}');
+    eq(await kv.get('meta:gone'), null);
+    eq(f.calls[0].args, ['GET', 'meta:x']);
+    assert(f.calls[0].auth === 'Bearer tok', 'missing bearer token');
+    assert(f.calls[0].url === 'https://kv.example', 'trailing slash not stripped');
+  });
+
+  await t('kv.put / kv.delete send SET / DEL with the raw string value', async () => {
+    const f = fakeUpstash([{ result: 'OK' }, { result: 1 }]);
+    const kv = createKvStore({ url: 'https://kv.example', token: 't', fetchImpl: f.fetchImpl });
+    await kv.put('comments:s', '[{"id":"c1"}]');
+    await kv.delete('comments:s');
+    eq(f.calls[0].args, ['SET', 'comments:s', '[{"id":"c1"}]']);
+    eq(f.calls[1].args, ['DEL', 'comments:s']);
+  });
+
+  await t('kv.list pages through SCAN with the worker loop contract', async () => {
+    const f = fakeUpstash([
+      { result: ['42', ['meta:a', 'meta:b']] },
+      { result: ['0', ['meta:c']] },
+    ]);
+    const kv = createKvStore({ url: 'https://kv.example', token: 't', fetchImpl: f.fetchImpl });
+    // Mirrors the worker's paging loop (indexHtml): concat until list_complete.
+    let names = [], cursor;
+    do {
+      const r = await kv.list({ prefix: 'meta:', cursor });
+      names = names.concat(r.keys.map(k => k.name));
+      cursor = r.cursor;
+      if (r.list_complete) break;
+    } while (cursor);
+    eq(names, ['meta:a', 'meta:b', 'meta:c']);
+    eq(f.calls[0].args, ['SCAN', '0', 'MATCH', 'meta:*', 'COUNT', '1000']);
+    eq(f.calls[1].args, ['SCAN', '42', 'MATCH', 'meta:*', 'COUNT', '1000']);
+  });
+
+  await t('kv errors throw (HTTP error and {error} body), never return junk', async () => {
+    const f = fakeUpstash([{ httpError: 500 }]);
+    const kv = createKvStore({ url: 'https://kv.example', token: 't', fetchImpl: f.fetchImpl });
+    let threw = false;
+    try { await kv.get('k'); } catch { threw = true; }
+    assert(threw, 'HTTP 500 did not throw');
+  });
+
+  await t('glob metacharacters in a prefix are escaped for MATCH', () => {
+    eq(globEscape('a*b?c[d]'), 'a\\*b\\?c\\[d\\]');
+  });
+
+  // ---- blob-r2 ----
+  // Fake @vercel/blob SDK over an in-memory map keyed by pathname.
+  function fakeBlobSdk() {
+    const store = new Map(); // pathname → {content, opts}
+    const calls = { put: [], del: [] };
+    return {
+      store, calls,
+      put: async (pathname, content, opts) => { calls.put.push({ pathname, opts }); store.set(pathname, { content, opts }); },
+      del: async (url) => { calls.del.push(url); for (const [k] of store) { if (`https://blob.test/${k}` === url) store.delete(k); } },
+      list: async ({ prefix = '', cursor, limit }) => ({
+        blobs: [...store.keys()].filter(k => k.startsWith(prefix))
+          .map(pathname => ({ pathname, url: `https://blob.test/${pathname}`, size: store.get(pathname).content.length })),
+        hasMore: false,
+        cursor: undefined,
+      }),
+      fetchBlob: async (url) => {
+        const key = url.replace('https://blob.test/', '');
+        const hit = store.get(key);
+        return hit ? { ok: true, text: async () => hit.content } : { ok: false, text: async () => '' };
+      },
+    };
+  }
+
+  await t('docs.put writes overwrite-in-place with the R2 contentType mapped', async () => {
+    const sdk = fakeBlobSdk();
+    const docs = createDocsStore(sdk);
+    await docs.put('docs/a/v1/index.html', '<html>', { httpMetadata: { contentType: 'text/html; charset=utf-8' } });
+    const p = sdk.calls.put[0];
+    assert(p.pathname === 'docs/a/v1/index.html', 'pathname mismatch');
+    assert(p.opts.addRandomSuffix === false && p.opts.allowOverwrite === true, 'must overwrite in place like R2');
+    assert(p.opts.contentType === 'text/html; charset=utf-8', 'contentType not mapped');
+  });
+
+  await t('docs.get/head resolve by EXACT pathname (v1 never matches v11)', async () => {
+    const sdk = fakeBlobSdk();
+    sdk.store.set('docs/a/v11/index.html', { content: 'ELEVEN', opts: {} });
+    const docs = createDocsStore(sdk);
+    eq(await docs.get('docs/a/v1/index.html'), null, 'prefix collision must not resolve');
+    eq(await docs.head('docs/a/v1/index.html'), null);
+    sdk.store.set('docs/a/v1/index.html', { content: 'ONE', opts: {} });
+    eq(await (await docs.get('docs/a/v1/index.html')).text(), 'ONE');
+    eq((await docs.head('docs/a/v1/index.html')).size, 3);
+  });
+
+  await t('docs.delete removes the exact blob; missing key is a no-op', async () => {
+    const sdk = fakeBlobSdk();
+    sdk.store.set('docs/a/v1/index.html', { content: 'x', opts: {} });
+    const docs = createDocsStore(sdk);
+    await docs.delete('docs/a/v1/index.html');
+    assert(!sdk.store.has('docs/a/v1/index.html'), 'not deleted');
+    await docs.delete('docs/a/v1/index.html'); // must not throw
+  });
+
+  await t('docs.list maps blobs→objects and hasMore→truncated', async () => {
+    const sdk = fakeBlobSdk();
+    sdk.store.set('docs/a/v1/index.html', { content: 'x', opts: {} });
+    sdk.store.set('docs/a/v2/index.html', { content: 'y', opts: {} });
+    sdk.store.set('docs/b/v1/index.html', { content: 'z', opts: {} });
+    const docs = createDocsStore(sdk);
+    const r = await docs.list({ prefix: 'docs/a/' });
+    eq(r.objects.map(o => o.key).sort(), ['docs/a/v1/index.html', 'docs/a/v2/index.html']);
+    assert(r.truncated === false, 'truncated mapping');
+  });
+
+  // ---- request-url ----
+  await t('rewritten request URL is reconstructed (path + merged query + fwd host)', () => {
+    const req = new Request('https://internal.fn/api/tdoc?__path=d/my-doc/v/2&version=all', {
+      headers: { 'x-forwarded-host': 'tdoc-me.vercel.app', 'x-forwarded-proto': 'https' },
+    });
+    eq(originalRequestUrl(req), 'https://tdoc-me.vercel.app/d/my-doc/v/2?version=all');
+  });
+
+  await t('root path and no-query rewrites resolve cleanly', () => {
+    const req = new Request('https://h.test/api/tdoc?__path=', {
+      headers: { 'x-forwarded-host': 'h.test' },
+    });
+    eq(originalRequestUrl(req), 'https://h.test/');
+  });
+
+  await t('non-rewritten request passes through with the public origin', () => {
+    const req = new Request('https://internal.fn/api/ping?x=1', {
+      headers: { 'x-forwarded-host': 'pub.test' },
+    });
+    eq(originalRequestUrl(req), 'https://pub.test/api/ping?x=1');
+  });
+
+  console.log(`\n${pass} passed, ${fail} failed`);
+  process.exit(fail ? 1 : 0);
+})();

--- a/vercel/README.md
+++ b/vercel/README.md
@@ -1,0 +1,61 @@
+# tdoc on Vercel
+
+This directory is the **deploy template** for publishing tdoc to Vercel
+instead of a Cloudflare Worker. You normally never touch it directly —
+`tdoc-publish --platform vercel <slug>` copies it to `~/.tdoc/vercel-app/`,
+bundles the worker into it, and drives the `vercel` CLI. Everything below is
+for people who want to understand or debug that flow.
+
+## Architecture
+
+The **same** worker code (`worker/worker.js` + `server/overlay.js`, bundled to
+`_worker.bundled.js` at publish time) runs behind a single catch-all Vercel
+function. Only the storage bindings differ:
+
+| Cloudflare binding | Vercel backend | Shim |
+|---|---|---|
+| `DOCS` (R2 bucket) | Vercel Blob | `lib/blob-r2.js` |
+| `META` (KV namespace) | Upstash Redis (Marketplace) / legacy Vercel KV | `lib/upstash-kv.js` |
+| `COMMENTS` (Durable Object) | *absent* | worker's built-in KV fallback |
+
+`vercel.json` rewrites every path to `/api/tdoc`, and `lib/request-url.js`
+reconstructs the original URL so the worker's own router sees the real path
+(`/d/<slug>/v/<N>`, `/api/upload`, …).
+
+## One-time setup (what tdoc-publish automates)
+
+1. `npm i -g vercel` and `vercel login`.
+2. `vercel link` a project (default name `tdoc`).
+3. In the Vercel dashboard → project → **Storage**:
+   - create a **Blob** store and connect it (provides `BLOB_READ_WRITE_TOKEN`);
+   - add an **Upstash Redis** store from the Marketplace and connect it
+     (provides `UPSTASH_REDIS_REST_URL` / `UPSTASH_REDIS_REST_TOKEN`; a legacy
+     Vercel KV store's `KV_REST_API_*` vars work too).
+4. Set the `TDOC_UPLOAD_TOKEN` env var (tdoc-publish generates it) and
+   optionally `TDOC_OWNER` (your GitHub login, for the owner-only `/me`
+   catalog).
+5. `vercel deploy --prod` — but only after tdoc-publish has written
+   `_worker.bundled.js`; deploying the raw template fails the build on
+   purpose, because a worker without the inlined overlay is broken.
+
+Both storage products have free tiers that comfortably cover personal use.
+
+## Known differences vs. the Cloudflare deployment
+
+- **No per-slug write serialization.** Cloudflare uses a Durable Object to
+  serialize concurrent comment writes (#34). Vercel has no equivalent
+  primitive here, so the worker uses its documented KV fallback: two people
+  commenting on the same doc in the same instant can race (last write wins).
+  Fine for personal/small-team use; heavy concurrent commenting is better
+  served by the Cloudflare target.
+- **Upload body limit ≈ 4.5 MB** (Vercel function request limit). Docs with
+  large embedded images that publish fine to Cloudflare (100 MB limit) can
+  exceed it.
+- **Blob is public-by-URL.** Doc bytes live in a Vercel Blob store whose
+  hostname contains a random store id. tdoc never emits blob URLs to clients
+  (docs are served through the function, which is also where the overlay is
+  injected), so docs remain link-only in practice — but unlike R2 there is no
+  hard ACL on the underlying objects. Treat published docs as
+  public-if-leaked, and don't publish secrets.
+- **Blob CDN staleness ≤ 60 s** when overwriting an already-published version
+  (fresh versions are unaffected).

--- a/vercel/api/tdoc.js
+++ b/vercel/api/tdoc.js
@@ -1,0 +1,87 @@
+// tdoc on Vercel — a single catch-all function that runs the SAME bundled
+// worker code the Cloudflare deployment runs, with the two storage bindings
+// swapped for Vercel-native backends:
+//
+//   DOCS (R2 bucket)   → Vercel Blob            (lib/blob-r2.js)
+//   META (KV namespace)→ Upstash Redis REST     (lib/upstash-kv.js)
+//   COMMENTS (DO)      → intentionally ABSENT   — the worker detects the
+//                        missing binding and uses its built-in KV fallback
+//                        (functional, not per-slug serialized; see #34).
+//
+// IMPORTANT: `../_worker.bundled.js` does not exist in the repo — tdoc-publish
+// generates it (worker/worker.js with server/overlay.js inlined) into the
+// deploy dir before every `vercel deploy`, exactly like the wrangler flow.
+// Deploying this directory without running tdoc-publish will fail the build,
+// on purpose: a worker without the overlay is a broken product.
+//
+// Uses the Node runtime's web handler signature (Request → Response), so the
+// worker's fetch handler runs unmodified.
+
+import worker from '../_worker.bundled.js';
+import { createDocsStore } from '../lib/blob-r2.js';
+import { createKvStore } from '../lib/upstash-kv.js';
+import { originalRequestUrl } from '../lib/request-url.js';
+
+function json(obj, status) {
+  return new Response(JSON.stringify(obj), {
+    status, headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+// Build the worker env from this deployment's environment variables. Returns
+// { env } or { error: Response } — a missing storage integration becomes a
+// clear 500 the user can act on, not a cryptic throw deep inside a route.
+async function buildEnv() {
+  const blobToken = process.env.BLOB_READ_WRITE_TOKEN;
+  if (!blobToken) {
+    return { error: json({ error: 'storage_not_configured', message: 'No Vercel Blob store is connected to this project (BLOB_READ_WRITE_TOKEN is unset). Create a Blob store in the Vercel dashboard (Storage tab) and connect it, then redeploy.' }, 500) };
+  }
+  // Marketplace Upstash exposes UPSTASH_REDIS_REST_*; stores created under the
+  // legacy "Vercel KV" name expose KV_REST_API_*. Accept both.
+  const kvUrl = process.env.KV_REST_API_URL || process.env.UPSTASH_REDIS_REST_URL;
+  const kvToken = process.env.KV_REST_API_TOKEN || process.env.UPSTASH_REDIS_REST_TOKEN;
+  if (!kvUrl || !kvToken) {
+    return { error: json({ error: 'storage_not_configured', message: 'No Redis/KV store is connected to this project (KV_REST_API_URL / UPSTASH_REDIS_REST_URL is unset). Add an Upstash Redis store from the Vercel Marketplace (Storage tab) and connect it, then redeploy.' }, 500) };
+  }
+  // @vercel/blob is imported lazily so this module stays loadable (and the
+  // config errors above stay reachable) even if the dependency install is
+  // broken — and so lib/blob-r2.js keeps its SDK injectable for tests.
+  const blob = await import('@vercel/blob');
+  const sdk = {
+    put: (key, value, opts) => blob.put(key, value, { ...opts, token: blobToken }),
+    del: (url) => blob.del(url, { token: blobToken }),
+    list: (opts) => blob.list({ ...opts, token: blobToken }),
+    fetchBlob: (url) => fetch(url),
+  };
+  return {
+    env: {
+      DOCS: createDocsStore(sdk),
+      META: createKvStore({ url: kvUrl, token: kvToken }),
+      TDOC_UPLOAD_TOKEN: process.env.TDOC_UPLOAD_TOKEN,
+      TDOC_OWNER: process.env.TDOC_OWNER || '',
+      // Same public GitHub Device Flow app the wrangler template ships —
+      // device flow has no redirect URI, so it works from any host.
+      GITHUB_CLIENT_ID: process.env.GITHUB_CLIENT_ID || 'Ov23liZ1UAGOchvKPmlS',
+      TDOC_DEBUG: process.env.TDOC_DEBUG || '',
+    },
+  };
+}
+
+async function handle(req) {
+  const built = await buildEnv();
+  if (built.error) return built.error;
+  const url = originalRequestUrl(req);
+  const init = { method: req.method, headers: req.headers, redirect: 'manual' };
+  if (req.method !== 'GET' && req.method !== 'HEAD') {
+    init.body = req.body;
+    init.duplex = 'half'; // Node fetch requires this for streamed bodies
+  }
+  return worker.fetch(new Request(url, init), built.env, {});
+}
+
+export const GET = handle;
+export const POST = handle;
+export const PATCH = handle;
+export const DELETE = handle;
+export const OPTIONS = handle;
+export const HEAD = handle;

--- a/vercel/lib/blob-r2.js
+++ b/vercel/lib/blob-r2.js
@@ -1,0 +1,72 @@
+// DOCS (Cloudflare R2) shim over Vercel Blob. The worker uses five R2
+// operations: put / get / head / delete / list. We map them onto the
+// @vercel/blob SDK, which is injected by the caller (api/tdoc.js) instead of
+// imported here — so the offline test suite can exercise this file with a
+// fake SDK and no npm install.
+//
+// Key → pathname is 1:1 (`docs/<slug>/v<N>/index.html`), no random suffix, so
+// re-publishing a version overwrites in place like R2.
+//
+// PRIVACY TRADEOFF (documented in vercel/README.md): Vercel Blob stores are
+// public-by-URL. The store hostname contains a random store id and we never
+// emit blob URLs to clients (docs are always served THROUGH the function), so
+// docs stay link-only in practice — but unlike R2 there is no hard ACL in
+// front of the bytes. Don't publish secrets in a doc.
+
+// Resolve a key to its blob record via an exact-pathname list match. We list
+// rather than head(pathname) because the SDK's head/del historically accepted
+// only full blob URLs; list-by-prefix + exact match works on every SDK
+// version and also hands us the URL that get()/delete() need.
+async function resolveBlob(sdk, key) {
+  const r = await sdk.list({ prefix: key, limit: 10 });
+  return (r.blobs || []).find(b => b.pathname === key) || null;
+}
+
+function createDocsStore(sdk) {
+  return {
+    // R2.put(key, body, {httpMetadata}) — worker checks nothing on the return
+    // value (it verifies with head() instead), so we just write.
+    async put(key, value, opts = {}) {
+      await sdk.put(key, value, {
+        access: 'public',
+        addRandomSuffix: false,
+        allowOverwrite: true,
+        contentType: (opts.httpMetadata && opts.httpMetadata.contentType) || 'application/octet-stream',
+        // Keep CDN staleness short: a re-published version should be visible
+        // quickly. 60s is the Blob minimum.
+        cacheControlMaxAge: 60,
+      });
+    },
+    // R2.get(key) → { text() } | null. The worker only ever calls .text().
+    async get(key) {
+      const blob = await resolveBlob(sdk, key);
+      if (!blob) return null;
+      const r = await sdk.fetchBlob(blob.url);
+      if (!r.ok) return null;
+      return { text: () => r.text() };
+    },
+    // R2.head(key) → { size } | null. Used as an existence probe and for the
+    // post-upload write verification (which reads .size).
+    async head(key) {
+      const blob = await resolveBlob(sdk, key);
+      return blob ? { size: blob.size } : null;
+    },
+    // R2.delete(key). Missing key is a no-op, matching R2.
+    async delete(key) {
+      const blob = await resolveBlob(sdk, key);
+      if (blob) await sdk.del(blob.url);
+    },
+    // R2.list({prefix, cursor}) → { objects: [{key}], truncated, cursor }.
+    // Only used by the admin delete path to enumerate a slug's versions.
+    async list({ prefix = '', cursor } = {}) {
+      const r = await sdk.list({ prefix, cursor, limit: 1000 });
+      return {
+        objects: (r.blobs || []).map(b => ({ key: b.pathname })),
+        truncated: !!r.hasMore,
+        cursor: r.cursor,
+      };
+    },
+  };
+}
+
+export { createDocsStore, resolveBlob };

--- a/vercel/lib/request-url.js
+++ b/vercel/lib/request-url.js
@@ -1,0 +1,27 @@
+// Rebuild the ORIGINAL request URL behind the vercel.json catch-all rewrite.
+//
+// vercel.json rewrites `/(.*)` → `/api/tdoc?__path=$1`, because a Vercel
+// project routes by filesystem and the worker routes by pathname — without
+// the rewrite every path except /api/tdoc would 404 before our code runs.
+// Vercel merges the source URL's own query params into the destination, so
+// the function sees `/api/tdoc?__path=d/my-doc/v/2&foo=bar` and must undo the
+// mangling before handing the request to the worker's router.
+//
+// Host/proto come from the x-forwarded-* headers when present: req.url inside
+// a function can carry an internal host, and the worker's redirect/cookie
+// behavior should be computed against the public origin.
+function originalRequestUrl(req) {
+  const u = new URL(req.url);
+  const host = req.headers.get('x-forwarded-host') || u.host;
+  const proto = req.headers.get('x-forwarded-proto') || 'https';
+  const path = u.searchParams.get('__path');
+  if (path == null) {
+    // Not rewritten (direct hit on a real path) — just normalize the origin.
+    return `${proto}://${host}${u.pathname}${u.search}`;
+  }
+  u.searchParams.delete('__path');
+  const qs = u.searchParams.toString();
+  return `${proto}://${host}/${path.replace(/^\/+/, '')}${qs ? `?${qs}` : ''}`;
+}
+
+export { originalRequestUrl };

--- a/vercel/lib/upstash-kv.js
+++ b/vercel/lib/upstash-kv.js
@@ -1,0 +1,76 @@
+// META (Cloudflare KV) shim over an Upstash Redis REST endpoint — the storage
+// Vercel's Marketplace provisions as its KV offering. The worker only uses
+// four KV operations (get / put / delete / list-by-prefix), so we implement
+// exactly that surface and nothing more.
+//
+// Raw REST (fetch) instead of @upstash/redis on purpose: the repo ships zero
+// runtime npm dependencies, the REST protocol is documented + stable
+// (https://upstash.com/docs/redis/features/restapi), and an injectable
+// `fetchImpl` keeps this testable offline with no SDK installed.
+//
+// Consistency note: Upstash REST reads hit the primary, so the worker's
+// read-after-write flows (device-flow login writes a session then the client
+// immediately uses the cookie; posting a comment then refetching the list)
+// behave the same as Cloudflare KV.
+
+// Escape Redis glob metacharacters so a literal prefix like "meta:" can't be
+// misread as a pattern. Prefixes we pass are [a-z:-] today; this is defense
+// against a future key charset change, not a live bug.
+function globEscape(s) {
+  return String(s).replace(/[\\*?[\]]/g, '\\$&');
+}
+
+function createKvStore({ url, token, fetchImpl }) {
+  if (!url || !token) throw new Error('upstash-kv: url and token are required');
+  const doFetch = fetchImpl || fetch;
+  const base = url.replace(/\/+$/, '');
+
+  // One Redis command per call, pipelining not needed at tdoc's volume.
+  // Non-2xx or an {error} body throws — the worker's endpoints already turn
+  // storage throws into 500s with a logged message, matching R2/KV behavior.
+  async function cmd(...args) {
+    const r = await doFetch(base, {
+      method: 'POST',
+      headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' },
+      body: JSON.stringify(args.map(String)),
+    });
+    let body;
+    try { body = await r.json(); } catch { body = {}; }
+    if (!r.ok || body.error) {
+      throw new Error(`upstash ${args[0]} failed: ${body.error || `HTTP ${r.status}`}`);
+    }
+    return body.result;
+  }
+
+  return {
+    // KV.get(key) → string | null. Upstash returns null for a missing key.
+    async get(key) {
+      const v = await cmd('GET', key);
+      return v == null ? null : String(v);
+    },
+    // KV.put(key, value). The worker only ever writes strings (JSON).
+    async put(key, value) {
+      await cmd('SET', key, value);
+    },
+    // KV.delete(key). Deleting a missing key is a no-op, same as KV.
+    async delete(key) {
+      await cmd('DEL', key);
+    },
+    // KV.list({prefix, cursor}) → { keys: [{name}], cursor, list_complete }.
+    // SCAN's contract matches the worker's paging loop exactly: it may return
+    // an empty page with a non-zero cursor (worker keeps looping) and signals
+    // completion with cursor "0" (worker breaks on list_complete).
+    async list({ prefix = '', cursor } = {}) {
+      const res = await cmd('SCAN', cursor || '0', 'MATCH', `${globEscape(prefix)}*`, 'COUNT', '1000');
+      const next = String(res[0]);
+      const names = Array.isArray(res[1]) ? res[1] : [];
+      return {
+        keys: names.map(name => ({ name })),
+        cursor: next === '0' ? undefined : next,
+        list_complete: next === '0',
+      };
+    },
+  };
+}
+
+export { createKvStore, globEscape };

--- a/vercel/package.json
+++ b/vercel/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "tdoc-vercel",
+  "private": true,
+  "type": "module",
+  "description": "tdoc publish target for Vercel — the bundled worker behind a catch-all function, with Blob (docs) + Upstash Redis (meta) storage shims.",
+  "dependencies": {
+    "@vercel/blob": "^0.27.0"
+  }
+}

--- a/vercel/vercel.json
+++ b/vercel/vercel.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "rewrites": [
+    { "source": "/(.*)", "destination": "/api/tdoc?__path=$1" }
+  ],
+  "functions": {
+    "api/tdoc.js": { "maxDuration": 60 }
+  }
+}


### PR DESCRIPTION
## What

`/tdoc publish --platform vercel <slug>` deploys tdoc to the user's own **Vercel** account instead of a Cloudflare Worker. Cloudflare stays the default; the platform is chosen once on the first publish and persisted in `~/.tdoc/published.json`, so existing users are untouched.

## Design: same worker, swapped bindings

The bundled worker (`worker.js` + inlined overlay) is pure Web API code, so it runs **unmodified** behind a single catch-all Vercel Function. Only the storage bindings differ:

| Cloudflare binding | Vercel backend | Shim |
|---|---|---|
| `DOCS` (R2) | Vercel Blob | `vercel/lib/blob-r2.js` |
| `META` (KV) | Upstash Redis REST (Marketplace) / legacy Vercel KV | `vercel/lib/upstash-kv.js` |
| `COMMENTS` (Durable Object) | *absent* | the worker's existing, documented KV fallback (#34) |

`vercel.json` rewrites every path to `/api/tdoc`; `lib/request-url.js` reconstructs the original URL so the worker's own router sees the real path. The KV shim is raw `fetch` against the documented Upstash REST API (keeping the repo's zero-runtime-dependency posture); `@vercel/blob` is the template's only dependency and is injected into the shim so tests need no install.

## UX mirrors the wrangler flow

First publish: CLI/login checks, `vercel link --project tdoc`, then the two dashboard steps (connect a Blob store + an Upstash Redis store) are surfaced as `fail_with_agent_prompt` paste-into-agent prompts — same pattern as the R2-enable flow. Token via `vercel env add`, deploy, `/api/ping` smoke check, and a probe for the stable `tdoc-<scope>.vercel.app` alias (scope-reserved, so it can't adopt a stranger's deployment). Redeploy-on-change works like the wrangler path, including `TDOC_SKIP_WORKER_DEPLOY=1`. `tdoc-pull` / `tdoc-unpublish` resolve the API base from the configured platform.

## Honest tradeoffs (documented in `vercel/README.md`)

- **No per-doc write serialization** — Vercel has no Durable Object equivalent, so concurrent comment writes use the worker's KV fallback (last-write-wins under a same-instant race). Fine for personal/small-team docs; heavy multiplayer commenting is better served by the Cloudflare target.
- **~4.5 MB upload cap** (Vercel request body limit) vs 100 MB on Cloudflare.
- **Blob is public-by-URL**: doc bytes sit behind a random store hostname and tdoc never emits blob URLs, but unlike R2 there's no hard ACL on the objects.
- `tdoc-doctor` is still Cloudflare-only; teaching it about the vercel config is left as a follow-up to keep this PR reviewable.

## Testing

- `npm test` — all 17 suites green, including the new **`test/vercel-shim.test.js`** (KV/R2 contract fidelity — notably exact-pathname resolution so `v1` never resolves to `v11`'s blob, and the SCAN paging loop matching the worker's `list_complete` contract — plus rewrite-URL reconstruction). Offline, no SDK installs.
- Offline end-to-end smoke (not committed): bundled the worker exactly as `tdoc-publish` does, ran it against the real shims over in-memory backends — upload → aid stamping → doc view with overlay injected → comments (KV-fallback path) → admin delete all behave identically to the Cloudflare path.
- **Not yet run against a live Vercel deployment** — I don't have a Vercel account to burn on this. The runtime surface I couldn't verify offline is the `vercel` CLI interactions and the Node web-handler signature; happy to iterate if anything needs adjusting on a real deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)