### PR TITLE
Expose runtime provenance and hash-based redeploy

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,8 @@ Same document snapshots; different roles (see [AGENTS.md](AGENTS.md)):
 
 Overlay code is bundled into the hosted runtime at publish time from the skill
 checkout; local overlay edits only affect Local Studio until the next publish
-redeploy.
+redeploy. Published pages also expose the bundled runtime provenance at
+`/api/runtime` and in `window.__TDOC__.runtime`.
 
 ## How comments work
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -417,10 +417,12 @@ GitHub sign-in) work identically on either host. Caveats: no per-doc write
 serialization (Cloudflare uses a Durable Object for that) and a ~4.5 MB upload
 cap per doc (Vercel request limit).
 
-Subsequent runs upload the latest version of `<slug>`. The script also detects
-when `server/overlay.js` or `worker/worker.js` is newer than the bundled file
-and redeploys the Worker automatically so users get the latest overlay code.
+Subsequent runs upload the latest version of `<slug>`. The script compares a
+content hash of the Worker/overlay bundle against the last deployed hash in
+`~/.tdoc/published.json` and redeploys automatically when runtime code changed.
 Set `TDOC_SKIP_WORKER_DEPLOY=1` to skip the redeploy (useful for batch uploads).
+Published pages expose runtime provenance at `/api/runtime` and in
+`window.__TDOC__.runtime`.
 
 On published docs, viewers sign in with GitHub (Device Flow, shared OAuth App
 `Ov23liZ1UAGOchvKPmlS`, scope `read:user`) before commenting.

