### PR TITLE
test: check worker bundle as an ES module

### DIFF
--- a/test/coverage.test.js
+++ b/test/coverage.test.js
@@ -183,7 +183,10 @@ t('BUNDLE: inlining replaces the placeholder with the real overlay, valid JS', (
     'active OVERLAY_JS placeholder still present after bundle');
   assert(/const OVERLAY_JS = "/.test(replaced), 'overlay was not inlined as a string');
   // bundled output must be syntactically valid JS
-  const tmp = path.join(os.tmpdir(), `tdoc-bundle-${Date.now()}.js`);
+  // The Worker bundle is an ES module (`export default` / exported classes).
+  // Node 18's `--check file.js` parses as CommonJS when package.json has no
+  // `"type": "module"`, so use .mjs here to validate the actual runtime shape.
+  const tmp = path.join(os.tmpdir(), `tdoc-bundle-${Date.now()}.mjs`);
   fs.writeFileSync(tmp, replaced);
   try {
     execFileSync(process.execPath, ['--check', tmp], { stdio: 'pipe' });


### PR DESCRIPTION
## Summary
- fix the local Node 18 coverage test by checking the bundled Worker output as an ES module (`.mjs`)
- matches the actual Worker/Vercel bundle shape (`export default` / exported classes)

## Verification
- `node test/coverage.test.js`
- `node test/run.js` — PASS, all 21 offline suites green

## Notes
This is test-only. It removes the local full-suite caveat we had been carrying after #103/#104.
