### PR TITLE
fix(vercel): honor expirationTtl in Upstash KV shim (session expiry)

### DIFF
--- a/test/vercel-shim.test.js
+++ b/test/vercel-shim.test.js
@@ -64,6 +64,14 @@ function fakeUpstash(replies) {
     eq(f.calls[1].args, ['DEL', 'comments:s']);
   });
 
+  await t('kv.put forwards expirationTtl as SET ... EX (sessions must expire)', async () => {
+    const f = fakeUpstash([{ result: 'OK' }]);
+    const kv = createKvStore({ url: 'https://kv.example', token: 't', fetchImpl: f.fetchImpl });
+    // Mirrors the worker's session write: env.META.put(key, val, {expirationTtl: 30d}).
+    await kv.put('session:sid', '{"login":"x"}', { expirationTtl: 60 * 60 * 24 * 30 });
+    eq(f.calls[0].args, ['SET', 'session:sid', '{"login":"x"}', 'EX', String(60 * 60 * 24 * 30)]);
+  });
+
   await t('kv.list pages through SCAN with the worker loop contract', async () => {
     const f = fakeUpstash([
       { result: ['42', ['meta:a', 'meta:b']] },

--- a/vercel/lib/upstash-kv.js
+++ b/vercel/lib/upstash-kv.js
@@ -48,9 +48,16 @@ function createKvStore({ url, token, fetchImpl }) {
       const v = await cmd('GET', key);
       return v == null ? null : String(v);
     },
-    // KV.put(key, value). The worker only ever writes strings (JSON).
-    async put(key, value) {
-      await cmd('SET', key, value);
+    // KV.put(key, value, {expirationTtl}). The worker writes strings (JSON),
+    // and for session records passes expirationTtl (30d) relying on the store
+    // to auto-expire them. Cloudflare KV honors that; forward it to Redis as
+    // `SET key value EX <seconds>` so Vercel sessions expire too — otherwise
+    // session:* keys live forever (unbounded growth + no server-side session
+    // expiry). Upstash REST supports the trailing EX arg.
+    async put(key, value, opts = {}) {
+      const ttl = opts && opts.expirationTtl;
+      if (ttl) await cmd('SET', key, value, 'EX', String(ttl));
+      else await cmd('SET', key, value);
     },
     // KV.delete(key). Deleting a missing key is a no-op, same as KV.
     async delete(key) {


### PR DESCRIPTION
Fast-follow to #76 (caught in review).

**Problem:** the worker writes login sessions with a 30-day TTL (`env.META.put(session, ..., { expirationTtl: 30d })`) and `getSession` has no app-level expiry check — it trusts the store to purge. Cloudflare KV honors that, but the Vercel Upstash shim's `put(key, value)` took only two args and issued a bare `SET`, so on Vercel:
- `session:*` keys **never expire** → unbounded growth
- a captured `tdoc_sid` cookie stays server-valid forever (masked in normal use by the cookie's own `Max-Age=30d`, but no server-side backstop)

**Fix:** forward `expirationTtl` as `SET key value EX <seconds>` (supported by Upstash REST). Added a shim test asserting the `EX` arg is emitted for a session write.

Full suite 17/17; vercel-shim suite 13/13.

🤖 Generated with [Claude Code](https://claude.com/claude-code)