### PR TITLE
docs(vercel): explain exact-pathname match in resolveBlob [test PR]

### DIFF
--- a/vercel/lib/blob-r2.js
+++ b/vercel/lib/blob-r2.js
@@ -76,4 +76,3 @@ function createDocsStore(sdk) {
 }
 
 export { createDocsStore, resolveBlob };
-

--- a/vercel/lib/blob-r2.js
+++ b/vercel/lib/blob-r2.js
@@ -76,3 +76,4 @@ function createDocsStore(sdk) {
 }
 
 export { createDocsStore, resolveBlob };
+

--- a/vercel/lib/blob-r2.js
+++ b/vercel/lib/blob-r2.js
@@ -17,6 +17,12 @@
 // rather than head(pathname) because the SDK's head/del historically accepted
 // only full blob URLs; list-by-prefix + exact match works on every SDK
 // version and also hands us the URL that get()/delete() need.
+//
+// The exact `pathname === key` match (not just the prefix) is what stops
+// `docs/a/v1/index.html` from resolving to `docs/a/v11/index.html`'s blob.
+// limit:10 is enough because keys are full pathnames — the only blobs sharing
+// this prefix would be longer paths under it, which tdoc never writes. If that
+// ever changes, page the list instead of raising the limit.
 async function resolveBlob(sdk, key) {
   const r = await sdk.list({ prefix: key, limit: 10 });
   return (r.blobs || []).find(b => b.pathname === key) || null;


### PR DESCRIPTION
**🧪 Test PR** — probing Greptile's behavior. Comment-only change to `resolveBlob` (zero behavior change): documents why the exact `pathname === key` match prevents `v1` resolving to `v11`'s blob, and why `limit: 10` is safe.

Now verifying #82: with `shouldUpdateDescription: false` live on main, Greptile should post a **comment below** rather than edit this description.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds inline documentation comments to `resolveBlob` in `vercel/lib/blob-r2.js`, explaining why the exact `pathname === key` comparison prevents prefix-collision between similarly named versions (e.g., `v1` vs `v11`), and why `limit: 10` is a safe upper bound given tdoc's key naming convention. There are zero functional changes.

- Adds a 5-line comment block above `resolveBlob` clarifying the exact-match guard and the `limit: 10` rationale, with a forward-looking note to paginate if the key convention ever changes.
- Appends a trailing newline at the end of the file.

<h3>Confidence Score: 5/5</h3>

Safe to merge — this is a documentation-only change with no modifications to runtime logic.

Only comment lines were added; the exact-match guard and limit value being documented are unchanged and correct. The new comments accurately describe the existing behavior.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| vercel/lib/blob-r2.js | Comment-only addition explaining the exact-pathname guard and limit:10 rationale in resolveBlob; no logic changes. |

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Caller as api/tdoc.js
    participant RS as resolveBlob
    participant SDK as @vercel/blob SDK

    Caller->>RS: resolveBlob(sdk, "docs/a/v1/index.html")
    RS->>SDK: "sdk.list({ prefix: "docs/a/v1/index.html", limit: 10 })"
    SDK-->>RS: "{ blobs: [ {pathname: "docs/a/v1/index.html", url: "..."}, ... ] }"
    Note over RS: find(b => b.pathname === key)<br/>exact match prevents v1→v11 collision
    RS-->>Caller: "blob record | null"
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Caller as api/tdoc.js
    participant RS as resolveBlob
    participant SDK as @vercel/blob SDK

    Caller->>RS: resolveBlob(sdk, "docs/a/v1/index.html")
    RS->>SDK: "sdk.list({ prefix: "docs/a/v1/index.html", limit: 10 })"
    SDK-->>RS: "{ blobs: [ {pathname: "docs/a/v1/index.html", url: "..."}, ... ] }"
    Note over RS: find(b => b.pathname === key)<br/>exact match prevents v1→v11 collision
    RS-->>Caller: "blob record | null"
```

</a>

<sub>Reviews (3): Last reviewed commit: ["chore: retrigger greptile (verify should..."](https://github.com/serenakeyitan/tdoc/commit/f48aa79bcaa857de3752cafaf5b24d84c7f30295) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44965166)</sub>

<!-- /greptile_comment -->