### PR TITLE
feat: manage remote docs from owner catalog

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -646,6 +646,7 @@ Remote storage holds optional `meta.access`:
 - Legacy meta without `access` stays world-readable + full history (back-compat).
 - Initial publish can set access via `tdoc-publish --visibility|--history|--commenting|--allow-user`.
 - After publish, access must be mutable directly on remote storage (`PATCH /api/doc/access` with the upload token) without local `meta.json` or full HTML re-upload.
+- `/me` may list docs through the owner GitHub session, but remote write actions still use the upload token; do not authorize destructive/access changes from the owner cookie while arbitrary published docs share the same origin.
 
 
 ### Comment anchor stability (important for `/tdoc edit`)

--- a/test/me-management.test.js
+++ b/test/me-management.test.js
@@ -1,0 +1,66 @@
+// Owner catalog remote-management guard.
+//
+// /me is the product management surface for remote source-of-truth docs. Since
+// published docs are arbitrary HTML on the same origin, remote writes must NOT
+// rely on the owner session cookie alone. The page asks for an admin token and
+// keeps it in memory only.
+
+const fs = require('fs');
+const path = require('path');
+
+let pass = 0, fail = 0;
+function ok(n) { console.log(`  ✓ ${n}`); pass++; }
+function bad(n, e) { console.log(`  ✗ ${n}\n    ${e}`); fail++; }
+function t(n, fn) { try { fn(); ok(n); } catch (e) { bad(n, e.message); } }
+function assert(c, m) { if (!c) throw new Error(m || 'assertion failed'); }
+
+const worker = fs.readFileSync(path.join(__dirname, '..', 'worker', 'worker.js'), 'utf8');
+const start = worker.indexOf('async function indexHtml(env, session)');
+const end = worker.indexOf('// ─────────────────────────────────────────────────────────────────────────', start);
+if (start < 0 || end < 0 || end <= start) throw new Error('indexHtml block missing');
+const index = worker.slice(start, end);
+
+const deleteStart = worker.indexOf("if (p === '/api/doc' && method === 'DELETE')");
+const deleteEnd = worker.indexOf("return text('Not found'", deleteStart);
+if (deleteStart < 0 || deleteEnd < 0 || deleteEnd <= deleteStart) throw new Error('/api/doc DELETE block missing');
+const deleteRoute = worker.slice(deleteStart, deleteEnd);
+
+console.log('/me remote management UI');
+
+t('/me exposes remote access controls for hosted docs', () => {
+  assert(index.includes('class="access-form"'), 'missing access form');
+  assert(index.includes('name="visibility"'), 'missing visibility control');
+  assert(index.includes('name="history_visibility"'), 'missing history visibility control');
+  assert(index.includes('name="commenting"'), 'missing commenting control');
+  assert(index.includes('name="allowed_users"'), 'missing allowed users control');
+});
+
+t('/me asks for an admin token without embedding the deployment secret', () => {
+  assert(index.includes('id="admin-token"'), 'missing admin token input');
+  assert(index.includes('type="password"'), 'admin token input should not be plain text');
+  assert(index.includes('autocomplete="off"'), 'admin token should not be browser-stored by default');
+  assert(!index.includes('TDOC_UPLOAD_TOKEN'), '/me HTML must not reference TDOC_UPLOAD_TOKEN');
+});
+
+t('/me saves access through the remote access endpoint with a bearer token', () => {
+  assert(index.includes("fetch('/api/doc/access'"), 'access form must call remote access endpoint');
+  assert(index.includes("method: 'PATCH'"), 'access form must PATCH');
+  assert(index.includes("'Authorization': 'Bearer ' + token"), 'access form must send bearer token');
+  assert(!index.includes("credentials: 'same-origin'"), 'remote writes must not rely on owner session cookies');
+  assert(index.includes('JSON.stringify({ slug, access })'), 'access form must send slug + access only');
+});
+
+t('/me deletes remote docs through DELETE /api/doc with a bearer token', () => {
+  assert(index.includes("fetch('/api/doc?slug=' + encodeURIComponent(slug)"), 'delete button must call remote delete endpoint');
+  assert(index.includes("method: 'DELETE'"), 'delete button must use DELETE');
+  assert(index.includes("headers,"), 'delete button must send auth headers');
+  assert(deleteRoute.includes('await requireUploadAuth(req, env)'), 'remote delete must keep upload-token auth');
+});
+
+t('/me does not introduce owner-cookie admin writes', () => {
+  assert(!worker.includes('requireAdminAuth'), 'worker must not add cookie-based admin writes on same origin as arbitrary docs');
+  assert(!worker.includes('isSameOriginRequest'), 'same-origin is not sufficient when docs are arbitrary same-origin HTML');
+});
+
+console.log(`\n${pass} passed, ${fail} failed`);
+process.exit(fail ? 1 : 0);

