### PR TITLE
Require explicit GitHub OAuth client for published auth

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -420,8 +420,10 @@ when `server/overlay.js` or `worker/worker.js` is newer than the bundled file
 and redeploys the Worker automatically so users get the latest overlay code.
 Set `TDOC_SKIP_WORKER_DEPLOY=1` to skip the redeploy (useful for batch uploads).
 
-On published docs, viewers sign in with GitHub (Device Flow, shared OAuth App
-`Ov23liZ1UAGOchvKPmlS`, scope `read:user`) before commenting.
+On published docs, viewers sign in with GitHub (Device Flow, scope
+`read:user`) before commenting. The deployment must configure an org-owned
+`GITHUB_CLIENT_ID`; if it is unset, published-doc sign-in is disabled rather
+than falling back to a personal OAuth app.
 
 Requires `jq`, plus `wrangler` (`npm i -g wrangler`) for the Cloudflare
 target or `vercel` (`npm i -g vercel`) for the Vercel target.
@@ -485,8 +487,9 @@ installed, or might be partway through. You **must** drive the flow from
 - ALWAYS show the user what you're running. Print the JSON status if helpful.
 - If a "click" step doesn't take effect after the user says "done", offer to
   re-check after waiting 10s (Cloudflare API can be slow to reflect changes).
-- The shared OAuth App client ID (`Ov23liZ1UAGOchvKPmlS`) is already baked
-  into the Worker — users do NOT register their own.
+- GitHub sign-in requires an org-owned OAuth App client ID in
+  `GITHUB_CLIENT_ID`. If it is unset, sign-in is disabled; do not point users
+  at a personal/deprecated OAuth app.
 
 ### `/tdoc update` — check for updates and pull the latest
 

--- a/skills/tdoc/SKILL.md
+++ b/skills/tdoc/SKILL.md
@@ -420,8 +420,10 @@ when `server/overlay.js` or `worker/worker.js` is newer than the bundled file
 and redeploys the Worker automatically so users get the latest overlay code.
 Set `TDOC_SKIP_WORKER_DEPLOY=1` to skip the redeploy (useful for batch uploads).
 
-On published docs, viewers sign in with GitHub (Device Flow, shared OAuth App
-`Ov23liZ1UAGOchvKPmlS`, scope `read:user`) before commenting.
+On published docs, viewers sign in with GitHub (Device Flow, scope
+`read:user`) before commenting. The deployment must configure an org-owned
+`GITHUB_CLIENT_ID`; if it is unset, published-doc sign-in is disabled rather
+than falling back to a personal OAuth app.
 
 Requires `jq`, plus `wrangler` (`npm i -g wrangler`) for the Cloudflare
 target or `vercel` (`npm i -g vercel`) for the Vercel target.
@@ -485,8 +487,9 @@ installed, or might be partway through. You **must** drive the flow from
 - ALWAYS show the user what you're running. Print the JSON status if helpful.
 - If a "click" step doesn't take effect after the user says "done", offer to
   re-check after waiting 10s (Cloudflare API can be slow to reflect changes).
-- The shared OAuth App client ID (`Ov23liZ1UAGOchvKPmlS`) is already baked
-  into the Worker — users do NOT register their own.
+- GitHub sign-in requires an org-owned OAuth App client ID in
+  `GITHUB_CLIENT_ID`. If it is unset, sign-in is disabled; do not point users
+  at a personal/deprecated OAuth app.
 
 ### `/tdoc update` — check for updates and pull the latest
 

