### PR TITLE
feat(access): public/unlisted/private policy + pure-publish history (JUL-31)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -70,6 +70,31 @@ GitHub-backed identity. Published comments live in hosted storage:
 Published overlay behavior comes from the deployed bundle. It does not change
 just because a local checkout changes.
 
+
+## Access Policy (published docs)
+
+Published documents carry an optional `meta.access` object:
+
+```json
+{
+  "visibility": "public | unlisted | private",
+  "commenting": "owner | invited | signed_in | off",
+  "history_visibility": "owner | invited | public",
+  "allowed_users": ["github-login", "..."]
+}
+```
+
+- **public / unlisted**: anyone with the link can read. Unlisted is for
+  pure-link sharing without discovery; the owner catalog at `/me` still lists
+  every doc the owner hosts.
+- **private**: only `TDOC_OWNER` and `allowed_users` (GitHub logins) can read.
+  Gates apply to `/d/.../v/N`, `/export`, `/fork`, and `GET /api/comments`.
+- **history_visibility**: controls whether the overlay version picker shows the
+  full history (pure-publish default for new policies: owner-only).
+- **Legacy docs** without `access` stay world-readable with full history for
+  back-compat. `tdoc-publish --visibility ...` writes the policy into local
+  `meta.json` before upload.
+
 ## Install, Preview, and Publish Checkouts
 
 There are three common code locations:

--- a/bin/tdoc-publish
+++ b/bin/tdoc-publish
@@ -25,14 +25,38 @@
 
 set -euo pipefail
 
-usage() { echo "usage: tdoc-publish [--platform cloudflare|vercel] <slug>" >&2; exit 1; }
+usage() {
+  cat >&2 <<'EOF'
+usage: tdoc-publish [options] <slug>
+
+Options:
+  --platform cloudflare|vercel
+  --visibility public|unlisted|private   (default for new access block: unlisted)
+  --history owner|invited|public         (default for new access block: owner)
+  --commenting owner|invited|signed_in|off  (default: signed_in)
+  --allow-user <github-login>            (repeatable; private/shared allowlist)
+EOF
+  exit 1
+}
 
 SLUG=""
 PLATFORM_FLAG="${TDOC_PLATFORM:-}"
+VISIBILITY_FLAG=""
+HISTORY_FLAG=""
+COMMENTING_FLAG=""
+ALLOW_USERS=()
 while [ $# -gt 0 ]; do
   case "$1" in
     --platform)   PLATFORM_FLAG="${2:-}"; [ -n "$PLATFORM_FLAG" ] || usage; shift 2 ;;
     --platform=*) PLATFORM_FLAG="${1#--platform=}"; [ -n "$PLATFORM_FLAG" ] || usage; shift ;;
+    --visibility) VISIBILITY_FLAG="${2:-}"; [ -n "$VISIBILITY_FLAG" ] || usage; shift 2 ;;
+    --visibility=*) VISIBILITY_FLAG="${1#--visibility=}"; [ -n "$VISIBILITY_FLAG" ] || usage; shift ;;
+    --history) HISTORY_FLAG="${2:-}"; [ -n "$HISTORY_FLAG" ] || usage; shift 2 ;;
+    --history=*) HISTORY_FLAG="${1#--history=}"; [ -n "$HISTORY_FLAG" ] || usage; shift ;;
+    --commenting) COMMENTING_FLAG="${2:-}"; [ -n "$COMMENTING_FLAG" ] || usage; shift 2 ;;
+    --commenting=*) COMMENTING_FLAG="${1#--commenting=}"; [ -n "$COMMENTING_FLAG" ] || usage; shift ;;
+    --allow-user) [ -n "${2:-}" ] || usage; ALLOW_USERS+=("$2"); shift 2 ;;
+    --allow-user=*) ALLOW_USERS+=("${1#--allow-user=}"); shift ;;
     # Anything else is treated as the slug — including dash-leading junk,
     # which the kebab-case validator below rejects with a precise message.
     *)  [ -z "$SLUG" ] || usage; SLUG="$1"; shift ;;
