### PR TITLE
Fix comment affordance and agent identity

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,11 +126,11 @@ It's the Google-Docs commenting model, built for generated HTML documents and
 wired to your agent:
 
 - **Text**: highlight any sentence (across paragraphs, across bold/links — anchors survive regeneration) → comment popup, cursor ready to type
-- **Artifacts** (img / canvas / svg / video / `<pre>`): hover → "Comment" pill → click
+- **Artifacts** (img / canvas / svg / video / `<pre>`): hover → comment icon → click
 - **Threads**: emoji reactions (👍 ❤️ 🔥 ✅ ❓ + `LGTM`) and replies; hover a reaction to see who reacted
 - **Move / remove anchor**: drag a comment to new text, or detach it entirely — it stays in the thread
 - **Multiplayer**: anyone with the link signs in once with GitHub and comments. Every comment is attributed to its real author, and concurrent commenters never clobber each other (writes are serialized per-doc — see Reliability below).
-- **Status sync**: comments carry a resolved-style status that stays in sync between the web view and your agent — `tdoc-agent` stamps each with ✅ applied / 🟡 partial / ❓ needs clarification when it regenerates, so "what's been addressed" is visible to everyone, live, without re-pinging.
+- **Status sync**: comments carry a resolved-style status that stays in sync between the web view and your agent — the acting agent stamps each with ✅ applied / 🟡 partial / ❓ needs clarification when it regenerates, so "what's been addressed" is visible to everyone, live, without re-pinging.
 
 ## Version history
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -339,11 +339,14 @@ silently is the #1 source of regression complaints.
    curl -sS -X POST "https://${WORKER}.workers.dev/api/agent/reply" \
      -H "Authorization: Bearer $TOKEN" \
      -H "Content-Type: application/json" \
-     -d "{\"slug\":\"<slug>\",\"parent_id\":\"<comment_id>\",\"text\":\"<one or two sentences>\",\"status\":\"applied\",\"applied_in\":<n+1>}"
+     -d "{\"slug\":\"<slug>\",\"parent_id\":\"<comment_id>\",\"text\":\"<one or two sentences>\",\"status\":\"applied\",\"applied_in\":<n+1>,\"agent_login\":\"<your-agent-handle>\",\"agent_name\":\"<your display name>\"}"
    ```
 
    **For local-only docs** — POST to `http://localhost:7878/api/agent/reply`
    (no token needed).
+   Always include `agent_login` and `agent_name` so reviewers can tell which
+   agent applied or questioned a comment. Old callers fall back to
+   `tdoc-agent`, but that generic label is only a compatibility fallback.
 
    The reply text should be specific:
    - applied: "Rewrote the second paragraph in English. The section heading