--- a/test/auth-config.test.js
+++ b/test/auth-config.test.js
@@ -1,0 +1,66 @@
+// Auth configuration guardrails.
+//
+// GitHub's Device Flow authorization screen shows the OAuth App owner/name.
+// This test prevents tdoc from silently falling back to a deprecated personal
+// app client ID after the project has moved under tornado-doc.
+
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+
+let pass = 0, fail = 0;
+function ok(n) { console.log(`  ✓ ${n}`); pass++; }
+function bad(n, e) { console.log(`  ✗ ${n}\n    ${e.message}`); fail++; }
+function t(n, fn) { try { fn(); ok(n); } catch (e) { bad(n, e); } }
+function assert(c, m) { if (!c) throw new Error(m || 'assertion failed'); }
+
+function sliceFn(src, name) {
+  const start = src.indexOf(`function ${name}(`);
+  if (start === -1) throw new Error(`function ${name} not found`);
+  let i = src.indexOf('{', start), depth = 0;
+  for (; i < src.length; i++) {
+    if (src[i] === '{') depth++;
+    else if (src[i] === '}') {
+      depth--;
+      if (depth === 0) { i++; break; }
+    }
+  }
+  return src.slice(start, i);
+}
+
+const root = path.join(__dirname, '..');
+const workerSrc = fs.readFileSync(path.join(root, 'worker', 'worker.js'), 'utf8');
+const vercelSrc = fs.readFileSync(path.join(root, 'vercel', 'api', 'tdoc.js'), 'utf8');
+const wranglerTemplate = fs.readFileSync(path.join(root, 'worker', 'wrangler.toml.template'), 'utf8');
+
+const oldClientId = 'Ov23liZ1UAGOchvKPmlS';
+
+const box = {};
+vm.createContext(box);
+vm.runInContext([
+  sliceFn(workerSrc, 'githubClientId'),
+  sliceFn(workerSrc, 'hasGitHubAuth'),
+].join('\n\n'), box);
+
+console.log('auth config');
+
+t('worker treats missing/blank GITHUB_CLIENT_ID as auth disabled', () => {
+  assert(box.githubClientId({}) === '');
+  assert(box.githubClientId({ GITHUB_CLIENT_ID: '   ' }) === '');
+  assert(box.hasGitHubAuth({}) === false);
+  assert(box.hasGitHubAuth({ GITHUB_CLIENT_ID: '   ' }) === false);
+});
+
+t('worker accepts an explicitly configured GitHub OAuth client id', () => {
+  assert(box.githubClientId({ GITHUB_CLIENT_ID: 'abc123' }) === 'abc123');
+  assert(box.hasGitHubAuth({ GITHUB_CLIENT_ID: 'abc123' }) === true);
+});
+
+t('deprecated personal OAuth client id is not baked into worker/vercel/template', () => {
+  assert(!workerSrc.includes(oldClientId), 'old client id is still in worker.js');
+  assert(!vercelSrc.includes(oldClientId), 'old client id is still in Vercel shim');
+  assert(!wranglerTemplate.includes(oldClientId), 'old client id is still in wrangler template');
+});
+
+console.log(`\n${pass} passed, ${fail} failed`);
+process.exit(fail ? 1 : 0);

--- a/test/run.js
+++ b/test/run.js
@@ -20,6 +20,7 @@ const OFFLINE = [
   'event-convergence.test.js',// eid dedup convergence + fold ordering
   'reconcile.test.js',        // anchor reconcile branches + compaction
   'security.test.js',         // injection / authz / CSRF / path-traversal
+  'auth-config.test.js',      // GitHub OAuth app must be explicit, no old fallback
   'oldver-strip.test.js',     // old-version banner predicate
   'cli.test.js',              // CLI resilience (drives bash hermetically)
   'no-drift.test.js',         // duplicated-helper drift guard

--- a/vercel/api/tdoc.js
+++ b/vercel/api/tdoc.js
@@ -59,9 +59,10 @@ async function buildEnv() {
       META: createKvStore({ url: kvUrl, token: kvToken }),
       TDOC_UPLOAD_TOKEN: process.env.TDOC_UPLOAD_TOKEN,
       TDOC_OWNER: process.env.TDOC_OWNER || '',
-      // Same public GitHub Device Flow app the wrangler template ships —
-      // device flow has no redirect URI, so it works from any host.
-      GITHUB_CLIENT_ID: process.env.GITHUB_CLIENT_ID || 'Ov23liZ1UAGOchvKPmlS',
+      // GitHub Device Flow app for published-doc comments. The OAuth app
+      // identity is user-visible on GitHub's authorization screen, so do not
+      // silently fall back to a personal/deprecated app.
+      GITHUB_CLIENT_ID: process.env.GITHUB_CLIENT_ID || '',
       TDOC_DEBUG: process.env.TDOC_DEBUG || '',
     },
   };

--- a/worker/worker.js
+++ b/worker/worker.js
@@ -4,7 +4,7 @@
 //   DOCS   — R2 bucket (key: docs/<slug>/v<N>/index.html)
 //   META   — KV namespace
 // Vars:
-//   GITHUB_CLIENT_ID — hardcoded "Ov23liZ1UAGOchvKPmlS"
+//   GITHUB_CLIENT_ID — GitHub OAuth App client ID for Device Flow auth.
 // Secrets:
 //   TDOC_UPLOAD_TOKEN — shared secret for /api/upload from `tdoc publish`
 //
@@ -624,15 +624,23 @@ function injectOverlayCfg(rawHtml, cfg) {
   return rawHtml + inject;
 }
 
