### PR TITLE
feat: mutate remote access without re-upload

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -644,7 +644,8 @@ Remote storage holds optional `meta.access`:
 - **private**: `TDOC_OWNER` + `allowed_users` only. Gates `/d/.../v/N`, export, fork, `GET /api/comments`.
 - **history_visibility**: version picker visibility (new policies default owner-only / pure-publish).
 - Legacy meta without `access` stays world-readable + full history (back-compat).
-- Set via `tdoc-publish --visibility|--history|--commenting|--allow-user` (writes local `meta.json` before upload to remote SoT).
+- Initial publish can set access via `tdoc-publish --visibility|--history|--commenting|--allow-user`.
+- After publish, access must be mutable directly on remote storage (`PATCH /api/doc/access` with the upload token) without local `meta.json` or full HTML re-upload.
 
 
 ### Comment anchor stability (important for `/tdoc edit`)

--- a/test/access.test.js
+++ b/test/access.test.js
@@ -112,5 +112,48 @@ t('invalid visibility falls back by legacy mode', () => {
   assert(box.normalizeAccess({ visibility: 'nope' }, { legacy: false }).visibility === 'unlisted');
 });
 
+t('remote access patch preserves document meta and mutates only access', () => {
+  const meta = {
+    title: 'Doc',
+    versions: [{ n: 1 }],
+    owner: 'must-not-change',
+    access: {
+      visibility: 'private',
+      history_visibility: 'owner',
+      commenting: 'signed_in',
+      allowed_users: ['alice'],
+    },
+  };
+  const r = box.applyAccessPatch(meta, {
+    visibility: 'public',
+    history_visibility: 'public',
+    allowed_users: ['github:Bob', '@alice'],
+  });
+  assert(!r.error, `unexpected error ${r.error}`);
+  assert(r.meta !== meta, 'must return a new meta object');
+  assert(meta.access.visibility === 'private', 'must not mutate input meta');
+  assert(r.meta.title === 'Doc' && r.meta.versions.length === 1, 'non-access meta was not preserved');
+  assert(r.meta.owner === 'must-not-change', 'non-access fields should pass through unchanged');
+  assert(r.access.visibility === 'public');
+  assert(r.access.history_visibility === 'public');
+  assert(r.access.commenting === 'signed_in');
+  assert(JSON.stringify(r.access.allowed_users) === JSON.stringify(['bob', 'alice']));
+});
+
+t('remote access patch creates product defaults for legacy meta', () => {
+  const r = box.applyAccessPatch({ title: 'Legacy' }, { visibility: 'private' });
+  assert(!r.error, `unexpected error ${r.error}`);
+  assert(r.access.visibility === 'private');
+  assert(r.access.history_visibility === 'owner', 'newly managed access must not inherit legacy public history');
+  assert(r.access.commenting === 'signed_in');
+  assert(JSON.stringify(r.access.allowed_users) === JSON.stringify([]));
+});
+
+t('remote access patch rejects non-access fields', () => {
+  const r = box.applyAccessPatch({ title: 'Doc' }, { visibility: 'private', owner: 'mallory' });
+  assert(r.error === 'invalid_access_field', `expected invalid_access_field, got ${r.error}`);
+  assert(JSON.stringify(r.fields) === JSON.stringify(['owner']), `unexpected fields ${JSON.stringify(r.fields)}`);
+});
+
 console.log(`\n${pass} passed, ${fail} failed`);
 process.exit(fail ? 1 : 0);