@@ -606,6 +630,43 @@ META_FILE="$DOC_DIR/meta.json"
 if [ ! -f "$META_FILE" ]; then
   echo "no meta.json at $META_FILE" >&2
   exit 1
+fi
+
+# JUL-31 access policy: merge flags into local meta.json so /api/upload
+# carries them. Defaults for a brand-new access block: unlisted + owner
+# history (pure publish). Existing access blocks keep unspecified fields.
+if [ -n "$VISIBILITY_FLAG" ] || [ -n "$HISTORY_FLAG" ] || [ -n "$COMMENTING_FLAG" ] || [ ${#ALLOW_USERS[@]} -gt 0 ]; then
+  case "${VISIBILITY_FLAG:-}" in
+    ''|public|unlisted|private) ;;
+    *) echo "[tdoc] invalid --visibility '$VISIBILITY_FLAG' (public|unlisted|private)" >&2; exit 1 ;;
+  esac
+  case "${HISTORY_FLAG:-}" in
+    ''|owner|invited|public) ;;
+    *) echo "[tdoc] invalid --history '$HISTORY_FLAG' (owner|invited|public)" >&2; exit 1 ;;
+  esac
+  case "${COMMENTING_FLAG:-}" in
+    ''|owner|invited|signed_in|off) ;;
+    *) echo "[tdoc] invalid --commenting '$COMMENTING_FLAG' (owner|invited|signed_in|off)" >&2; exit 1 ;;
+  esac
+  ALLOW_JSON='[]'
+  if [ ${#ALLOW_USERS[@]} -gt 0 ]; then
+    ALLOW_JSON="$(printf '%s
+' "${ALLOW_USERS[@]}" | jq -R . | jq -s .)"
+  fi
+  tmp_meta="$(mktemp -t tdoc-meta.XXXXXX)"
+  jq     --arg vis "${VISIBILITY_FLAG}"     --arg hist "${HISTORY_FLAG}"     --arg comm "${COMMENTING_FLAG}"     --argjson allow "$ALLOW_JSON"     '
+      .access = (.access // {})
+      | .access.visibility = (if $vis != "" then $vis else (.access.visibility // "unlisted") end)
+      | .access.history_visibility = (if $hist != "" then $hist else (.access.history_visibility // "owner") end)
+      | .access.commenting = (if $comm != "" then $comm else (.access.commenting // "signed_in") end)
+      | .access.allowed_users = (
+          if ($allow|length) > 0 then
+            (((.access.allowed_users // []) + $allow) | map(ascii_downcase|sub("^github:";"")|sub("^@";"")) | unique)
+          else (.access.allowed_users // []) end
+        )
+    ' "$META_FILE" > "$tmp_meta"
+  mv "$tmp_meta" "$META_FILE"
+  echo "[tdoc] access → $(jq -c .access "$META_FILE")"
 fi
 
 VERSION="$(jq -r '.versions | sort_by(.n) | last | .n' "$META_FILE")"

--- a/test/access.test.js
+++ b/test/access.test.js
@@ -1,0 +1,116 @@
+// JUL-31 access policy pure-function regressions.
+// Extracts the access-policy block from worker.js as one contiguous chunk.
+
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+
+let pass = 0, fail = 0;
+function ok(n) { console.log(`  ✓ ${n}`); pass++; }
+function bad(n, e) { console.log(`  ✗ ${n}\n    ${e}`); fail++; }
+function t(n, fn) { try { fn(); ok(n); } catch (e) { bad(n, e.message); } }
+function assert(c, m) { if (!c) throw new Error(m || 'assertion failed'); }
+
+const workerSrc = fs.readFileSync(path.join(__dirname, '..', 'worker', 'worker.js'), 'utf8');
+const start = workerSrc.indexOf('// Access policy (JUL-31)');
+const end = workerSrc.indexOf('function agentIdentity(');
+if (start < 0 || end < 0 || end <= start) throw new Error('access policy block markers missing');
+// isOwnerSession is defined earlier and is a dependency.
+const ownerStart = workerSrc.indexOf('function isOwnerSession(');
+let i = workerSrc.indexOf('{', ownerStart), depth = 0;
+for (; i < workerSrc.length; i++) {
+  if (workerSrc[i] === '{') depth++;
+  else if (workerSrc[i] === '}') { depth--; if (depth === 0) { i++; break; } }
+}
+const isOwnerFn = workerSrc.slice(ownerStart, i);
+const block = isOwnerFn + '\n' + workerSrc.slice(start, end);
+
+const box = {};
+vm.createContext(box);
+vm.runInContext(block, box);
+
+const ENV = { TDOC_OWNER: 'julie' };
+const owner = { login: 'julie' };
+const alice = { login: 'alice' };
+const bob = { login: 'bob' };
+
+console.log('access policy (JUL-31)');
+
+t('legacy missing access defaults to public + public history', () => {
+  const a = box.accessFromMeta({});
+  assert(a.visibility === 'public');
+  assert(a.history_visibility === 'public');
+  assert(a.commenting === 'signed_in');
+});
+
+t('explicit private access normalizes allowlist logins', () => {
+  const a = box.normalizeAccess({
+    visibility: 'private',
+    history_visibility: 'owner',
+    commenting: 'invited',
+    allowed_users: ['github:Alice', '@Bob', 'alice', '!!!', ''],
+  }, { legacy: false });
+  assert(a.visibility === 'private');
+  assert(JSON.stringify(a.allowed_users) === JSON.stringify(['alice', 'bob']));
+});
+
+t('new (non-legacy) defaults are unlisted + owner history', () => {
+  const a = box.normalizeAccess({}, { legacy: false });
+  assert(a.visibility === 'unlisted');
+  assert(a.history_visibility === 'owner');
+});
+
+t('public/unlisted readable by anyone; private requires allowlist', () => {
+  const pub = box.normalizeAccess({ visibility: 'public' });
+  const unlist = box.normalizeAccess({ visibility: 'unlisted' });
+  const priv = box.normalizeAccess({ visibility: 'private', allowed_users: ['alice'] });
+  assert(box.canReadDoc(pub, null, ENV) === true);
+  assert(box.canReadDoc(unlist, null, ENV) === true);
+  assert(box.canReadDoc(priv, null, ENV) === false);
+  assert(box.canReadDoc(priv, alice, ENV) === true);
+  assert(box.canReadDoc(priv, bob, ENV) === false);
+  assert(box.canReadDoc(priv, owner, ENV) === true);
+});
+
+t('history_visibility owner hides picker from allowlisted non-owner', () => {
+  const a = box.normalizeAccess({
+    visibility: 'private',
+    history_visibility: 'owner',
+    allowed_users: ['alice'],
+  });
+  assert(box.canSeeHistory(a, owner, ENV) === true);
+  assert(box.canSeeHistory(a, alice, ENV) === false);
+  assert(box.canSeeHistory(a, null, ENV) === false);
+});
+
+t('history_visibility invited allows allowlist', () => {
+  const a = box.normalizeAccess({
+    visibility: 'private',
+    history_visibility: 'invited',
+    allowed_users: ['alice'],
+  });
+  assert(box.canSeeHistory(a, alice, ENV) === true);
+  assert(box.canSeeHistory(a, bob, ENV) === false);
+});
+
+t('commenting gates: off / signed_in / owner / invited', () => {
+  const off = box.normalizeAccess({ commenting: 'off' });
+  const signed = box.normalizeAccess({ commenting: 'signed_in' });
+  const own = box.normalizeAccess({ commenting: 'owner' });
+  const inv = box.normalizeAccess({ commenting: 'invited', allowed_users: ['alice'] });
+  assert(box.canCommentOnDoc(off, alice, ENV) === false);
+  assert(box.canCommentOnDoc(signed, alice, ENV) === true);
+  assert(box.canCommentOnDoc(signed, null, ENV) === false);
+  assert(box.canCommentOnDoc(own, alice, ENV) === false);
+  assert(box.canCommentOnDoc(own, owner, ENV) === true);
+  assert(box.canCommentOnDoc(inv, alice, ENV) === true);
+  assert(box.canCommentOnDoc(inv, bob, ENV) === false);
+});
+
+t('invalid visibility falls back by legacy mode', () => {
+  assert(box.normalizeAccess({ visibility: 'nope' }, { legacy: true }).visibility === 'public');
+  assert(box.normalizeAccess({ visibility: 'nope' }, { legacy: false }).visibility === 'unlisted');
+});
+
+console.log(`\n${pass} passed, ${fail} failed`);
+process.exit(fail ? 1 : 0);

--- a/test/run.js
+++ b/test/run.js
@@ -20,6 +20,7 @@ const OFFLINE = [
   'event-convergence.test.js',// eid dedup convergence + fold ordering
   'reconcile.test.js',        // anchor reconcile branches + compaction
   'security.test.js',         // injection / authz / CSRF / path-traversal
+  'access.test.js',           // JUL-31 access policy (public/unlisted/private)
   'oldver-strip.test.js',     // old-version banner predicate
   'cli.test.js',              // CLI resilience (drives bash hermetically)
   'no-drift.test.js',         // duplicated-helper drift guard

--- a/worker/worker.js
+++ b/worker/worker.js
@@ -76,6 +76,160 @@ function canMutate(record, session, env) {
   const who = record && record.author && record.author.login;
   return !!(who && session && session.login && who === session.login);
 }
+
+// ─────────────────────────────────────────────────────────────────────────
+// Access policy (JUL-31)
+//
+// Product ladder on published docs:
+//   public   — anyone with the link can read; may appear in future discovery
+//   unlisted — anyone with the link can read; never listed in catalogs
+//   private  — owner + allowlisted GitHub logins only (sign-in required)
+//
+// Pure-publish default for NEW meta written by tdoc-publish:
+//   history_visibility = owner (readers see only the requested version)
+// Missing/legacy meta without `access` stays world-readable for back-compat.
+// ─────────────────────────────────────────────────────────────────────────
+const ACCESS_VISIBILITIES = new Set(['public', 'unlisted', 'private']);
+const ACCESS_COMMENTING = new Set(['owner', 'invited', 'signed_in', 'off']);
+const ACCESS_HISTORY = new Set(['owner', 'invited', 'public']);
+
+function sessionLogin(session) {
+  return session && typeof session.login === 'string' && session.login
+    ? session.login.trim().toLowerCase()
+    : null;
+}
+
+function normalizeGithubLogin(v) {
+  if (typeof v !== 'string') return null;
+  let s = v.trim().toLowerCase();
+  if (!s) return null;
+  if (s.startsWith('github:')) s = s.slice('github:'.length);
+  if (s.startsWith('@')) s = s.slice(1);
+  // GitHub logins: alphanumeric + hyphen
+  if (!/^[a-z0-9](?:[a-z0-9-]{0,37}[a-z0-9])?$/.test(s)) return null;
+  return s;
+}
+
+// Normalize meta.access. `legacy` chooses defaults when the field is absent:
+//   true  → back-compat for already-published docs (public + full history)
+//   false → product defaults for newly written policy objects
+function normalizeAccess(raw, { legacy = true } = {}) {
+  const a = raw && typeof raw === 'object' && !Array.isArray(raw) ? raw : {};
+  const visibility = ACCESS_VISIBILITIES.has(a.visibility)
+    ? a.visibility
+    : (legacy ? 'public' : 'unlisted');
+  const commenting = ACCESS_COMMENTING.has(a.commenting)
+    ? a.commenting
+    : 'signed_in';
+  const history_visibility = ACCESS_HISTORY.has(a.history_visibility)
+    ? a.history_visibility
+    : (legacy ? 'public' : 'owner');
+  const allowed = [];
+  const seen = new Set();
+  const srcList = Array.isArray(a.allowed_users) ? a.allowed_users : [];
+  for (const item of srcList) {
+    const login = normalizeGithubLogin(item);
+    if (!login || seen.has(login)) continue;
+    seen.add(login);
+    allowed.push(login);
+  }
+  return { visibility, commenting, history_visibility, allowed_users: allowed };
+}
+
+function accessFromMeta(meta) {
+  const has = meta && meta.access && typeof meta.access === 'object';
+  return normalizeAccess(has ? meta.access : null, { legacy: !has });
+}
+
+function isAllowlisted(access, session, env) {
+  if (isOwnerSession(env, session)) return true;
+  const login = sessionLogin(session);
+  if (!login) return false;
+  return (access.allowed_users || []).includes(login);
+}
+
+function canReadDoc(access, session, env) {
+  if (access.visibility === 'public' || access.visibility === 'unlisted') return true;
+  return isAllowlisted(access, session, env);
+}
+
+function canSeeHistory(access, session, env) {
+  if (access.history_visibility === 'public') return true;
+  if (access.history_visibility === 'invited') return isAllowlisted(access, session, env);
+  // owner — TDOC_OWNER only (not every allowlisted reviewer)
+  return isOwnerSession(env, session);
+}
+
+function canCommentOnDoc(access, session, env) {
+  if (access.commenting === 'off') return false;
+  if (!sessionLogin(session)) return false;
+  if (access.commenting === 'signed_in') return true;
+  if (access.commenting === 'owner') return isOwnerSession(env, session);
+  if (access.commenting === 'invited') return isAllowlisted(access, session, env);
+  return false;
+}
+
+async function loadDocMeta(env, slug) {
+  try {
+    const raw = await env.META.get(`meta:${slug}`);
+    if (!raw) return null;
+    const meta = JSON.parse(raw);
+    return meta && typeof meta === 'object' ? meta : null;
+  } catch {
+    return null;
+  }
+}
+
+function accessDeniedHtml({ status, title, body, slug, version }) {
+  const next = slug && version ? `/d/${encodeURIComponent(slug)}/v/${version}` : '/';
+  return html(`<!doctype html><html lang="en"><head>
+<meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1">
+<title>${escapeHtml(title)} · tdoc</title>
+<style>
+  body{font:15px/1.5 system-ui,-apple-system,sans-serif;margin:0;min-height:100vh;
+    display:flex;align-items:center;justify-content:center;background:#fff;color:#111}
+  .box{max-width:420px;padding:28px 24px;border:1px solid #e5e7eb;border-radius:12px}
+  h1{font-size:18px;margin:0 0 8px}
+  p{margin:0 0 14px;color:#444}
+  a{color:#1652f0}
+  .meta{font-size:12px;color:#888;margin-top:18px}
+</style></head><body><div class="box">
+  <h1>${escapeHtml(title)}</h1>
+  <p>${escapeHtml(body)}</p>
+  <p><a href="${escapeHtml(next)}">Retry this link</a> after signing in from any page on this host that shows the tdoc bar.</p>
+  <p class="meta">tdoc access control</p>
+</div></body></html>`, { status });
+}
+
+async function enforceDocAccess(env, req, slug, version) {
+  const meta = await loadDocMeta(env, slug);
+  // No meta yet (orphan R2 object) — treat as public so legacy uploads still work.
+  const access = accessFromMeta(meta || {});
+  const session = await getSession(env, req);
+  if (canReadDoc(access, session, env)) {
+    return { ok: true, access, session, meta };
+  }
+  if (!sessionLogin(session)) {
+    return {
+      ok: false,
+      response: accessDeniedHtml({
+        status: 401,
+        title: 'Sign in required',
+        body: 'This document is private. Sign in with GitHub, then open the link again. Only allowlisted accounts can read it.',
+        slug, version,
+      }),
+    };
+  }
+  return {
+    ok: false,
+    response: accessDeniedHtml({
+      status: 403,
+      title: 'Access denied',
+      body: `Signed in as ${session.login}, but this private document does not include you on the allowlist.`,
+      slug, version,
+    }),
+  };
+}
 function agentIdentity(body = {}, env = {}) {
   const fallbackLogin = env.TDOC_AGENT_LOGIN || 'tdoc-agent';
   const fallbackName = env.TDOC_AGENT_NAME || fallbackLogin;
@@ -1512,19 +1666,22 @@ export default {
     const docMatch = p.match(/^\/d\/([^/]+)\/v\/(\d+)\/?$/);
     if (docMatch && (method === 'GET' || method === 'HEAD')) {
       const [, slug, vStr] = docMatch;
+      const gate = await enforceDocAccess(env, req, slug, Number(vStr));
+      if (!gate.ok) return gate.response;
       const obj = await env.DOCS.get(`docs/${slug}/v${vStr}/index.html`);
       if (!obj) return text(`Not found: ${slug} v${vStr}`, { status: 404 });
       const raw = await obj.text();
-      const session = await getSession(env, req);
+      const session = gate.session;
       const identity = session ? { login: session.login, avatar_url: session.avatar_url, name: session.name } : null;
-      // Pull the full versions array from meta so the bar can render a
-      // version picker. Falls back to single-version if meta is missing.
-      let versions = null;
+      // Pure-publish: version picker only for callers allowed by history_visibility.
+      let versions = [{ n: Number(vStr), created: null }];
       try {
-        const metaRaw = await env.META.get(`meta:${slug}`);
-        if (metaRaw) {
-          const meta = JSON.parse(metaRaw);
-          if (Array.isArray(meta.versions)) versions = meta.versions.map(v => ({ n: v.n, created: v.created || null }));
+        const meta = gate.meta;
+        if (meta && Array.isArray(meta.versions) && canSeeHistory(gate.access, session, env)) {
+          versions = meta.versions.map(v => ({ n: v.n, created: v.created || null }));
+        } else if (meta && Array.isArray(meta.versions)) {
+          const hit = meta.versions.find(v => Number(v.n) === Number(vStr));
+          versions = [{ n: Number(vStr), created: (hit && hit.created) || null }];
         }
       } catch {}
       return html(injectOverlay(raw, slug, Number(vStr), identity, versions, isOwnerSession(env, session)));
@@ -1548,6 +1705,8 @@ export default {
     const exportMatch = p.match(/^\/d\/([^/]+)\/v\/(\d+)\/(export|fork)\/?$/);
     if (exportMatch && method === 'GET') {
       const [, slug, vStr, kind] = exportMatch;
+      const gate = await enforceDocAccess(env, req, slug, Number(vStr));
+      if (!gate.ok) return gate.response;
       const obj = await env.DOCS.get(`docs/${slug}/v${vStr}/index.html`);
       if (!obj) return text(`Not found: ${slug} v${vStr}`, { status: 404 });
       let html = await obj.text();
@@ -1729,6 +1888,9 @@ export default {
     if (p === '/api/comments' && method === 'GET') {
       const slug = url.searchParams.get('slug');
       if (!slug) return json({ error: 'slug required' }, { status: 400 });
+      // Same read gate as the HTML routes: private docs don't leak comments.
+      const gate = await enforceDocAccess(env, req, slug, parseVersionParam(url) || 1);
+      if (!gate.ok) return json({ error: 'access_denied' }, { status: gate.response.status || 403 });
       // Read from the DO (source of truth; it lazily migrates from KV on first
       // touch). Migrate-in-memory for this response only — never persist from a
       // read (writes go through the DO).
@@ -1749,6 +1911,12 @@ export default {
       const { slug, version, anchor, text: commentText, parent_id } = body;
       if (!slug || !commentText) return json({ error: 'slug and text required' }, { status: 400 });
       if (!isValidSlug(slug)) return json({ error: 'invalid_slug' }, { status: 400 });
+      {
+        const meta = await loadDocMeta(env, slug);
+        const access = accessFromMeta(meta || {});
+        if (!canReadDoc(access, s, env)) return json({ error: 'access_denied' }, { status: 403 });
+        if (!canCommentOnDoc(access, s, env)) return json({ error: 'commenting_disabled' }, { status: 403 });
+      }
       const author = { login: s.login, avatar_url: s.avatar_url, name: s.name };
       const created = new Date().toISOString();
       const V = coerceBodyVersion(version);
@@ -1965,7 +2133,25 @@ export default {
         console.error('[upload] R2 write did not persist:', r2Key);
         return json({ error: 'r2_write_lost', message: 'PUT succeeded but the key is not readable. Re-deploy the worker; the R2 binding may be stale.' }, { status: 500 });
       }
-      if (meta) await env.META.put(`meta:${slug}`, JSON.stringify(meta));
+      if (meta) {
+        // Normalize access policy onto every uploaded meta snapshot. If the
+        // payload omits `access`, keep any previously stored policy (so a
+        // partial republish without access flags does not reset private docs
+        // to public). Only brand-new docs fall through to legacy defaults.
+        const incoming = (meta && typeof meta === 'object') ? { ...meta } : {};
+        let prev = null;
+        try {
+          const prevRaw = await env.META.get(`meta:${slug}`);
+          if (prevRaw) prev = JSON.parse(prevRaw);
+        } catch {}
+        if (!incoming.access && prev && prev.access) {
+          incoming.access = prev.access;
+        }
+        if (incoming.access) {
+          incoming.access = normalizeAccess(incoming.access, { legacy: false });
+        }
+        await env.META.put(`meta:${slug}`, JSON.stringify(incoming));
+      }
       // Reconcile existing open comments against the new artifact set:
       // bind by aid where possible; mark lost where the artifact is gone
       // or ambiguous. This is the ENFORCED publish-time invariant — no


### PR DESCRIPTION
## Summary
Linear **JUL-31** access control — first shippable slice so publish is not always world-readable + full history.

- **`meta.access`**: `visibility` (public | unlisted | private), `commenting`, `history_visibility`, `allowed_users`
- **Route gates** (private): `/d/:slug/v/:n`, `/export`, `/fork`, `GET /api/comments`
- **Comment POST** respects `commenting` (owner / invited / signed_in / off)
- **Pure-publish**: version picker only when `history_visibility` allows the viewer (default for *new* policy: owner)
- **CLI**: `tdoc-publish --visibility private --allow-user alice --history owner --commenting invited`
- **Republish-safe**: if upload meta omits `access`, keep previously stored policy
- **Legacy**: docs without `access` stay public + full history (no break)

## Validation
- `node test/access.test.js` — 8/8
- `node test/run.js` — offline suite: only pre-existing `coverage.test.js` BUNDLE syntax check fails under Node 18 (`export class CommentsStore` as CJS), same as noted on PR #99

## Out of scope (next)
- JUL-30 hosted out-of-box (needs CF account decision)
- UI for access picker on published pages
- Invite-by-email (GitHub login allowlist only for now)

## How to try
```bash
tdoc-publish --visibility private --allow-user <github-login> <slug>
# redeploy worker so gates are live, then open the URL signed-out → 401; wrong user → 403
```

@Grokie