-function injectOverlay(rawHtml, slug, version, identity, versions, isOwner) {
+function injectOverlay(rawHtml, slug, version, identity, versions, isOwner, authConfigured) {
   return injectOverlayCfg(rawHtml, {
     slug, version,
     identity: identity || null,
     isOwner: !!isOwner,
-    authConfigured: true,
+    authConfigured: !!authConfigured,
     mode: 'published',
     versions: Array.isArray(versions) && versions.length ? versions : [{ n: version }],
   });
+}
+
+function githubClientId(env) {
+  return String(env?.GITHUB_CLIENT_ID || '').trim();
+}
+
+function hasGitHubAuth(env) {
+  return githubClientId(env).length > 0;
 }
 
 // Neutral landing page served at `/`. No catalog, no slug list — just
@@ -1527,7 +1535,7 @@ export default {
           if (Array.isArray(meta.versions)) versions = meta.versions.map(v => ({ n: v.n, created: v.created || null }));
         }
       } catch {}
-      return html(injectOverlay(raw, slug, Number(vStr), identity, versions, isOwnerSession(env, session)));
+      return html(injectOverlay(raw, slug, Number(vStr), identity, versions, isOwnerSession(env, session), hasGitHubAuth(env)));
     }
 
     // ---- doc export / fork ----
@@ -1646,14 +1654,18 @@ export default {
       return json({
         identity: s ? { login: s.login, avatar_url: s.avatar_url, name: s.name } : null,
         isOwner: isOwnerSession(env, s),
-        authConfigured: true,
+        authConfigured: hasGitHubAuth(env),
       });
     }
 
     if (p === '/api/auth/device/start' && method === 'POST') {
+      const clientId = githubClientId(env);
+      if (!clientId) {
+        return json({ error: 'auth_not_configured', message: 'GitHub OAuth is not configured for this tdoc deployment.' }, { status: 503 });
+      }
       try {
         const r = await ghPost('/login/device/code', {
-          client_id: env.GITHUB_CLIENT_ID,
+          client_id: clientId,
           scope: 'read:user',
         });
         if (r.error) return json({ error: r.error, message: r.error_description }, { status: 400 });
@@ -1670,12 +1682,16 @@ export default {
     }
 
     if (p === '/api/auth/device/poll' && method === 'POST') {
+      const clientId = githubClientId(env);
+      if (!clientId) {
+        return json({ error: 'auth_not_configured', message: 'GitHub OAuth is not configured for this tdoc deployment.' }, { status: 503 });
+      }
       let body = {};
       try { body = await req.json(); } catch {}
       if (!body.device_code) return json({ error: 'device_code required' }, { status: 400 });
       try {
         const r = await ghPost('/login/oauth/access_token', {
-          client_id: env.GITHUB_CLIENT_ID,
+          client_id: clientId,
           device_code: body.device_code,
           grant_type: 'urn:ietf:params:oauth:grant-type:device_code',
         });

--- a/worker/wrangler.toml.template
+++ b/worker/wrangler.toml.template
@@ -26,7 +26,10 @@ tag = "v1-comments-do"
 new_sqlite_classes = ["CommentsStore"]
 
 [vars]
-GITHUB_CLIENT_ID = "Ov23liZ1UAGOchvKPmlS"
+# GitHub OAuth App client ID for Device Flow auth. The OAuth app identity is
+# user-visible on GitHub's authorization screen, so configure an org-owned app
+# for hosted/share rollout. Leave empty to disable published-doc sign-in.
+GITHUB_CLIENT_ID = ""
 # The worker owner's GitHub login. Only this signed-in viewer sees the
 # "My docs" catalog (profile chip → My docs). Empty = catalog stays fully
 # private (no one can enumerate docs; they're reachable only by direct link).


### PR DESCRIPTION
## Summary
- remove the deprecated/personal GitHub OAuth client ID as a Worker/Vercel fallback
- disable published-doc auth when GITHUB_CLIENT_ID is unset instead of sending users to the old OAuth app
- update wrangler template and tdoc skill docs to require an org-owned OAuth app client ID
- add an offline regression test so the old client ID cannot be reintroduced into runtime config

## Validation
- node test/auth-config.test.js
- node test/vercel-shim.test.js
- node test/security.test.js
- git diff --check
- node test/run.js: 17/18 suites green; existing coverage.test.js bundle syntax check fails under local Node 18 because worker bundle contains export class CommentsStore parsed as CommonJS

## Rollout note
This PR prevents future deploys from silently using the old Serena/keyitan OAuth app. The live GitHub authorization screen will show tornado-doc only after an org-owned GitHub OAuth app is created/configured and its client ID is set as GITHUB_CLIENT_ID in the deployment environment.