### PR TITLE
Fix access policy write validation

### DIFF
--- a/test/access.test.js
+++ b/test/access.test.js
@@ -155,5 +155,90 @@ t('remote access patch rejects non-access fields', () => {
   assert(JSON.stringify(r.fields) === JSON.stringify(['owner']), `unexpected fields ${JSON.stringify(r.fields)}`);
 });
 
+t('access write validation keeps legacy read fallback out of write paths', () => {
+  const valid = box.validateAccessWrite({
+    visibility: 'private',
+    commenting: 'owner',
+    history_visibility: 'owner',
+    allowed_users: ['@Alice', 'github:bob'],
+  });
+  assert(!valid.error, `unexpected error ${valid.error}`);
+  assert(JSON.stringify(valid.access.allowed_users) === JSON.stringify(['alice', 'bob']));
+
+  for (const patch of [
+    { visibility: 'privat' },
+    { commenting: 'signedin' },
+    { history_visibility: 'everyone' },
+    { allowed_users: ['not valid!'] },
+  ]) {
+    const r = box.validateAccessWrite(patch);
+    assert(r.error === 'invalid_access_value', `expected invalid_access_value for ${JSON.stringify(patch)}`);
+  }
+});
+
+t('remote access patch rejects invalid enum values instead of silently downgrading', () => {
+  const meta = {
+    title: 'Doc',
+    access: {
+      visibility: 'private',
+      history_visibility: 'owner',
+      commenting: 'owner',
+      allowed_users: ['alice'],
+    },
+  };
+  const r = box.applyAccessPatch(meta, { visibility: 'privat' });
+  assert(r.error === 'invalid_access_value', `expected invalid_access_value, got ${r.error}`);
+  assert(r.field === 'visibility', `unexpected field ${r.field}`);
+  assert(meta.access.visibility === 'private', 'input meta must remain private');
+});
+
+t('remote access patch rejects invalid commenting values instead of broadening writers', () => {
+  const meta = {
+    title: 'Doc',
+    access: { visibility: 'private', history_visibility: 'owner', commenting: 'owner', allowed_users: ['alice'] },
+  };
+  const r = box.applyAccessPatch(meta, { commenting: 'signedin' });
+  assert(r.error === 'invalid_access_value', `expected invalid_access_value, got ${r.error}`);
+  assert(r.field === 'commenting', `unexpected field ${r.field}`);
+  assert(meta.access.commenting === 'owner', 'input meta must remain owner-only');
+});
+
+t('remote access patch rejects invalid history visibility values', () => {
+  const meta = {
+    title: 'Doc',
+    access: { visibility: 'private', history_visibility: 'owner', commenting: 'owner', allowed_users: ['alice'] },
+  };
+  const r = box.applyAccessPatch(meta, { history_visibility: 'everyone' });
+  assert(r.error === 'invalid_access_value', `expected invalid_access_value, got ${r.error}`);
+  assert(r.field === 'history_visibility', `unexpected field ${r.field}`);
+  assert(meta.access.history_visibility === 'owner', 'input meta history policy must not change');
+});
+
+t('remote access patch rejects invalid allowlist entries instead of silently clearing them', () => {
+  const r = box.applyAccessPatch({ title: 'Doc' }, { allowed_users: ['alice', 'not valid!'] });
+  assert(r.error === 'invalid_access_value', `expected invalid_access_value, got ${r.error}`);
+  assert(r.field === 'allowed_users', `unexpected field ${r.field}`);
+});
+
+t('remote access patch treats JSON-present null/empty values as invalid writes', () => {
+  for (const [field, value] of [
+    ['visibility', null],
+    ['commenting', ''],
+    ['history_visibility', ''],
+    ['allowed_users', null],
+  ]) {
+    const patch = JSON.parse(JSON.stringify({ [field]: value }));
+    const r = box.applyAccessPatch({ title: 'Doc' }, patch);
+    assert(r.error === 'invalid_access_value', `${field} should reject ${value}`);
+    assert(r.field === field, `unexpected field for ${field}: ${r.field}`);
+  }
+});
+
+t('remote access patch rejects empty JSON patch after undefined fields are omitted', () => {
+  const patch = JSON.parse(JSON.stringify({ visibility: undefined }));
+  const r = box.applyAccessPatch({ title: 'Doc' }, patch);
+  assert(r.error === 'access patch required', `expected access patch required, got ${r.error}`);
+});
+
 console.log(`\n${pass} passed, ${fail} failed`);
 process.exit(fail ? 1 : 0);

--- a/test/remote-access-route.test.js
+++ b/test/remote-access-route.test.js
@@ -19,6 +19,11 @@ const end = worker.indexOf('// ---- admin delete ----', start);
 if (start < 0 || end < 0 || end <= start) throw new Error('/api/doc/access route block missing');
 const route = worker.slice(start, end);
 