--- a/test/run.js
+++ b/test/run.js
@@ -23,6 +23,7 @@ const OFFLINE = [
   'security.test.js',         // injection / authz / CSRF / path-traversal
   'access.test.js',           // JUL-31 access policy (public/unlisted/private)
   'remote-access-route.test.js', // remote access mutation auth + meta-only guard
+  'me-management.test.js',    // /me remote SoT management UI guard
   'oldver-strip.test.js',     // old-version banner predicate
   'cli.test.js',              // CLI resilience (drives bash hermetically)
   'no-drift.test.js',         // duplicated-helper drift guard

--- a/worker/worker.js
+++ b/worker/worker.js
@@ -853,6 +853,9 @@ async function indexHtml(env, session) {
     let meta = {};
     try { meta = JSON.parse(metaRaw || '{}'); } catch {}
     const latest = meta.versions?.[meta.versions.length - 1]?.n || 1;
+    const access = accessFromMeta(meta);
+    const selected = (value, current) => value === current ? ' selected' : '';
+    const allowlist = (access.allowed_users || []).join(', ');
     // Only list docs whose latest version actually exists in R2 — otherwise
     // the index advertises 404s. (We hit this when R2 writes silently failed
     // while KV meta updates succeeded; defense in depth.)
@@ -862,27 +865,149 @@ async function indexHtml(env, session) {
       <td><a href="/d/${encodeURIComponent(slug)}/v/${latest}">${escapeHtml(meta.title || slug)}</a></td>
       <td>${escapeHtml(slug)}</td>
       <td>v${latest}</td>
+      <td>
+        <form class="access-form" data-slug="${escapeHtml(slug)}">
+          <label>Visibility
+            <select name="visibility">
+              <option value="unlisted"${selected('unlisted', access.visibility)}>Unlisted</option>
+              <option value="private"${selected('private', access.visibility)}>Private</option>
+              <option value="public"${selected('public', access.visibility)}>Public</option>
+            </select>
+          </label>
+          <label>History
+            <select name="history_visibility">
+              <option value="owner"${selected('owner', access.history_visibility)}>Owner</option>
+              <option value="invited"${selected('invited', access.history_visibility)}>Invited</option>
+              <option value="public"${selected('public', access.history_visibility)}>Public</option>
+            </select>
+          </label>
+          <label>Comments
+            <select name="commenting">
+              <option value="signed_in"${selected('signed_in', access.commenting)}>Signed in</option>
+              <option value="invited"${selected('invited', access.commenting)}>Invited</option>
+              <option value="owner"${selected('owner', access.commenting)}>Owner</option>
+              <option value="off"${selected('off', access.commenting)}>Off</option>
+            </select>
+          </label>
+          <label>Allowed users
+            <input name="allowed_users" value="${escapeHtml(allowlist)}" placeholder="github-login, another-login">
+          </label>
+          <button type="submit">Save</button>
+        </form>
+      </td>
+      <td><button class="delete-doc" data-slug="${escapeHtml(slug)}" data-title="${escapeHtml(meta.title || slug)}">Delete</button></td>
     </tr>`);
   }
 
   return `<!doctype html><html><head><meta charset="utf-8"><title>tdoc</title>
 <style>
-  body { font: 15px system-ui, -apple-system, sans-serif; max-width: 760px; margin: 60px auto; padding: 0 20px; color: #111; }
+  body { font: 15px system-ui, -apple-system, sans-serif; max-width: 1120px; margin: 48px auto; padding: 0 20px; color: #111; }
   h1 { font-size: 28px; margin: 0 0 4px; color: #1652f0; }
   .sub { color: #666; margin: 0 0 32px; }
   table { width: 100%; border-collapse: collapse; }
-  th, td { text-align: left; padding: 10px 12px; border-bottom: 1px solid #eee; }
+  th, td { text-align: left; vertical-align: top; padding: 10px 12px; border-bottom: 1px solid #eee; }
   th { font-size: 12px; text-transform: uppercase; color: #888; letter-spacing: 0.04em; }
   a { color: #1652f0; text-decoration: none; }
   a:hover { text-decoration: underline; }
   .empty { color: #888; padding: 40px 0; text-align: center; }
   .who { color: #888; font-size: 13px; margin: 0 0 32px; }
   .who b { color: #444; font-weight: 600; }
+  .toolbar { display: flex; gap: 10px; align-items: end; margin: 0 0 18px; }
+  .toolbar label { max-width: 320px; }
+  .toolbar input { min-width: 280px; }
+  .access-form { display: grid; grid-template-columns: repeat(4, minmax(110px, 1fr)) auto; gap: 8px; align-items: end; min-width: 620px; }
+  label { display: grid; gap: 4px; color: #666; font-size: 12px; }
+  select, input, button { font: inherit; border: 1px solid #d7d7d7; border-radius: 6px; background: #fff; color: #111; padding: 7px 8px; }
+  input { min-width: 180px; }
+  button { cursor: pointer; }
+  button:hover { border-color: #1652f0; }
+  .delete-doc { color: #b42318; border-color: #f1b8b2; }
+  .status { min-height: 20px; margin: 0 0 16px; color: #666; font-size: 13px; }
+  .status[data-kind="error"] { color: #b42318; }
+  .status[data-kind="ok"] { color: #087443; }
+  @media (max-width: 900px) {
+    table, thead, tbody, tr, th, td { display: block; }
+    thead { display: none; }
+    tr { padding: 14px 0; border-bottom: 1px solid #eee; }
+    td { border: 0; padding: 5px 0; }
+    .access-form { min-width: 0; grid-template-columns: 1fr; }
+  }
 </style></head><body>
 <h1>My docs</h1>
 <p class="who">Documents hosted on this worker${session && session.login ? ` · signed in as <b>${escapeHtml(session.login)}</b>` : ''}.</p>
+<div class="toolbar">
+  <label>Admin token
+    <input id="admin-token" type="password" autocomplete="off" placeholder="Required for remote changes">
+  </label>
+</div>
+<p id="status" class="status" aria-live="polite"></p>
 ${rows.length === 0 ? '<p class="empty">No published docs yet.</p>' :
-  `<table><thead><tr><th>Title</th><th>Slug</th><th>Version</th></tr></thead><tbody>${rows.join('')}</tbody></table>`}
+  `<table><thead><tr><th>Title</th><th>Slug</th><th>Version</th><th>Remote access</th><th>Remote delete</th></tr></thead><tbody>${rows.join('')}</tbody></table>`}
+<script>
+(() => {
+  const status = document.getElementById('status');
+  const tokenInput = document.getElementById('admin-token');
+  const say = (message, kind = '') => {
+    status.textContent = message || '';
+    status.dataset.kind = kind;
+  };
+  const authHeaders = () => {
+    const token = tokenInput.value.trim();
+    if (!token) throw new Error('Admin token is required for remote changes.');
+    return { 'Content-Type': 'application/json', 'Authorization': 'Bearer ' + token };
+  };
+  const users = (value) => value.split(/[\\s,]+/).map((x) => x.trim()).filter(Boolean);
+  document.querySelectorAll('.access-form').forEach((form) => {
+    form.addEventListener('submit', async (event) => {
+      event.preventDefault();
+      const slug = form.dataset.slug;
+      const access = {
+        visibility: form.elements.visibility.value,
+        history_visibility: form.elements.history_visibility.value,
+        commenting: form.elements.commenting.value,
+        allowed_users: users(form.elements.allowed_users.value),
+      };
+      say('Saving access...');
+      let headers;
+      try { headers = authHeaders(); } catch (e) { say(e.message, 'error'); return; }
+      const res = await fetch('/api/doc/access', {
+        method: 'PATCH',
+        headers,
+        body: JSON.stringify({ slug, access }),
+      });
+      if (!res.ok) {
+        let body = {};
+        try { body = await res.json(); } catch {}
+        say(body.error ? 'Access save failed: ' + body.error : 'Access save failed.', 'error');
+        return;
+      }
+      say('Access saved for ' + slug + '.', 'ok');
+    });
+  });
+  document.querySelectorAll('.delete-doc').forEach((button) => {
+    button.addEventListener('click', async () => {
+      const slug = button.dataset.slug;
+      const title = button.dataset.title || slug;
+      if (!confirm('Delete "' + title + '" from remote storage? This removes all versions and comments.')) return;
+      say('Deleting ' + slug + '...');
+      let headers;
+      try { headers = authHeaders(); } catch (e) { say(e.message, 'error'); return; }
+      const res = await fetch('/api/doc?slug=' + encodeURIComponent(slug), {
+        method: 'DELETE',
+        headers,
+      });
+      if (!res.ok) {
+        let body = {};
+        try { body = await res.json(); } catch {}
+        say(body.error ? 'Delete failed: ' + body.error : 'Delete failed.', 'error');
+        return;
+      }
+      button.closest('tr').remove();
+      say('Deleted ' + slug + ' from remote storage.', 'ok');
+    });
+  });
+})();
+</script>
 </body></html>`;
 }
 


### PR DESCRIPTION
## Summary
- add remote access controls to owner-only /me catalog (visibility, history visibility, commenting, allowed users)
- add remote delete action from /me using the existing DELETE /api/doc endpoint
- require the upload/admin token for remote writes instead of relying on owner cookies, because published docs are arbitrary same-origin HTML
- document and test the /me management security contract

## Verification
- node test/me-management.test.js
- node test/remote-access-route.test.js
- node test/access.test.js
- node test/run.js (fails only at the existing local Node 18 coverage bundle syntax check: export class CommentsStore; new suites pass before that)

## Notes
This intentionally does not solve hosted identity or tokenless OOB management. It gives the current owner catalog a remote SoT management surface without exposing TDOC_UPLOAD_TOKEN or authorizing destructive writes via same-origin owner cookies.