--- a/bin/tdoc-publish
+++ b/bin/tdoc-publish
@@ -220,11 +220,30 @@ bundle_worker() {
   OUT_DIR="$out_dir" node -e '
     const fs = require("fs");
     const path = require("path");
+    const crypto = require("crypto");
+    const cp = require("child_process");
     const skill = process.env.SKILL_DIR;
     const worker = fs.readFileSync(path.join(skill, "worker/worker.js"), "utf8");
     const overlay = fs.readFileSync(path.join(skill, "server/overlay.js"), "utf8");
-    // Replace the whole declaration so JSON.stringify safely escapes everything.
-    const replaced = worker.replace(
+    const sha = (s) => crypto.createHash("sha256").update(s).digest("hex");
+    const git = (...args) => {
+      try { return cp.execFileSync("git", ["-C", skill, ...args], { encoding: "utf8", stdio: ["ignore", "pipe", "ignore"] }).trim(); }
+      catch { return ""; }
+    };
+    const sourceSha = git("rev-parse", "--short=12", "HEAD") || null;
+    const sourceDirty = !!git("status", "--porcelain", "--untracked-files=no");
+    const bundleSha = sha(worker + "\0" + overlay);
+    const build = {
+      source_sha: sourceSha,
+      source_dirty: sourceDirty,
+      worker_sha: sha(worker).slice(0, 12),
+      overlay_sha: sha(overlay).slice(0, 12),
+      bundle_sha: bundleSha.slice(0, 12),
+      built_at: new Date().toISOString(),
+      generated_by: "tdoc-publish",
+    };
+    // Replace whole declarations so JSON.stringify safely escapes everything.
+    let replaced = worker.replace(
       /const OVERLAY_JS = `__TDOC_OVERLAY_JS__`;/,
       "const OVERLAY_JS = " + JSON.stringify(overlay) + ";"
     );
@@ -232,9 +251,58 @@ bundle_worker() {
       console.error("bundle: failed to find OVERLAY_JS placeholder");
       process.exit(1);
     }
+    const withBuild = replaced.replace(
+      /const TDOC_BUILD_INFO = "__TDOC_BUILD_INFO__";/,
+      "const TDOC_BUILD_INFO = " + JSON.stringify(build) + ";"
+    );
+    if (withBuild === replaced) {
+      console.error("bundle: failed to find TDOC_BUILD_INFO placeholder");
+      process.exit(1);
+    }
+    replaced = withBuild;
     fs.writeFileSync(path.join(process.env.OUT_DIR, "_worker.bundled.js"), replaced);
+    fs.writeFileSync(path.join(process.env.OUT_DIR, "_worker.bundled.sha256"), bundleSha + "\n");
   '
   echo "bundled: $out"
+}
+
+worker_bundle_sha() {
+  node -e '
+    const fs = require("fs");
+    const path = require("path");
+    const crypto = require("crypto");
+    const skill = process.env.SKILL_DIR;
+    const worker = fs.readFileSync(path.join(skill, "worker/worker.js"), "utf8");
+    const overlay = fs.readFileSync(path.join(skill, "server/overlay.js"), "utf8");
+    process.stdout.write(crypto.createHash("sha256").update(worker + "\0" + overlay).digest("hex"));
+  '
+}
+
+vercel_bundle_sha() {
+  node -e '
+    const fs = require("fs");
+    const path = require("path");
+    const crypto = require("crypto");
+    const skill = process.env.SKILL_DIR;
+    const h = crypto.createHash("sha256");
+    for (const rel of ["worker/worker.js", "server/overlay.js"]) {
+      h.update(rel); h.update("\0"); h.update(fs.readFileSync(path.join(skill, rel))); h.update("\0");
+    }
+    const dir = path.join(skill, "vercel");
+    const walk = (d) => {
+      for (const name of fs.readdirSync(d).sort()) {
+        const p = path.join(d, name);
+        const st = fs.statSync(p);
+        if (st.isDirectory()) walk(p);
+        else {
+          const rel = path.relative(skill, p);
+          h.update(rel); h.update("\0"); h.update(fs.readFileSync(p)); h.update("\0");
+        }
+      }
+    };
+    walk(dir);
+    process.stdout.write(h.digest("hex"));
+  '
 }
 
 first_time_setup() {
@@ -546,14 +614,15 @@ if [ "$PLATFORM" = "vercel" ]; then
   CUSTOM_DOMAIN=""
   [ -n "$PUBLIC_HOST" ] || PUBLIC_HOST="${BASE#https://}"
 
-  # --- redeploy if worker/overlay/template is newer than the bundled file ---
+  # --- redeploy if worker/overlay/template content changed ---
   # Skipped via TDOC_SKIP_WORKER_DEPLOY=1 (useful for batch uploads in tests).
+  # Store a content hash in published.json so copied files, clock skew, or
+  # stale mtimes cannot make "already deployed" look true.
   BUNDLED="$VERCEL_APP_DIR/_worker.bundled.js"
   if [ "${TDOC_SKIP_WORKER_DEPLOY:-0}" != "1" ]; then
-    if [ ! -f "$BUNDLED" ] \
-      || [ "$SKILL_DIR/server/overlay.js" -nt "$BUNDLED" ] \
-      || [ "$SKILL_DIR/worker/worker.js" -nt "$BUNDLED" ] \
-      || [ -n "$(find "$SKILL_DIR/vercel" -type f -newer "$BUNDLED" 2>/dev/null | head -1)" ]; then
+    DESIRED_BUNDLE_SHA="$(SKILL_DIR="$SKILL_DIR" vercel_bundle_sha)"
+    DEPLOYED_BUNDLE_SHA="$(jq -r '.vercel_bundle_sha256 // empty' "$CONFIG_FILE")"
+    if [ ! -f "$BUNDLED" ] || [ "$DESIRED_BUNDLE_SHA" != "$DEPLOYED_BUNDLE_SHA" ]; then
       require_vercel
       echo "[tdoc] worker code changed locally — redeploying to Vercel..."
       sync_vercel_app
@@ -565,6 +634,8 @@ if [ "$PLATFORM" = "vercel" ]; then
           && mv "$CONFIG_FILE.tmp" "$CONFIG_FILE" && chmod 600 "$CONFIG_FILE"
         BASE="$NEW_BASE"
       fi
+      jq --arg sha "$DESIRED_BUNDLE_SHA" '.vercel_bundle_sha256 = $sha' "$CONFIG_FILE" > "$CONFIG_FILE.tmp" \
+        && mv "$CONFIG_FILE.tmp" "$CONFIG_FILE" && chmod 600 "$CONFIG_FILE"
     fi
   fi
   UPLOAD_BASE="$BASE"
@@ -591,13 +662,15 @@ else
   UPLOAD_BASE="https://${WORKER_NAME}.${SUBDOMAIN}.workers.dev"
   PUBLIC_BASE="https://${PUBLIC_HOST}"
 
-  # --- redeploy worker if overlay.js / worker.js is newer than the bundled file ---
+  # --- redeploy worker if overlay.js / worker.js content changed ---
   # Skipped via TDOC_SKIP_WORKER_DEPLOY=1 (useful for batch uploads in tests).
+  # Do not trust mtimes here: copied files and branch switches can preserve or
+  # skew timestamps. The content hash is the release contract.
   BUNDLED="$WORKER_DIR/_worker.bundled.js"
   if [ "${TDOC_SKIP_WORKER_DEPLOY:-0}" != "1" ]; then
-    if [ ! -f "$BUNDLED" ] \
-      || [ "$SKILL_DIR/server/overlay.js" -nt "$BUNDLED" ] \
-      || [ "$SKILL_DIR/worker/worker.js" -nt "$BUNDLED" ]; then
+    DESIRED_BUNDLE_SHA="$(SKILL_DIR="$SKILL_DIR" worker_bundle_sha)"
+    DEPLOYED_BUNDLE_SHA="$(jq -r '.worker_bundle_sha256 // empty' "$CONFIG_FILE")"
+    if [ ! -f "$BUNDLED" ] || [ "$DESIRED_BUNDLE_SHA" != "$DEPLOYED_BUNDLE_SHA" ]; then
       require_wrangler
       echo "[tdoc] worker code changed locally — redeploying..."
       # Backfill TDOC_OWNER into an existing wrangler.toml that predates the
@@ -621,6 +694,8 @@ else
       fi
       SKILL_DIR="$SKILL_DIR" bundle_worker
       (cd "$WORKER_DIR" && wrangler deploy)
+      jq --arg sha "$DESIRED_BUNDLE_SHA" '.worker_bundle_sha256 = $sha' "$CONFIG_FILE" > "$CONFIG_FILE.tmp" \
+        && mv "$CONFIG_FILE.tmp" "$CONFIG_FILE" && chmod 600 "$CONFIG_FILE"
     fi
   fi
 fi

--- a/skills/tdoc/SKILL.md
+++ b/skills/tdoc/SKILL.md
@@ -415,10 +415,12 @@ GitHub sign-in) work identically on either host. Caveats: no per-doc write
 serialization (Cloudflare uses a Durable Object for that) and a ~4.5 MB upload
 cap per doc (Vercel request limit).
 
-Subsequent runs upload the latest version of `<slug>`. The script also detects
-when `server/overlay.js` or `worker/worker.js` is newer than the bundled file
-and redeploys the Worker automatically so users get the latest overlay code.
+Subsequent runs upload the latest version of `<slug>`. The script compares a
+content hash of the Worker/overlay bundle against the last deployed hash in
+`~/.tdoc/published.json` and redeploys automatically when runtime code changed.
 Set `TDOC_SKIP_WORKER_DEPLOY=1` to skip the redeploy (useful for batch uploads).
+Published pages expose runtime provenance at `/api/runtime` and in
+`window.__TDOC__.runtime`.
 
 On published docs, viewers sign in with GitHub (Device Flow, shared OAuth App
 `Ov23liZ1UAGOchvKPmlS`, scope `read:user`) before commenting.

--- a/test/coverage.test.js
+++ b/test/coverage.test.js
@@ -175,6 +175,17 @@ t('BUNDLE: inlining replaces the placeholder with the real overlay, valid JS', (
   const replaced = worker.replace(
     /const OVERLAY_JS = `__TDOC_OVERLAY_JS__`;/,
     'const OVERLAY_JS = ' + JSON.stringify(overlay) + ';'
+  ).replace(
+    /const TDOC_BUILD_INFO = "__TDOC_BUILD_INFO__";/,
+    'const TDOC_BUILD_INFO = ' + JSON.stringify({
+      source_sha: 'testsha',
+      source_dirty: false,
+      worker_sha: 'worker123',
+      overlay_sha: 'overlay123',
+      bundle_sha: 'bundle123',
+      built_at: '2026-01-01T00:00:00.000Z',
+      generated_by: 'coverage.test',
+    }) + ';'
   );
   assert(replaced !== worker, 'placeholder not found — bundle would fail');
   // The ACTIVE placeholder (the const declaration) must be gone. A mention in a
@@ -182,6 +193,9 @@ t('BUNDLE: inlining replaces the placeholder with the real overlay, valid JS', (
   assert(!/const OVERLAY_JS = `__TDOC_OVERLAY_JS__`;/.test(replaced),
     'active OVERLAY_JS placeholder still present after bundle');
   assert(/const OVERLAY_JS = "/.test(replaced), 'overlay was not inlined as a string');
+  assert(!/const TDOC_BUILD_INFO = "__TDOC_BUILD_INFO__";/.test(replaced),
+    'active TDOC_BUILD_INFO placeholder still present after bundle');
+  assert(/const TDOC_BUILD_INFO = \{/.test(replaced), 'build info was not inlined as an object');
   // bundled output must be syntactically valid JS
   // The Worker bundle is an ES module (`export default` / exported classes).
   // Node 18's `--check file.js` parses as CommonJS when package.json has no

--- a/test/run.js
+++ b/test/run.js
@@ -24,6 +24,7 @@ const OFFLINE = [
   'access.test.js',           // JUL-31 access policy (public/unlisted/private)
   'remote-access-route.test.js', // remote access mutation auth + meta-only guard
   'me-management.test.js',    // /me remote SoT management UI guard
+  'runtime-provenance.test.js', // release provenance + content-hash redeploy
   'oldver-strip.test.js',     // old-version banner predicate
   'cli.test.js',              // CLI resilience (drives bash hermetically)
   'no-drift.test.js',         // duplicated-helper drift guard

--- a/test/runtime-provenance.test.js
+++ b/test/runtime-provenance.test.js
@@ -1,0 +1,88 @@
+// Runtime provenance and release redeploy guards.
+//
+// A published page must be able to identify the runtime bundle that served it,
+// and publish must decide redeploy by source content hash, not mtimes.
+
+const fs = require('fs');
+const path = require('path');
+
+let pass = 0, fail = 0;
+function ok(n) { console.log(`  ✓ ${n}`); pass++; }
+function bad(n, e) { console.log(`  ✗ ${n}\n    ${e}`); fail++; }
+function t(n, fn) { try { fn(); ok(n); } catch (e) { bad(n, e.message); } }
+function assert(c, m) { if (!c) throw new Error(m || 'assertion failed'); }
+
+const root = path.join(__dirname, '..');
+const worker = fs.readFileSync(path.join(root, 'worker', 'worker.js'), 'utf8');
+const publish = fs.readFileSync(path.join(root, 'bin', 'tdoc-publish'), 'utf8');
+const RUNTIME_PUBLIC_KEYS = [
+  'service',
+  'mode',
+  'source_sha',
+  'source_dirty',
+  'worker_sha',
+  'overlay_sha',
+  'bundle_sha',
+  'built_at',
+  'generated_by',
+];
+
+function runtimeInfoPublicKeys() {
+  const start = worker.indexOf('function runtimeInfo()');
+  const end = worker.indexOf('\nfunction parseCookie', start);
+  assert(start !== -1 && end !== -1, 'runtimeInfo function must be parseable');
+  const block = worker.slice(start, end);
+  const m = block.match(/return\s*\{([\s\S]*?)\n\s*\};/);
+  assert(m, 'runtimeInfo must return an object literal');
+  assert(!/^\s*\.\.\./m.test(m[1]), 'runtimeInfo must not spread arbitrary build/env objects');
+  return Array.from(m[1].matchAll(/^\s*([A-Za-z_][A-Za-z0-9_]*)\s*:/gm), (hit) => hit[1]);
+}
+
+console.log('runtime provenance');
+
+t('Worker has a bundled build-info placeholder and runtime endpoint', () => {
+  assert(worker.includes('const TDOC_BUILD_INFO = "__TDOC_BUILD_INFO__";'),
+    'worker must expose a build-info placeholder for bundling');
+  assert(worker.includes("if (p === '/api/runtime') return json({ ok: true, runtime: runtimeInfo() });"),
+    'worker must expose /api/runtime');
+  assert(worker.includes("runtime: cfg.runtime || runtimeInfo()"),
+    'published boot config must include runtime provenance');
+});
+
+t('/api/ping stays backward-compatible and minimal', () => {
+  assert(worker.includes("if (p === '/api/ping') return json({ ok: true, service: 'tdoc' });"),
+    '/api/ping should remain a simple health check');
+});
+
+t('/api/runtime exposes only the intended public provenance fields', () => {
+  const actual = runtimeInfoPublicKeys();
+  assert(JSON.stringify(actual) === JSON.stringify(RUNTIME_PUBLIC_KEYS),
+    `/api/runtime field set changed: ${JSON.stringify(actual)}`);
+  assert(!worker.includes('leaked_token'), '/api/runtime test must catch accidental secret-looking fields');
+});
+
+t('publish bundles deterministic provenance fields', () => {
+  for (const field of ['source_sha', 'source_dirty', 'worker_sha', 'overlay_sha', 'bundle_sha', 'generated_by']) {
+    assert(publish.includes(field), `bundle build info missing ${field}`);
+  }
+  assert(publish.includes('const TDOC_BUILD_INFO = "__TDOC_BUILD_INFO__";'),
+    'publish must replace the TDOC_BUILD_INFO declaration');
+});
+
+t('publish redeploys by stored content hash, not mtimes', () => {
+  assert(publish.includes('worker_bundle_sha256'), 'cloudflare publish must persist worker_bundle_sha256');
+  assert(publish.includes('vercel_bundle_sha256'), 'vercel publish must persist vercel_bundle_sha256');
+  assert(publish.includes('worker_bundle_sha()'), 'cloudflare publish must compute desired content hash');
+  assert(publish.includes('vercel_bundle_sha()'), 'vercel publish must compute desired content hash');
+  assert(publish.includes('DESIRED_BUNDLE_SHA') && publish.includes('DEPLOYED_BUNDLE_SHA'),
+    'publish must compare desired hash to deployed hash');
+  assert(!publish.includes('server/overlay.js" -nt "$BUNDLED"'),
+    'mtime-based overlay redeploy check must not come back');
+  assert(!publish.includes('worker/worker.js" -nt "$BUNDLED"'),
+    'mtime-based worker redeploy check must not come back');
+  assert(!publish.includes('find "$SKILL_DIR/vercel" -type f -newer "$BUNDLED"'),
+    'mtime-based Vercel template redeploy check must not come back');
+});
+
+console.log(`\n${pass} passed, ${fail} failed`);
+process.exit(fail ? 1 : 0);

--- a/worker/worker.js
+++ b/worker/worker.js
@@ -8,12 +8,13 @@
 // Secrets:
 //   TDOC_UPLOAD_TOKEN — shared secret for /api/upload from `tdoc publish`
 //
-// IMPORTANT: This file contains a placeholder string `__TDOC_OVERLAY_JS__`.
-// The publish script reads server/overlay.js and replaces that placeholder
-// inline before deploy, producing worker/_worker.bundled.js. Do not deploy
-// worker.js directly — the overlay would be missing.
+// IMPORTANT: This file contains placeholder strings `__TDOC_OVERLAY_JS__` and
+// `__TDOC_BUILD_INFO__`. The publish script replaces them before deploy,
+// producing worker/_worker.bundled.js. Do not deploy worker.js directly — the
+// overlay/provenance would be missing.
 
 const OVERLAY_JS = `__TDOC_OVERLAY_JS__`;
+const TDOC_BUILD_INFO = "__TDOC_BUILD_INFO__";
 
 const CORS = {
   'Access-Control-Allow-Origin': '*',
@@ -38,6 +39,21 @@ function html(body, init = {}) {
     status: init.status || 200,
     headers: { 'Content-Type': 'text/html; charset=utf-8', ...(init.headers || {}) },
   });
+}
+
+function runtimeInfo() {
+  const b = TDOC_BUILD_INFO && typeof TDOC_BUILD_INFO === 'object' ? TDOC_BUILD_INFO : {};
+  return {
+    service: 'tdoc',
+    mode: 'published',
+    source_sha: b.source_sha || null,
+    source_dirty: !!b.source_dirty,
+    worker_sha: b.worker_sha || null,
+    overlay_sha: b.overlay_sha || null,
+    bundle_sha: b.bundle_sha || null,
+    built_at: b.built_at || null,
+    generated_by: b.generated_by || 'unknown',
+  };
 }
 
 function parseCookie(req) {
@@ -794,8 +810,9 @@ function reconcileAnchors(comments, aidsInVersion, V) {
 // the published view and the /fork view (which previously re-implemented this
 // inline, risking drift).
 function injectOverlayCfg(rawHtml, cfg) {
+  const bootCfg = { ...cfg, runtime: cfg.runtime || runtimeInfo() };
   const inject =
-    `<script>window.__TDOC__ = ${safeJsonForScript(cfg)};</script>\n` +
+    `<script>window.__TDOC__ = ${safeJsonForScript(bootCfg)};</script>\n` +
     `<script>${OVERLAY_JS}</script>`;
   if (rawHtml.includes('</body>')) return rawHtml.replace('</body>', `${inject}\n</body>`);
   return rawHtml + inject;
@@ -1789,6 +1806,7 @@ export default {
     if (method === 'OPTIONS') return new Response(null, { status: 204, headers: CORS });
 
     if (p === '/api/ping') return json({ ok: true, service: 'tdoc' });
+    if (p === '/api/runtime') return json({ ok: true, runtime: runtimeInfo() });
 
     // ---- landing (NO public catalog) ----
     // `/` never lists docs. Docs are only reachable via their direct link.


### PR DESCRIPTION
## Summary
- add bundled runtime provenance to published docs via `window.__TDOC__.runtime`
- add `/api/runtime` for deployed Worker self-identification
- replace mtime-based Worker/Vercel redeploy detection with stored content hashes in `~/.tdoc/published.json`
- document the runtime provenance surface and hash redeploy behavior

## Verification
- `node test/runtime-provenance.test.js`
- `node test/coverage.test.js`
- `node test/run.js` (PASS: all 22 offline suites green)

## Notes
- This PR intentionally does not touch GitHub OAuth / #99.
- Do not merge until Julie explicitly approves; opened while she is sleeping for review only.