### PR TITLE
Delete doc: CLI + local index button (JUL-35)

### DIFF
--- a/bin/tdoc-delete
+++ b/bin/tdoc-delete
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+# tdoc-delete — delete a doc: the local copy (~/tdocs/<slug>) and, if it was
+# published, the published copy too (all versions + comments, via
+# tdoc-unpublish). The one command behind the "Delete" button.
+#
+# Usage: tdoc-delete <slug> [--local-only|--published-only]
+set -euo pipefail
+
+SLUG="${1:-}"
+MODE="${2:-}"
+if [ -z "$SLUG" ]; then echo "usage: tdoc-delete <slug> [--local-only|--published-only]" >&2; exit 1; fi
+# Same kebab-case rule as tdoc-new/tdoc-unpublish; keeps $SLUG shell/URL-safe
+# and, critically here, safe to splice into an rm -rf path.
+if ! printf '%s' "$SLUG" | grep -Eq '^[a-z0-9]([a-z0-9-]*[a-z0-9])?$'; then
+  echo "[tdoc] invalid slug '$SLUG' — must be lowercase kebab-case (a-z, 0-9, -)." >&2
+  exit 1
+fi
+
+TDOC_DIR="${TDOC_DIR:-$HOME/tdocs}"
+LOCAL_DIR="$TDOC_DIR/$SLUG"
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+deleted_something=0
+
+if [ "$MODE" != "--local-only" ]; then
+  # Best-effort: only try the network delete when a publish config exists.
+  if [ -f "$HOME/.tdoc/published.json" ]; then
+    if "$SCRIPT_DIR/tdoc-unpublish" "$SLUG"; then
+      deleted_something=1
+    else
+      # A doc that was never published 404s here — that's fine when we're
+      # also deleting locally, fatal when --published-only was requested.
+      if [ "$MODE" = "--published-only" ]; then exit 1; fi
+      echo "[tdoc] published copy not removed (may never have been published) — continuing with local delete." >&2
+    fi
+  elif [ "$MODE" = "--published-only" ]; then
+    echo "no ~/.tdoc/published.json — nothing published to delete." >&2
+    exit 1
+  fi
+fi
+
+if [ "$MODE" != "--published-only" ]; then
+  if [ -d "$LOCAL_DIR" ]; then
+    rm -rf "$LOCAL_DIR"
+    echo "Deleted local $LOCAL_DIR."
+    deleted_something=1
+  else
+    echo "[tdoc] no local copy at $LOCAL_DIR." >&2
+  fi
+fi
+
+if [ "$deleted_something" = "0" ]; then
+  echo "[tdoc] nothing deleted for '$SLUG'." >&2
+  exit 1
+fi