--- a/test/remote-access-route.test.js
+++ b/test/remote-access-route.test.js
@@ -1,0 +1,54 @@
+// Remote access mutation route guard.
+//
+// This route can turn a private document public. It must stay upload-token
+// gated, mutate only meta.access, and never touch document bytes.
+
+const fs = require('fs');
+const path = require('path');
+
+let pass = 0, fail = 0;
+function ok(n) { console.log(`  ✓ ${n}`); pass++; }
+function bad(n, e) { console.log(`  ✗ ${n}\n    ${e}`); fail++; }
+function t(n, fn) { try { fn(); ok(n); } catch (e) { bad(n, e.message); } }
+function assert(c, m) { if (!c) throw new Error(m || 'assertion failed'); }
+
+const worker = fs.readFileSync(path.join(__dirname, '..', 'worker', 'worker.js'), 'utf8');
+
+const start = worker.indexOf("if (p === '/api/doc/access' && method === 'PATCH')");
+const end = worker.indexOf('// ---- admin delete ----', start);
+if (start < 0 || end < 0 || end <= start) throw new Error('/api/doc/access route block missing');
+const route = worker.slice(start, end);
+
+console.log('remote access mutation route');
+
+t('CORS allows PATCH for remote access mutation', () => {
+  assert(worker.includes("'Access-Control-Allow-Methods': 'GET,POST,PATCH,DELETE,OPTIONS'"),
+    'PATCH missing from Access-Control-Allow-Methods');
+});
+
+t('PATCH /api/doc/access authenticates before parsing body or writing meta', () => {
+  const auth = route.indexOf('await requireUploadAuth(req, env)');
+  const body = route.indexOf('await req.json()');
+  const write = route.indexOf('env.META.put(`meta:${slug}`');
+  assert(auth >= 0, 'route must call requireUploadAuth');
+  assert(body >= 0, 'route should parse request JSON after auth');
+  assert(write >= 0, 'route should persist meta after auth');
+  assert(auth < body, 'auth must happen before body parse');
+  assert(auth < write, 'auth must happen before META write');
+});
+
+t('PATCH /api/doc/access only writes remote meta, never document bytes', () => {
+  assert(route.includes('applyAccessPatch(meta, access)'), 'route must use access-only helper');
+  assert(route.includes('env.META.put(`meta:${slug}`'), 'route must write updated meta');
+  assert(!route.includes('env.DOCS.put'), 'route must not write R2 document HTML');
+  assert(!route.includes('env.DOCS.delete'), 'route must not delete R2 document HTML');
+  assert(!route.includes('mutateComments'), 'route must not mutate comments');
+});
+
+t('PATCH /api/doc/access rejects top-level fields outside slug/access', () => {
+  assert(route.includes("k !== 'slug' && k !== 'access'"), 'route must whitelist top-level fields');
+  assert(route.includes("json({ error: 'invalid_field'"), 'route must reject top-level unknown fields');
+});
+
+console.log(`\n${pass} passed, ${fail} failed`);
+process.exit(fail ? 1 : 0);