+const uploadStart = worker.indexOf("if (p === '/api/upload' && method === 'POST')");
+const uploadEnd = worker.indexOf('// ---- admin access mutation ----', uploadStart);
+if (uploadStart < 0 || uploadEnd < 0 || uploadEnd <= uploadStart) throw new Error('/api/upload route block missing');
+const uploadRoute = worker.slice(uploadStart, uploadEnd);
+
 console.log('remote access mutation route');
 
 t('CORS allows PATCH for remote access mutation', () => {
@@ -48,6 +53,24 @@ t('PATCH /api/doc/access only writes remote meta, never document bytes', () => {
 t('PATCH /api/doc/access rejects top-level fields outside slug/access', () => {
   assert(route.includes("k !== 'slug' && k !== 'access'"), 'route must whitelist top-level fields');
   assert(route.includes("json({ error: 'invalid_field'"), 'route must reject top-level unknown fields');
+});
+
+t('PATCH /api/doc/access returns invalid value details without writing', () => {
+  assert(route.includes("error: next.error"), 'route should surface helper errors');
+  assert(route.includes("field: next.field"), 'route should surface the invalid access field');
+  const error = route.indexOf('if (next.error)');
+  const write = route.indexOf('env.META.put(`meta:${slug}`');
+  assert(error >= 0 && write >= 0 && error < write, 'route must reject invalid access before META write');
+});
+
+t('POST /api/upload validates incoming access before writing document bytes', () => {
+  assert(uploadRoute.includes('validateAccessWrite(incoming.access)'), 'upload route must validate incoming access');
+  const validate = uploadRoute.indexOf('validateAccessWrite(incoming.access)');
+  const r2Write = uploadRoute.indexOf('env.DOCS.put');
+  const metaWrite = uploadRoute.indexOf('env.META.put(`meta:${slug}`');
+  assert(validate >= 0 && r2Write >= 0 && metaWrite >= 0, 'upload route missing validation/R2/meta operations');
+  assert(validate < r2Write, 'upload must reject invalid access before writing R2 document bytes');
+  assert(validate < metaWrite, 'upload must reject invalid access before writing meta');
 });
 
 console.log(`\n${pass} passed, ${fail} failed`);

--- a/worker/worker.js
+++ b/worker/worker.js
@@ -158,6 +158,51 @@ function accessFromMeta(meta) {
   return normalizeAccess(has ? meta.access : null, { legacy: !has });
 }
 
+function validateAccessWrite(access) {
+  if (!access || typeof access !== 'object' || Array.isArray(access)) {
+    return { error: 'access object required' };
+  }
+  const keys = Object.keys(access);
+  const unknown = keys.filter((k) => !ACCESS_PATCH_FIELDS.has(k));
+  if (unknown.length) return { error: 'invalid_access_field', fields: unknown };
+
+  const out = {};
+  if ('visibility' in access) {
+    if (!ACCESS_VISIBILITIES.has(access.visibility)) {
+      return { error: 'invalid_access_value', field: 'visibility' };
+    }
+    out.visibility = access.visibility;
+  }
+  if ('commenting' in access) {
+    if (!ACCESS_COMMENTING.has(access.commenting)) {
+      return { error: 'invalid_access_value', field: 'commenting' };
+    }
+    out.commenting = access.commenting;
+  }
+  if ('history_visibility' in access) {
+    if (!ACCESS_HISTORY.has(access.history_visibility)) {
+      return { error: 'invalid_access_value', field: 'history_visibility' };
+    }
+    out.history_visibility = access.history_visibility;
+  }
+  if ('allowed_users' in access) {
+    if (!Array.isArray(access.allowed_users)) {
+      return { error: 'invalid_access_value', field: 'allowed_users' };
+    }
+    const allowed = [];
+    const seen = new Set();
+    for (const item of access.allowed_users) {
+      const login = normalizeGithubLogin(item);
+      if (!login) return { error: 'invalid_access_value', field: 'allowed_users' };
+      if (seen.has(login)) continue;
+      seen.add(login);
+      allowed.push(login);
+    }
+    out.allowed_users = allowed;
+  }
+  return { access: out };
+}
+
 function applyAccessPatch(meta, patch) {
   if (!meta || typeof meta !== 'object' || Array.isArray(meta)) {
     return { error: 'missing_meta' };
@@ -167,8 +212,8 @@ function applyAccessPatch(meta, patch) {
   }
   const keys = Object.keys(patch);
   if (!keys.length) return { error: 'access patch required' };
-  const unknown = keys.filter((k) => !ACCESS_PATCH_FIELDS.has(k));
-  if (unknown.length) return { error: 'invalid_access_field', fields: unknown };
+  const validated = validateAccessWrite(patch);
+  if (validated.error) return validated;
 
   // A remote access mutation creates/updates only the access policy. If the doc
   // has legacy meta without access, switch to product defaults instead of
@@ -176,7 +221,7 @@ function applyAccessPatch(meta, patch) {
   const base = meta.access && typeof meta.access === 'object'
     ? normalizeAccess(meta.access, { legacy: false })
     : normalizeAccess({}, { legacy: false });
-  const next = normalizeAccess({ ...base, ...patch }, { legacy: false });
+  const next = normalizeAccess({ ...base, ...validated.access }, { legacy: false });
   return { meta: { ...meta, access: next }, access: next };
 }
 
@@ -2277,6 +2322,27 @@ export default {
       if (!isValidSlug(slug)) return json({ error: 'invalid_slug' }, { status: 400 });
       const verNum = Number(version);
       if (!Number.isInteger(verNum) || verNum < 1) return json({ error: 'invalid_version' }, { status: 400 });
+      // Validate write-side access policy before writing doc bytes. Read paths
+      // stay tolerant for legacy/corrupt stored meta; writes must fail closed.
+      let incoming = null;
+      if (meta) {
+        incoming = (meta && typeof meta === 'object') ? { ...meta } : {};
+        let prev = null;
+        try {
+          const prevRaw = await env.META.get(`meta:${slug}`);
+          if (prevRaw) prev = JSON.parse(prevRaw);
+        } catch {}
+        if (!incoming.access && prev && prev.access) {
+          incoming.access = prev.access;
+        }
+        if (incoming.access) {
+          const validatedAccess = validateAccessWrite(incoming.access);
+          if (validatedAccess.error) {
+            return json({ error: validatedAccess.error, ...(validatedAccess.field ? { field: validatedAccess.field } : {}), ...(validatedAccess.fields ? { fields: validatedAccess.fields } : {}) }, { status: 400 });
+          }
+          incoming.access = normalizeAccess(validatedAccess.access, { legacy: false });
+        }
+      }
       // Identity-stamp every commentable artifact with a content-hashed
       // data-tdoc-aid. The SAME artifact in a different version has the
       // SAME aid — so a comment anchored by aid resolves identity-first
@@ -2299,23 +2365,7 @@ export default {
         console.error('[upload] R2 write did not persist:', r2Key);
         return json({ error: 'r2_write_lost', message: 'PUT succeeded but the key is not readable. Re-deploy the worker; the R2 binding may be stale.' }, { status: 500 });
       }
-      if (meta) {
-        // Normalize access policy onto every uploaded meta snapshot. If the
-        // payload omits `access`, keep any previously stored policy (so a
-        // partial republish without access flags does not reset private docs
-        // to public). Only brand-new docs fall through to legacy defaults.
-        const incoming = (meta && typeof meta === 'object') ? { ...meta } : {};
-        let prev = null;
-        try {
-          const prevRaw = await env.META.get(`meta:${slug}`);
-          if (prevRaw) prev = JSON.parse(prevRaw);
-        } catch {}
-        if (!incoming.access && prev && prev.access) {
-          incoming.access = prev.access;
-        }
-        if (incoming.access) {
-          incoming.access = normalizeAccess(incoming.access, { legacy: false });
-        }
+      if (incoming) {
         await env.META.put(`meta:${slug}`, JSON.stringify(incoming));
       }
       // Reconcile existing open comments against the new artifact set:
@@ -2371,7 +2421,7 @@ export default {
       if (!meta) return json({ error: 'not_found' }, { status: 404 });
       const next = applyAccessPatch(meta, access);
       if (next.error) {
-        return json({ error: next.error, ...(next.fields ? { fields: next.fields } : {}) }, { status: 400 });
+        return json({ error: next.error, ...(next.field ? { field: next.field } : {}), ...(next.fields ? { fields: next.fields } : {}) }, { status: 400 });
       }
       await env.META.put(`meta:${slug}`, JSON.stringify(next.meta));
       return json({ ok: true, slug, access: next.access });


### PR DESCRIPTION
## Summary
- reject invalid access enum values and malformed allowlists on write paths instead of silently normalizing them
- keep legacy/corrupt read fallback in normalizeAccess, but require strict values for PATCH /api/doc/access and upload meta.access
- validate upload access before writing R2 document bytes, so malformed policy fails closed without partial doc writes

## Verification
- node test/access.test.js
- node test/remote-access-route.test.js
- node test/run.js
- mutation check: removing visibility validation makes access.test.js fail