--- a/server/server.js
+++ b/server/server.js
@@ -208,6 +208,7 @@ function indexPage() {
       <td>${escHtml(slug)}</td>
       <td>v${latest}</td>
       <td>${open ? `<b>${open} open</b>` : '—'}</td>
+      <td><button class="del" data-slug="${escHtml(slug)}" data-versions="${latest}" data-comments="${comments.length}">Delete</button></td>
     </tr>`;
   }).join('');
   return `<!doctype html><html><head><meta charset="utf-8"><title>tdoc</title>
@@ -221,10 +222,27 @@ function indexPage() {
   a { color: #1652f0; text-decoration: none; }
   a:hover { text-decoration: underline; }
   .empty { color: #888; padding: 40px 0; text-align: center; }
+  .del { font: 12px system-ui; color: #a52323; background: none; border: 1px solid #e0c9c9; border-radius: 6px; padding: 3px 9px; cursor: pointer; }
+  .del:hover { background: #a52323; color: #fff; border-color: #a52323; }
 </style></head><body>
 <h1>tdoc</h1><p class="sub">Prompt-native documents.</p>
 ${slugs.length === 0 ? '<p class="empty">No docs yet. Try <code>/tdoc new &lt;prompt&gt;</code>.</p>' :
-  `<table><thead><tr><th>Title</th><th>Slug</th><th>Version</th><th>Comments</th></tr></thead><tbody>${rows}</tbody></table>`}
+  `<table><thead><tr><th>Title</th><th>Slug</th><th>Version</th><th>Comments</th><th></th></tr></thead><tbody>${rows}</tbody></table>`}
+<script>
+document.addEventListener('click', async (e) => {
+  const b = e.target.closest('.del');
+  if (!b) return;
+  const slug = b.dataset.slug;
+  // Irreversible: name exactly what disappears before acting.
+  const msg = 'Delete "' + slug + '"?\n\nThis permanently removes ' + b.dataset.versions +
+    ' version(s) and ' + b.dataset.comments + ' comment(s) — the local copy AND the published copy (if any). No undo.';
+  if (!confirm(msg)) return;
+  b.disabled = true; b.textContent = 'Deleting…';
+  const r = await fetch('/api/delete', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ slug }) });
+  if (r.ok) { b.closest('tr').remove(); }
+  else { const d = await r.json().catch(() => ({})); alert('Delete failed: ' + (d.error || r.status)); b.disabled = false; b.textContent = 'Delete'; }
+});
+</script>
 </body></html>`;
 }
 
@@ -438,6 +456,34 @@ const server = http.createServer(async (req, res) => {
   // first run); the browser modal shows a "this can take a minute" hint.
   // Honor TDOC_DRY_PUBLISH=1 for tests — echoes "would publish <slug>" and
   // returns a fake URL without invoking wrangler.
+  if (p === '/api/delete' && req.method === 'POST') {
+    if (!isLocalMutation(req)) return json(res, 403, { error: 'forbidden' });
+    const body = await readBody(req);
+    const slug = safeSlug(body.slug);
+    if (!slug) return json(res, 400, { error: 'invalid slug' });
+    if (!fs.existsSync(path.join(ROOT, slug))) return json(res, 404, { error: 'not found' });
+    const bin = path.join(__dirname, '..', 'bin', 'tdoc-delete');
+    if (!fs.existsSync(bin)) return json(res, 500, { error: 'tdoc-delete script not found' });
+    // Same spawn hardening as /api/publish: error listener, hard timeout,
+    // bounded output. Deleting is quick; 60s covers a slow unpublish curl.
+    const args = body.published === false ? [slug, '--local-only'] : [slug];
+    const proc = spawn(bin, args, { env: process.env });
+    let out = '', err = '', settled = false, killed = false;
+    const CAP = 64 * 1024;
+    const append = (buf, d) => (buf.length < CAP ? buf + d : buf);
+    const settle = (status, obj) => { if (settled) return; settled = true; clearTimeout(timer); json(res, status, obj); };
+    const timer = setTimeout(() => { killed = true; proc.kill('SIGTERM'); setTimeout(() => proc.kill('SIGKILL'), 3000); }, 60000);
+    proc.on('error', (e) => settle(500, { error: 'delete_spawn_failed', detail: String(e && e.message || e) }));
+    proc.stdout.on('data', d => { out = append(out, d); });
+    proc.stderr.on('data', d => { err = append(err, d); });
+    proc.on('close', (code) => {
+      if (killed) return settle(504, { error: 'delete_timeout', stdout: out, stderr: err });
+      if (code !== 0) return settle(500, { error: 'delete_failed', code, stdout: out, stderr: err });
+      settle(200, { ok: true, stdout: out });
+    });
+    return;
+  }
+
   if (p === '/api/publish' && req.method === 'POST') {
     if (!isLocalMutation(req)) return json(res, 403, { error: 'forbidden' });
     const body = await readBody(req);


### PR DESCRIPTION
Linear JUL-35 — julie: "现在好像没有 delete 文档功能 🤣"

The delete backend existed (worker `DELETE /api/doc`, `tdoc-unpublish`) but had no user-facing entry.

- **`bin/tdoc-delete <slug> [--local-only|--published-only]`** — one command: removes `~/tdocs/<slug>` and, if a publish config exists, the published copy (all versions + comments). Kebab-case slug validation before anything touches `rm -rf`.
- **`POST /api/delete`** on the local server — origin/CSRF-gated like `/api/publish`, same spawn hardening (error listener, 60s SIGTERM→SIGKILL, bounded output).
- **Delete button** on the local index page with a confirm dialog that names exactly what disappears (N versions, M comments, local + published copies; no undo).

Out of scope (noted in ticket): an "Unpublish" control on *published* pages — the worker delete is upload-token-gated, so a browser owner-session delete route belongs with the JUL-31 access-control work.

Verification: offline suite 17/17 green; live smoke — button renders, POST deletes the dir, re-delete 404s, `--local-only` honored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)