### PR TITLE
Center reader area when comments are open

### DIFF
--- a/server/overlay.js
+++ b/server/overlay.js
@@ -81,11 +81,10 @@
   body { padding-top: 44px !important; padding-bottom: 24px; -webkit-user-select: text; user-select: text; }
   body .tdoc-bar, body .tdoc-bar *, body #tdoc-comment-layer, body #tdoc-comment-layer *, body #tdoc-pin-layer, body #tdoc-pin-layer *, body .tdoc-cluster-pop, body .tdoc-cluster-pop *, body .tdoc-hover-outline, body .tdoc-comment-pill, body .tdoc-emoji-picker, body .tdoc-secondary-menu, body .tdoc-anchor-mark.tdoc-anchor-mark-element, body .tdoc-drag-marquee, body .tdoc-modal, body .tdoc-modal * { -webkit-user-select: none !important; user-select: none !important; }
   body .tdoc-modal .code, body .tdoc-modal textarea, body .tdoc-modal input { -webkit-user-select: text !important; user-select: text !important; }
-  /* Reserve the 320px comment column on the right. The article centers
-     itself inside the remaining reading area via margin auto (applied below
-     in :where()). Keep only a small left gutter; a larger one visibly pushes
-     the document off-center when comments are open. */
-  body.tdoc-has-comments:not(.tdoc-narrow) { padding-right: 360px !important; padding-left: 24px !important; }
+  /* Reserve the comment rail on the right. The body content box becomes the
+     reader area, so article margin:auto centers content in that area exactly
+     instead of using a compensating left gutter. */
+  body.tdoc-has-comments:not(.tdoc-narrow) { padding-right: 360px !important; padding-left: 0 !important; }
   body.tdoc-narrow { padding-right: 0 !important; }
   /* Center the article container in the reading column. :where() so any
      doc-defined margin wins. Applies only on wide layouts; narrow mode

--- a/test/dimensions-audit.js
+++ b/test/dimensions-audit.js
@@ -114,7 +114,7 @@ const REQUIRE_FOOTER = process.env.AUDIT_REQUIRE_FOOTER !== '0';
     if (m.hasComments && !m.narrow && m.article) {
       const readerCenter = (m.innerWidth - 360) / 2;
       const articleCenter = (m.article.left + m.article.right) / 2;
-      if (Math.abs(articleCenter - readerCenter) > 24) {
+      if (Math.abs(articleCenter - readerCenter) > 2) {
         errs.push(`article center=${articleCenter.toFixed(0)} not centered in reading area center=${readerCenter.toFixed(0)}`);
       }
       for (const c of m.cards) {


### PR DESCRIPTION
Follow-up to PR #96 based on Julie's review: remove the compensating left gutter in comment mode and make the article center exactly within the reader area reserved by the right comment rail.\n\nChanges:\n- comment mode reserves only the right comment rail on body\n- article margin:auto now centers exactly in the body content box / reader area\n- dimensions audit threshold tightened from 24px to 2px\n\nLocal verification:\n- node test/overlay-pure.test.js && node test/pins-layout.test.js && node test/api.test.js\n- node test/responsive.test.js\n- AUDIT_START=800 AUDIT_END=1600 AUDIT_STEP=100 node test/dimensions-audit.js\n- focused Playwright measurement: comment-mode center delta is 0px at 1024/1200/1440/1600