--- a/server/overlay.js
+++ b/server/overlay.js
@@ -487,21 +487,18 @@
   .tdoc-element-outline.pending { border-color: #f0d000; border-width: 2px; background: transparent; }
   .tdoc-element-outline.active { border-color: var(--td-accent); border-width: 2px; box-shadow: 0 0 0 4px var(--td-accent-ring-soft); }
   .tdoc-hover-outline { position: absolute; pointer-events: none; z-index: 999995; border: 2px dashed var(--td-accent); border-radius: 4px; background: var(--td-accent-wash); box-sizing: border-box; transition: opacity .12s; }
-  /* Clickable pill that appears NEXT TO commentable artifacts (img/canvas/svg/video/pre).
+  /* Icon-only button that appears on commentable artifacts (img/canvas/svg/video/pre).
      Positioned just outside the artifact's right edge so it can't obscure
      content. Uses !important on the visible colors to defend against doc-side
      button:hover rules that would otherwise repaint our background. */
-  /* v2 redesign: quiet surface chip (white card + hairline border + neutral
-     shadow, dark label, accent icon); accent fill arrives only on hover. */
   .tdoc-comment-pill {
     position: absolute !important; z-index: 999998 !important;
-    background: #fff !important; color: #1a1a1a !important;
-    font: 600 11.5px system-ui !important;
-    padding: 5px 10px !important;
-    border: 1px solid #e2e2e4 !important; border-radius: 999px !important;
+    width: 30px !important; height: 30px !important; padding: 0 !important;
+    background: rgba(255,255,255,0.96) !important; color: var(--td-accent) !important;
+    border: 1px solid #dedee3 !important; border-radius: 999px !important;
     cursor: pointer !important;
-    box-shadow: 0 1px 2px rgba(0,0,0,0.05), 0 4px 12px rgba(0,0,0,0.08) !important;
-    display: inline-flex !important; align-items: center !important; gap: 6px !important;
+    box-shadow: 0 1px 2px rgba(0,0,0,0.06), 0 3px 10px rgba(0,0,0,0.08) !important;
+    display: inline-flex !important; align-items: center !important; justify-content: center !important;
     transition: transform .12s, background-color .12s, border-color .12s, color .12s, box-shadow .12s !important;
     line-height: 1 !important;
     text-decoration: none !important;
@@ -514,7 +511,7 @@
     box-shadow: 0 2px 4px rgba(0,0,0,0.08), 0 8px 22px var(--td-accent-ring-soft) !important;
   }
   .tdoc-comment-pill:active { background: var(--td-accent-hover) !important; transform: translateY(0) !important; }
-  .tdoc-comment-pill svg { width: 13px !important; height: 13px !important; flex-shrink: 0 !important; stroke: var(--td-accent) !important; }
+  .tdoc-comment-pill svg { width: 14px !important; height: 14px !important; flex-shrink: 0 !important; stroke: currentColor !important; margin: 0 !important; }
   .tdoc-comment-pill:hover svg { stroke: #fff !important; }
   .tdoc-drag-marquee { position: absolute; pointer-events: none; z-index: 999997; border: 1.5px solid var(--td-accent); background: var(--td-accent-wash); box-sizing: border-box; }
 
@@ -1315,9 +1312,9 @@
   function renderAuthor(author) {
     if (!author) return `<div class="author"><span class="anon">anonymous</span></div>`;
     if (author.kind === 'agent') {
-      // Agent identity (currently always 'tdoc-agent'). No avatar URL — use
-      // a generic icon-circle to differentiate from human commenters.
-      return `<div class="author tdoc-agent-author"><span class="tdoc-agent-badge">⚡</span><span class="login">${escapeHtml(author.login || 'tdoc-agent')}</span></div>`;
+      const label = author.name || author.login || 'tdoc-agent';
+      const title = author.login && author.name && author.login !== author.name ? author.login : label;
+      return `<div class="author tdoc-agent-author" title="${escapeHtml(title)}"><span class="tdoc-agent-badge">⚡</span><span class="login">${escapeHtml(label)}</span></div>`;
     }
     const avatar = author.avatar_url ? `<img src="${escapeHtml(author.avatar_url)}" alt="">` : '';
     return `<div class="author">${avatar}<span class="login">${escapeHtml(author.login || 'anonymous')}</span></div>`;
@@ -1329,7 +1326,7 @@
     if (!entries.length) return '';
     const chips = entries.map(([emoji, users]) => {
       const mine = users.includes(me);
-      const hasAgent = users.includes('tdoc-agent');
+      const hasAgent = users.some(u => u === 'tdoc-agent' || /agent|codex|claude/i.test(u));
       const cls = [`tdoc-react-chip`, mine ? 'mine' : '', hasAgent ? 'agent' : ''].filter(Boolean).join(' ');
       return `<span class="${cls}" data-emoji="${escapeHtml(emoji)}" data-target-id="${escapeHtml(target.id)}" data-users="${users.map(escapeHtml).join('\n')}">${escapeHtml(emoji)} ${users.length}</span>`;
     }).join('');
@@ -1377,8 +1374,9 @@
     // and expand its replies so the agent's resolution is visible, not buried.
     const isResolved = comment.status === 'applied';
     const verdict = comment._agentVerdict || 'applied';
+    const resolvedBy = comment._agentActor || comment.agent_actor || 'tdoc-agent';
     const resolvedChip = isResolved
-      ? `<span class="tdoc-resolved-chip" title="Resolved by tdoc-agent${comment.applied_in ? ' in v' + escapeHtml(String(comment.applied_in)) : ''}">✓ ${
+      ? `<span class="tdoc-resolved-chip" title="Resolved by ${escapeHtml(resolvedBy)}${comment.applied_in ? ' in v' + escapeHtml(String(comment.applied_in)) : ''}">✓ ${
           verdict === 'partial' ? 'partially fixed' : verdict === 'question' ? 'needs input' : 'fixed'
         }${comment.applied_in ? ' · v' + escapeHtml(String(comment.applied_in)) : ''}</span>`
       : '';
@@ -3071,10 +3069,10 @@
     commentPill.type = 'button';
     commentPill.setAttribute('aria-label', 'Comment on this section');
     commentPill.title = 'Comment on this section';
-    commentPill.innerHTML = `<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"/></svg>Comment`;
+    commentPill.innerHTML = `<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"/></svg>`;
     // Top-right corner of the SECTION, so it visually belongs to the whole
     // artifact regardless of where inside it the cursor is.
-    const pillW = 110;
+    const pillW = 30;
     commentPill.style.top = (window.scrollY + r.top + 8) + 'px';
     commentPill.style.left = (window.scrollX + Math.max(r.left + 8, r.right - pillW - 8)) + 'px';
     commentPill.onclick = (e) => {

--- a/server/server.js
+++ b/server/server.js
@@ -70,27 +70,43 @@ function isLocalMutation(req) {
 
 // Escape `</script>` and HTML comment terminators so a malicious or stray value
 // inside the JSON payload can't break out of the surrounding <script> block.
-// Replace `tdoc-agent`'s reaction on a comment with the emoji for the new
-// status. Removes any existing tdoc-agent reactions first so old state
+// Replace the acting agent's reaction on a comment with the emoji for the new
+// status. Also removes legacy `tdoc-agent` reactions first so old state
 // can't outlive the new outcome (e.g. an "applied" ✅ after a later
 // "question" outcome on the same comment).
 const AGENT_STATUS_EMOJI = { applied: '✅', partial: '🟡', question: '❓' };
 // The emoji set the agent uses as a verdict marker — used by the per-version
 // fold to strip a stale verdict off snapshots where the comment reads 'open'.
 const AGENT_VERDICT_EMOJI = new Set(Object.values(AGENT_STATUS_EMOJI));
-function setAgentReaction(target, status) {
+function agentIdentity(body = {}) {
+  const fallbackLogin = process.env.TDOC_AGENT_LOGIN || process.env.USER || 'tdoc-agent';
+  const fallbackName = process.env.TDOC_AGENT_NAME || fallbackLogin;
+  const clean = (v, fallback) => {
+    if (typeof v !== 'string') return fallback;
+    const s = v.trim().slice(0, 80);
+    return s || fallback;
+  };
+  const avatar = typeof body.agent_avatar_url === 'string' && /^https:\/\/[^ \n\r\t]+$/i.test(body.agent_avatar_url)
+    ? body.agent_avatar_url
+    : null;
+  const login = clean(body.agent_login || body.agent_id, fallbackLogin);
+  return { kind: 'agent', login, name: clean(body.agent_name, fallbackName), avatar_url: avatar };
+}
+function setAgentReaction(target, status, actor = 'tdoc-agent') {
   if (!target.reactions) target.reactions = {};
+  const agentUsers = new Set(['tdoc-agent', actor].filter(Boolean));
   for (const emoji of Object.keys(target.reactions)) {
     const users = target.reactions[emoji] || [];
-    const idx = users.indexOf('tdoc-agent');
-    if (idx >= 0) users.splice(idx, 1);
+    for (let i = users.length - 1; i >= 0; i--) {
+      if (agentUsers.has(users[i])) users.splice(i, 1);
+    }
     if (users.length === 0) delete target.reactions[emoji];
     else target.reactions[emoji] = users;
   }
   const next = AGENT_STATUS_EMOJI[status];
   if (!next) return;
   const u = target.reactions[next] || [];
-  if (!u.includes('tdoc-agent')) u.push('tdoc-agent');
+  if (!u.includes(actor)) u.push(actor);
   target.reactions[next] = u;
 }
 
@@ -149,12 +165,13 @@ function foldCommentsAtVersion(comments, version) {
     // would carry the CURRENT reactions — including the agent verdict emoji
     // (✅/🟡/❓ written by setAgentReaction) — onto every past snapshot. On a
     // version where the comment folds to 'open' that's a contradictory
-    // "resolved" emoji, so drop the tdoc-agent verdict there.
+    // "resolved" emoji, so drop the agent verdict there.
     let reactions = c.reactions;
     if (!resolvedByV && reactions) {
       const filtered = {};
       for (const [emoji, users] of Object.entries(reactions)) {
-        const rest = Array.isArray(users) ? users.filter(u => !(u === 'tdoc-agent' && AGENT_VERDICT_EMOJI.has(emoji))) : users;
+        const agentActor = c.agent_actor || 'tdoc-agent';
+        const rest = Array.isArray(users) ? users.filter(u => !((u === 'tdoc-agent' || u === agentActor) && AGENT_VERDICT_EMOJI.has(emoji))) : users;
         if (rest && rest.length) filtered[emoji] = rest;
       }
       reactions = filtered;
@@ -283,7 +300,7 @@ const server = http.createServer(async (req, res) => {
     return json(res, 200, entry);
   }
 
-  // Agent reply: posts a reply attributed to `tdoc-agent`, updates the
+  // Agent reply: posts a reply attributed to the acting agent, updates the
   // parent comment's status, AND drops a status emoji on the parent's
   // reactions row. Each status maps to a different emoji so the user can
   // tell at a glance from the comment list which were addressed:
@@ -303,6 +320,8 @@ const server = http.createServer(async (req, res) => {
     const parent = all.find(c => c.id === parent_id);
     if (!parent) return json(res, 404, { error: 'parent_not_found' });
     if (!Array.isArray(parent.replies)) parent.replies = [];
+    const agent = agentIdentity(body);
+    parent.agent_actor = agent.login;
     const reply = {
       id: `r_${Date.now()}`,
       parent_id,
@@ -310,7 +329,7 @@ const server = http.createServer(async (req, res) => {
       // Scope the agent reply to the version it was applied at (falls back to
       // the request version, then 1) so the fold can hide it on earlier ones.
       version: Number(applied_in != null ? applied_in : body.version) || 1,
-      author: { kind: 'agent', login: 'tdoc-agent', name: 'tdoc-agent', avatar_url: null },
+      author: agent,
       agent_status: ['applied', 'partial', 'question'].includes(agentStatus) ? agentStatus : null,
       created: new Date().toISOString(),
       reactions: {},
@@ -322,7 +341,7 @@ const server = http.createServer(async (req, res) => {
     } else if (agentStatus === 'question' || agentStatus === 'partial') {
       parent.status = 'open';
     }
-    setAgentReaction(parent, agentStatus);
+    setAgentReaction(parent, agentStatus, agent.login);
     writeJson(file, all);
     return json(res, 200, reply);
   }
@@ -345,7 +364,8 @@ const server = http.createServer(async (req, res) => {
     target.anchor = anchor;
     target.status = 'open';
     delete target.applied_in;
-    setAgentReaction(target, null);
+    setAgentReaction(target, null, target.agent_actor || 'tdoc-agent');
+    delete target.agent_actor;
     writeJson(file, all);
     return json(res, 200, target);
   }

--- a/skills/tdoc/SKILL.md
+++ b/skills/tdoc/SKILL.md
@@ -339,11 +339,14 @@ silently is the #1 source of regression complaints.
    curl -sS -X POST "https://${WORKER}.workers.dev/api/agent/reply" \
      -H "Authorization: Bearer $TOKEN" \
      -H "Content-Type: application/json" \
-     -d "{\"slug\":\"<slug>\",\"parent_id\":\"<comment_id>\",\"text\":\"<one or two sentences>\",\"status\":\"applied\",\"applied_in\":<n+1>}"
+     -d "{\"slug\":\"<slug>\",\"parent_id\":\"<comment_id>\",\"text\":\"<one or two sentences>\",\"status\":\"applied\",\"applied_in\":<n+1>,\"agent_login\":\"<your-agent-handle>\",\"agent_name\":\"<your display name>\"}"
    ```
 
    **For local-only docs** — POST to `http://localhost:7878/api/agent/reply`
    (no token needed).
+   Always include `agent_login` and `agent_name` so reviewers can tell which
+   agent applied or questioned a comment. Old callers fall back to
+   `tdoc-agent`, but that generic label is only a compatibility fallback.
 
    The reply text should be specific:
    - applied: "Rewrote the second paragraph in English. The section heading

--- a/test/api.test.js
+++ b/test/api.test.js
@@ -123,12 +123,31 @@ function waitReady(port, ms = 5000) {
     if (!r.body.reactions['🔥']) throw new Error('reaction not stored on reply');
   });
 
+  await t('POST /api/agent/reply preserves agent identity', async () => {
+    const r = await req('POST', '/api/agent/reply', {
+      slug: SLUG,
+      parent_id: topId,
+      text: 'Applied the requested edit.',
+      status: 'applied',
+      applied_in: 2,
+      agent_login: 'codex-pm',
+      agent_name: 'Codex PM',
+    });
+    if (r.status !== 200) throw new Error(`status ${r.status}: ${JSON.stringify(r.body)}`);
+    if (r.body.author?.login !== 'codex-pm') throw new Error(`wrong agent login ${r.body.author?.login}`);
+    if (r.body.author?.name !== 'Codex PM') throw new Error(`wrong agent name ${r.body.author?.name}`);
+    const after = await req('GET', `/api/comments?slug=${SLUG}`);
+    const c = after.body[0];
+    if (c.agent_actor !== 'codex-pm') throw new Error(`wrong parent agent_actor ${c.agent_actor}`);
+    if (!c.reactions['✅']?.includes('codex-pm')) throw new Error('agent verdict reaction did not use agent login');
+  });
+
   await t('DELETE /api/comments?id=<reply-id> removes the reply, leaves top', async () => {
     const r = await req('DELETE', `/api/comments?slug=${SLUG}&id=${replyId}`);
     if (r.status !== 200) throw new Error(`status ${r.status}: ${JSON.stringify(r.body)}`);
     const after = await req('GET', `/api/comments?slug=${SLUG}`);
     if (after.body.length !== 1) throw new Error('top comment was removed');
-    if (after.body[0].replies.length !== 0) throw new Error('reply not removed');
+    if (after.body[0].replies.some(r => r.id === replyId)) throw new Error('reply not removed');
   });
 
   await t('DELETE /api/comments?id=<top-id> removes the top comment', async () => {

--- a/worker/worker.js
+++ b/worker/worker.js
@@ -76,6 +76,20 @@ function canMutate(record, session, env) {
   const who = record && record.author && record.author.login;
   return !!(who && session && session.login && who === session.login);
 }
+function agentIdentity(body = {}, env = {}) {
+  const fallbackLogin = env.TDOC_AGENT_LOGIN || 'tdoc-agent';
+  const fallbackName = env.TDOC_AGENT_NAME || fallbackLogin;
+  const clean = (v, fallback) => {
+    if (typeof v !== 'string') return fallback;
+    const s = v.trim().slice(0, 80);
+    return s || fallback;
+  };
+  const avatar = typeof body.agent_avatar_url === 'string' && /^https:\/\/[^ \n\r\t]+$/i.test(body.agent_avatar_url)
+    ? body.agent_avatar_url
+    : null;
+  const login = clean(body.agent_login || body.agent_id, fallbackLogin);
+  return { kind: 'agent', login, name: clean(body.agent_name, fallbackName), avatar_url: avatar };
+}
 function rand(n) {
   const a = new Uint8Array(n);
   crypto.getRandomValues(a);
@@ -878,11 +892,13 @@ function snapshotAt(c, V) {
         snap.status = 'applied';
         snap.applied_in = e.applied_in || e.at_version;
         snap._agentVerdict = e.agent_status || 'applied';
+        snap._agentActor = e.by || 'tdoc-agent';
         break;
       case 'marked_open':
         snap.status = 'open';
         snap.applied_in = undefined;
         snap._agentVerdict = e.agent_status || null;
+        snap._agentActor = e.by || 'tdoc-agent';
         break;
       case 'deleted':
         snap.deleted = true;
@@ -950,8 +966,9 @@ function snapshotAt(c, V) {
   // parent card) matches today without storing it as a real reaction event.
   if (snap._agentVerdict && AGENT_STATUS_EMOJI[snap._agentVerdict]) {
     const emoji = AGENT_STATUS_EMOJI[snap._agentVerdict];
+    const actor = snap._agentActor || 'tdoc-agent';
     const u = snap.reactions[emoji] || [];
-    if (!u.includes('tdoc-agent')) u.push('tdoc-agent');
+    if (!u.includes(actor)) u.push(actor);
     snap.reactions[emoji] = u;
   }
   delete snap._agentVerdict;
@@ -1856,7 +1873,8 @@ export default {
     // ---- agent reply (from `tdoc edit` after applying a comment) ----
     // Authenticated with the same upload token as /api/upload — only the doc
     // owner's machine has it, so this can't be spoofed by readers. Posts a
-    // reply on the parent comment, attributed to the `tdoc-agent` identity.
+    // reply on the parent comment, attributed to the supplied agent identity
+    // with `tdoc-agent` kept as the compatibility fallback.
     // status values: 'applied', 'partial', 'question'. The status appears as
     // a visible badge on the reply and also flips the parent comment's
     // status to 'applied' / 'open' so the dashboard reflects it.
@@ -1878,31 +1896,32 @@ export default {
       if (!parent) return json({ error: 'parent_not_found' }, { status: 404 });
 
       const verdict = ['applied', 'partial', 'question'].includes(agentStatus) ? agentStatus : null;
+      const agent = agentIdentity(body, env);
       const V = coerceBodyVersion(applied_in, parent.created_in || 1);
       const now = new Date().toISOString();
       const replyId = `r_${Date.now()}_${rand(4)}`;
 
       const events = [{
         kind: 'reply_added', at_version: V, at: now,
-        reply: { id: replyId, author: { kind: 'agent', login: 'tdoc-agent', name: 'tdoc-agent', avatar_url: null }, text: replyText, agent_status: verdict },
+        reply: { id: replyId, author: agent, text: replyText, agent_status: verdict },
       }];
       if (verdict === 'applied') {
-        events.push({ kind: 'marked_applied', at_version: V, at: now, applied_in: V, by: 'tdoc-agent', agent_status: 'applied' });
+        events.push({ kind: 'marked_applied', at_version: V, at: now, applied_in: V, by: agent.login, agent_status: 'applied' });
       } else if (verdict === 'partial' || verdict === 'question') {
-        events.push({ kind: 'marked_open', at_version: V, at: now, by: 'tdoc-agent', agent_status: verdict });
+        events.push({ kind: 'marked_open', at_version: V, at: now, by: agent.login, agent_status: verdict });
       }
       if (bind_anchor_aid && typeof bind_anchor_aid === 'string') {
         const cur = snapshotAt(parent, V) || {};
         const fallback = cur.anchor?.fallback;
         const label = cur.anchor?.label || 'svg';
         events.push({
-          kind: 'anchor_changed', at_version: V, at: now, by: 'tdoc-agent', reset_status: false,
+          kind: 'anchor_changed', at_version: V, at: now, by: agent.login, reset_status: false,
           anchor: { kind: 'element', aid: bind_anchor_aid, selector: `[data-tdoc-aid="${bind_anchor_aid}"]`, label, ...(fallback ? { fallback } : {}) },
         });
       }
       const res = await mutateComments(env, slug, {
         kind: 'raw_events', slug, id: parent_id, events,
-        responseBody: { id: replyId, parent_id, text: replyText, author: { kind: 'agent', login: 'tdoc-agent', name: 'tdoc-agent', avatar_url: null }, agent_status: verdict, created: now, reactions: {} },
+        responseBody: { id: replyId, parent_id, text: replyText, author: agent, agent_status: verdict, created: now, reactions: {} },
       });
       return json(res.body, { status: res.status });
     }


### PR DESCRIPTION
## Summary
- replace the large artifact Comment pill with a compact icon-only affordance
- preserve caller-provided agent identity on /api/agent/reply in local server and worker
- update docs/skill guidance so agents pass agent_login and agent_name

## Verification
- node --check server/overlay.js && node --check server/server.js && node --input-type=module --check < worker/worker.js
- node test/overlay-pure.test.js && node test/pins-layout.test.js && node test/api.test.js && node test/responsive.test.js
- TDOC_TEST_URL=http://127.0.0.1:7993/d/sample-doc/v/2 AUDIT_START=800 AUDIT_END=1600 AUDIT_STEP=100 node test/dimensions-audit.js