### PR TITLE
Fix generated doc spacing and comment-mode centering

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -594,7 +594,7 @@ Always set `body { background: #fff; }` (or your chosen color) so the page doesn
 Every doc must work on mobile out of the box. The overlay injects defensive CSS for artifacts, but the doc itself should also be authored responsively:
 
 - **Always include** `<meta name="viewport" content="width=device-width, initial-scale=1">` in `<head>`. (The overlay injects this if you forget, but include it.)
-- **Use fluid widths**, not hardcoded pixels. Container: `max-width: 720px; padding: 0 24px;` (no `margin: 0 auto` — overlay handles it).
+- **Use fluid widths**, not hardcoded pixels. Container: `max-width: 720px;` (no `margin: 0 auto`; no top-level `padding: 0 ...` — overlay handles margins and top/bottom reading space). If you need custom inner spacing, put it on a child element inside the container.
 - **Canvas / SVG / images**: do NOT hardcode width=N height=M. Either:
   - Use `width="100%"` + CSS aspect-ratio (`aspect-ratio: 16/9`), or
   - Use a wrapper with `max-width: 100%` and let the artifact scale.

--- a/server/overlay.js
+++ b/server/overlay.js
@@ -82,10 +82,10 @@
   body .tdoc-bar, body .tdoc-bar *, body #tdoc-comment-layer, body #tdoc-comment-layer *, body #tdoc-pin-layer, body #tdoc-pin-layer *, body .tdoc-cluster-pop, body .tdoc-cluster-pop *, body .tdoc-hover-outline, body .tdoc-comment-pill, body .tdoc-emoji-picker, body .tdoc-secondary-menu, body .tdoc-anchor-mark.tdoc-anchor-mark-element, body .tdoc-drag-marquee, body .tdoc-modal, body .tdoc-modal * { -webkit-user-select: none !important; user-select: none !important; }
   body .tdoc-modal .code, body .tdoc-modal textarea, body .tdoc-modal input { -webkit-user-select: text !important; user-select: text !important; }
   /* Reserve the 320px comment column on the right. The article centers
-     itself inside the remaining (viewport - 320px) space via margin auto
-     (applied below in :where()). Adding a left padding keeps it from
-     hugging the screen edge on wide windows. */
-  body.tdoc-has-comments:not(.tdoc-narrow) { padding-right: 360px !important; padding-left: 80px !important; }
+     itself inside the remaining reading area via margin auto (applied below
+     in :where()). Keep only a small left gutter; a larger one visibly pushes
+     the document off-center when comments are open. */
+  body.tdoc-has-comments:not(.tdoc-narrow) { padding-right: 360px !important; padding-left: 24px !important; }
   body.tdoc-narrow { padding-right: 0 !important; }
   /* Center the article container in the reading column. :where() so any
      doc-defined margin wins. Applies only on wide layouts; narrow mode

--- a/skills/tdoc/SKILL.md
+++ b/skills/tdoc/SKILL.md
@@ -594,7 +594,7 @@ Always set `body { background: #fff; }` (or your chosen color) so the page doesn
 Every doc must work on mobile out of the box. The overlay injects defensive CSS for artifacts, but the doc itself should also be authored responsively:
 
 - **Always include** `<meta name="viewport" content="width=device-width, initial-scale=1">` in `<head>`. (The overlay injects this if you forget, but include it.)
-- **Use fluid widths**, not hardcoded pixels. Container: `max-width: 720px; padding: 0 24px;` (no `margin: 0 auto` — overlay handles it).
+- **Use fluid widths**, not hardcoded pixels. Container: `max-width: 720px;` (no `margin: 0 auto`; no top-level `padding: 0 ...` — overlay handles margins and top/bottom reading space). If you need custom inner spacing, put it on a child element inside the container.
 - **Canvas / SVG / images**: do NOT hardcode width=N height=M. Either:
   - Use `width="100%"` + CSS aspect-ratio (`aspect-ratio: 16/9`), or
   - Use a wrapper with `max-width: 100%` and let the artifact scale.

--- a/test/dimensions-audit.js
+++ b/test/dimensions-audit.js
@@ -42,7 +42,10 @@ const REQUIRE_FOOTER = process.env.AUDIT_REQUIRE_FOOTER !== '0';
       const docEl = document.documentElement;
       const hasComments = body.classList.contains('tdoc-has-comments');
       const narrow = body.classList.contains('tdoc-narrow');
-      const cards = [...document.querySelectorAll('.tdoc-margin-comment')].map(c => {
+      const cards = [...document.querySelectorAll('.tdoc-margin-comment')].filter(c => {
+        const cs = getComputedStyle(c);
+        return cs.display !== 'none' && c.offsetWidth > 0 && c.offsetHeight > 0;
+      }).map(c => {
         const r = c.getBoundingClientRect();
         return { left: r.left, right: r.right, top: r.top, width: r.width };
       });
@@ -75,6 +78,8 @@ const REQUIRE_FOOTER = process.env.AUDIT_REQUIRE_FOOTER !== '0';
           left: r.left,
         };
       }) : [];
+      const docTitle = document.querySelector('.tdoc-bar .doc-title');
+      const docTitleVisible = !!(docTitle && docTitle.offsetWidth > 0 && docTitle.offsetHeight > 0);
 
       const footer = document.querySelector('.tdoc-footer');
       const footerRect = footer ? footer.getBoundingClientRect() : null;
@@ -92,6 +97,7 @@ const REQUIRE_FOOTER = process.env.AUDIT_REQUIRE_FOOTER !== '0';
         article: aRect ? { left: aRect.left, right: aRect.right, width: aRect.width } : null,
         bar: barRect ? { left: barRect.left, right: barRect.right } : null,
         barChildren,
+        docTitleVisible,
         footer: footerRect ? { left: footerRect.left, right: footerRect.right, width: footerRect.width } : null,
         footerLinks,
       };
@@ -106,6 +112,11 @@ const REQUIRE_FOOTER = process.env.AUDIT_REQUIRE_FOOTER !== '0';
     // Overlap rule: when has-comments && !narrow, cards must sit to the right
     // of the article (article.right <= card.left).
     if (m.hasComments && !m.narrow && m.article) {
+      const readerCenter = (m.innerWidth - 360) / 2;
+      const articleCenter = (m.article.left + m.article.right) / 2;
+      if (Math.abs(articleCenter - readerCenter) > 24) {
+        errs.push(`article center=${articleCenter.toFixed(0)} not centered in reading area center=${readerCenter.toFixed(0)}`);
+      }
       for (const c of m.cards) {
         if (c.right > m.innerWidth + 1) errs.push(`card right=${c.right.toFixed(0)} overflows viewport ${m.innerWidth}`);
         if (c.left < m.article.right - 2) errs.push(`card overlaps article (card.left=${c.left.toFixed(0)} < article.right=${m.article.right.toFixed(0)})`);
@@ -120,18 +131,18 @@ const REQUIRE_FOOTER = process.env.AUDIT_REQUIRE_FOOTER !== '0';
     }
 
     // Top bar children: at minimum, the title + identity slot must be visible.
-    const title = m.barChildren.find(c => c.cls.includes('title'));
-    if (!title || !title.visible) errs.push('bar title not visible');
-    const identSlot = m.barChildren.find(c => c.id === 'tdoc-identity-slot');
+    if (!m.docTitleVisible) errs.push('bar title not visible');
+    const hasIdentSlot = m.barChildren.some(c => c.id === 'tdoc-identity-slot');
     // identity slot is a span wrapper; might collapse to 0 width before its
-    // child renders. Probe the actual chip/button instead.
+    // child renders. Probe the actual chip/button instead when this target has
+    // identity chrome at all; the anonymous local fixture does not.
     const chipVisible = await page.evaluate(() => {
       const slot = document.querySelector('#tdoc-identity-slot');
-      if (!slot || !slot.firstElementChild) return false;
+      if (!slot || !slot.firstElementChild) return null;
       const el = slot.firstElementChild;
       return el.offsetWidth > 0 && el.offsetHeight > 0;
     });
-    if (!chipVisible) errs.push('identity chip/signin not visible');
+    if (hasIdentSlot && chipVisible === false) errs.push('identity chip/signin not visible');
 
     if (REQUIRE_FOOTER) {
       if (!m.footer) errs.push('footer missing');

--- a/test/responsive.test.js
+++ b/test/responsive.test.js
@@ -73,7 +73,10 @@ async function tPub(name, fn) {
     // Read the actual layout state once; assertions derive from it.
     const st = await page.evaluate(() => {
       const vis = (sel) => { const el = document.querySelector(sel); return !!(el && el.offsetWidth > 0 && el.offsetHeight > 0); };
-      const cards = [...document.querySelectorAll('.tdoc-margin-comment')].map(c => {
+      const cards = [...document.querySelectorAll('.tdoc-margin-comment')].filter(c => {
+        const cs = getComputedStyle(c);
+        return cs.display !== 'none' && c.offsetWidth > 0 && c.offsetHeight > 0;
+      }).map(c => {
         const r = c.getBoundingClientRect(); return { left: r.left, right: r.right };
       });
       return {


### PR DESCRIPTION
## Summary
- stop telling generated docs to set top-level container padding to 0, which removes overlay-provided top spacing
- reduce the comment-mode left gutter so the doc remains centered in the reader area while the right rail is open
- update browser layout tests for pins-mode and add a reader-area centering invariant

## Verification
- node test/overlay-pure.test.js && node test/pins-layout.test.js && node test/api.test.js
- node test/responsive.test.js
- AUDIT_START=800 AUDIT_END=1600 AUDIT_STEP=100 node test/dimensions-audit.js
- focused Chromium measurement: comments open at 1024/1200/1440/1600px, article center stayed 12px from reader-area center; h1 gap below top bar was 59px

## Note
- npm test currently has an unrelated local failure in coverage.test.js under Node 18: the generated worker bundle contains ESM export syntax and node --check treats it as CJS.