--- a/test/run.js
+++ b/test/run.js
@@ -22,6 +22,7 @@ const OFFLINE = [
   'reconcile.test.js',        // anchor reconcile branches + compaction
   'security.test.js',         // injection / authz / CSRF / path-traversal
   'access.test.js',           // JUL-31 access policy (public/unlisted/private)
+  'remote-access-route.test.js', // remote access mutation auth + meta-only guard
   'oldver-strip.test.js',     // old-version banner predicate
   'cli.test.js',              // CLI resilience (drives bash hermetically)
   'no-drift.test.js',         // duplicated-helper drift guard

--- a/worker/worker.js
+++ b/worker/worker.js
@@ -17,7 +17,7 @@ const OVERLAY_JS = `__TDOC_OVERLAY_JS__`;
 
 const CORS = {
   'Access-Control-Allow-Origin': '*',
-  'Access-Control-Allow-Methods': 'GET,POST,DELETE,OPTIONS',
+  'Access-Control-Allow-Methods': 'GET,POST,PATCH,DELETE,OPTIONS',
   'Access-Control-Allow-Headers': 'Content-Type,Authorization',
 };
 
@@ -92,6 +92,7 @@ function canMutate(record, session, env) {
 const ACCESS_VISIBILITIES = new Set(['public', 'unlisted', 'private']);
 const ACCESS_COMMENTING = new Set(['owner', 'invited', 'signed_in', 'off']);
 const ACCESS_HISTORY = new Set(['owner', 'invited', 'public']);
+const ACCESS_PATCH_FIELDS = new Set(['visibility', 'commenting', 'history_visibility', 'allowed_users']);
 
 function sessionLogin(session) {
   return session && typeof session.login === 'string' && session.login
@@ -139,6 +140,28 @@ function normalizeAccess(raw, { legacy = true } = {}) {
 function accessFromMeta(meta) {
   const has = meta && meta.access && typeof meta.access === 'object';
   return normalizeAccess(has ? meta.access : null, { legacy: !has });
+}
+
+function applyAccessPatch(meta, patch) {
+  if (!meta || typeof meta !== 'object' || Array.isArray(meta)) {
+    return { error: 'missing_meta' };
+  }
+  if (!patch || typeof patch !== 'object' || Array.isArray(patch)) {
+    return { error: 'access object required' };
+  }
+  const keys = Object.keys(patch);
+  if (!keys.length) return { error: 'access patch required' };
+  const unknown = keys.filter((k) => !ACCESS_PATCH_FIELDS.has(k));
+  if (unknown.length) return { error: 'invalid_access_field', fields: unknown };
+
+  // A remote access mutation creates/updates only the access policy. If the doc
+  // has legacy meta without access, switch to product defaults instead of
+  // carrying public-history legacy defaults into a newly managed policy.
+  const base = meta.access && typeof meta.access === 'object'
+    ? normalizeAccess(meta.access, { legacy: false })
+    : normalizeAccess({}, { legacy: false });
+  const next = normalizeAccess({ ...base, ...patch }, { legacy: false });
+  return { meta: { ...meta, access: next }, access: next };
 }
 
 function isAllowlisted(access, session, env) {
@@ -2184,6 +2207,31 @@ export default {
         console.error('[upload] comment merge/reconcile failed (non-fatal):', e.message);
       }
       return json({ ok: true, url: `/d/${slug}/v/${verNum}`, size: verify.size, aids: aids.length, mergedComments: mergedLocal });
+    }
+
+    // ---- admin access mutation ----
+    // Remote storage is the source of truth: access policy must be mutable
+    // without a local meta.json or full document re-upload. Authenticated with
+    // the same upload token as /api/upload and /api/doc DELETE.
+    if (p === '/api/doc/access' && method === 'PATCH') {
+      const unauth = await requireUploadAuth(req, env);
+      if (unauth) return unauth;
+      let body = {};
+      try { body = await req.json(); } catch {}
+      const topKeys = Object.keys(body || {});
+      const unknownTop = topKeys.filter((k) => k !== 'slug' && k !== 'access');
+      if (unknownTop.length) return json({ error: 'invalid_field', fields: unknownTop }, { status: 400 });
+      const { slug, access } = body || {};
+      if (!slug) return json({ error: 'slug required' }, { status: 400 });
+      if (!isValidSlug(slug)) return json({ error: 'invalid_slug' }, { status: 400 });
+      const meta = await loadDocMeta(env, slug);
+      if (!meta) return json({ error: 'not_found' }, { status: 404 });
+      const next = applyAccessPatch(meta, access);
+      if (next.error) {
+        return json({ error: next.error, ...(next.fields ? { fields: next.fields } : {}) }, { status: 400 });
+      }
+      await env.META.put(`meta:${slug}`, JSON.stringify(next.meta));
+      return json({ ok: true, slug, access: next.access });
     }
 
     // ---- admin delete ----


### PR DESCRIPTION
## Summary
- add PATCH /api/doc/access for upload-token-authenticated remote access policy updates
- whitelist access-only fields (visibility, commenting, history_visibility, allowed_users) and preserve document meta/content
- document remote access mutation as the post-publish path in SKILL.md

## Verification
- node test/access.test.js
- node test/remote-access-route.test.js
- targeted auth mutation check: removing requireUploadAuth from the new route fails the guard as expected
- node test/run.js (fails only at the existing local Node 18 coverage bundle syntax check: export class CommentsStore; all new/focused suites pass before that)

## Notes
This PR intentionally does not add the /me management UI yet. It adds the remote SoT mutation primitive that UI/CLI can call next.