### PR TITLE
Keep docs centered when comment pins are visible

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,1 +1,2 @@
 Remote storage is source of truth. Local HTML is disposable. Local skill is authoring/scaffold.
+Published reader invariants are provider-enforced in overlay/worker code and tests, not left only to author HTML or prompts.

--- a/server/overlay.js
+++ b/server/overlay.js
@@ -81,11 +81,11 @@
   body { padding-top: 44px !important; padding-bottom: 24px; -webkit-user-select: text; user-select: text; }
   body .tdoc-bar, body .tdoc-bar *, body #tdoc-comment-layer, body #tdoc-comment-layer *, body #tdoc-pin-layer, body #tdoc-pin-layer *, body .tdoc-cluster-pop, body .tdoc-cluster-pop *, body .tdoc-hover-outline, body .tdoc-comment-pill, body .tdoc-emoji-picker, body .tdoc-secondary-menu, body .tdoc-anchor-mark.tdoc-anchor-mark-element, body .tdoc-drag-marquee, body .tdoc-modal, body .tdoc-modal * { -webkit-user-select: none !important; user-select: none !important; }
   body .tdoc-modal .code, body .tdoc-modal textarea, body .tdoc-modal input { -webkit-user-select: text !important; user-select: text !important; }
-  /* Reserve the comment rail on the right. The body content box becomes the
-     reader area, so article margin:auto centers content in that area exactly
-     instead of using a compensating left gutter. */
-  body.tdoc-has-comments:not(.tdoc-narrow) { padding-right: 360px !important; padding-left: 0 !important; }
-  body.tdoc-narrow { padding-right: 0 !important; }
+  /* Comment pins/cards are provider chrome, not document layout. Keep the
+     document centered in the viewport; if the comment UI cannot fit beside it,
+     narrow mode switches comments into the drawer. */
+  body.tdoc-pins:not(.tdoc-narrow) { padding-right: 0 !important; padding-left: 0 !important; }
+  body.tdoc-narrow { padding-right: 0 !important; padding-left: 0 !important; }
   /* Center the article container in the reading column. :where() so any
      doc-defined margin wins. Applies only on wide layouts; narrow mode
      uses the full body width via the drawer. */
@@ -93,11 +93,8 @@
     margin-left: auto !important;
     margin-right: auto !important;
   }
-  /* The body right-padding reserves space for the comment column. The
-     article centers itself naturally inside the remaining (viewport minus
-     320px) space via its own margin auto. As the window shrinks, the symmetric
-     margins shrink with it; once they hit the article's min width, narrow-mode
-     takes over and the drawer kicks in. */
+  /* The article stays centered in the viewport. As the window shrinks, narrow
+     mode takes over and the drawer kicks in before comment chrome overlaps it. */
   /* ========== Default doc template (single typography template) ==========
      One canonical look for every tdoc doc: same font stack, sizes, spacing,
      headings, lists, code, tables, quotes. Wrapped in :where() so a doc that
@@ -572,6 +569,8 @@
 
   /* Narrow mode (drawer + FAB) — still driven by the layout evaluator so
      it can also kick in when the comment column would crowd the article. */
+  body.tdoc-narrow .tdoc-bar #tdoc-fork-btn, body.tdoc-narrow .tdoc-bar #tdoc-saveas-btn { display: none; }
+  body.tdoc-narrow .tdoc-bar .tdoc-secondary-toggle { display: inline-flex; }
   body.tdoc-narrow #tdoc-comment-layer { position: fixed; top: auto; left: 0; right: 0; bottom: 0; max-height: 70vh; width: 100%; pointer-events: auto; background: #fff; border-top: 1px solid #e5e5e5; box-shadow: 0 -4px 24px rgba(0,0,0,0.08); transform: translateY(100%); transition: transform .2s; overflow-y: auto; padding: 12px 12px 24px; box-sizing: border-box; z-index: 999998; }
   body.tdoc-narrow #tdoc-comment-layer.open { transform: translateY(0); }
   body.tdoc-narrow #tdoc-comment-layer .tdoc-drawer-handle { display: block; width: 36px; height: 4px; background: #ccc; border-radius: 2px; margin: 0 auto 12px; cursor: grab; touch-action: none; user-select: none; }

--- a/test/agent-md.test.js
+++ b/test/agent-md.test.js
@@ -1,11 +1,12 @@
 // AGENTS.md is the durable product rule for agents (auto-loaded by agent hosts).
-// Keep it one line; do not reintroduce ARCHITECTURE.md as a second source of truth.
+// Keep it short; do not reintroduce ARCHITECTURE.md as a second source of truth.
 const fs = require('fs');
 const path = require('path');
 
 const root = path.join(__dirname, '..');
 const expected =
-  'Remote storage is source of truth. Local HTML is disposable. Local skill is authoring/scaffold.\n';
+  'Remote storage is source of truth. Local HTML is disposable. Local skill is authoring/scaffold.\n' +
+  'Published reader invariants are provider-enforced in overlay/worker code and tests, not left only to author HTML or prompts.\n';
 
 let pass = 0, fail = 0;
 function ok(n) { console.log(`  ✓ ${n}`); pass++; }
@@ -15,9 +16,9 @@ function assert(c, m) { if (!c) throw new Error(m || 'assertion failed'); }
 
 console.log('agents.md source-of-truth rule');
 
-t('AGENTS.md exists and is exactly the one-line rule', () => {
+t('AGENTS.md exists and is exactly the short source-of-truth rule', () => {
   const body = fs.readFileSync(path.join(root, 'AGENTS.md'), 'utf8');
-  assert(body === expected, `AGENTS.md must be exactly one line + newline.\nGot:\n${JSON.stringify(body)}`);
+  assert(body === expected, `AGENTS.md must be exactly the guarded short rule.\nGot:\n${JSON.stringify(body)}`);
 });
 
 t('AGENT.md (singular) is not used — hosts auto-read AGENTS.md', () => {

--- a/test/dimensions-audit.js
+++ b/test/dimensions-audit.js
@@ -2,6 +2,8 @@
 // 320 to 1600 and asserts:
 //   - body.tdoc-has-comments && !body.tdoc-narrow  =>  cards sit ENTIRELY to
 //     the right of the doc article (no visual overlap with prose).
+//   - body.tdoc-pins && !body.tdoc-narrow => article stays centered in the
+//     viewport; comment pins are provider chrome and must not shift the doc.
 //   - top bar children all have offsetWidth > 0 (when expected visible).
 //   - no horizontal overflow on documentElement.
 //   - footer (.tdoc-footer) present + within viewport.
@@ -93,6 +95,7 @@ const REQUIRE_FOOTER = process.env.AUDIT_REQUIRE_FOOTER !== '0';
         scrollWidth: docEl.scrollWidth,
         hasComments,
         narrow,
+        pinsMode: body.classList.contains('tdoc-pins'),
         cards,
         article: aRect ? { left: aRect.left, right: aRect.right, width: aRect.width } : null,
         bar: barRect ? { left: barRect.left, right: barRect.right } : null,
@@ -109,13 +112,15 @@ const REQUIRE_FOOTER = process.env.AUDIT_REQUIRE_FOOTER !== '0';
     // legitimately overflow on phone widths; that's the doc author's call, not
     // the overlay's bug. Instead we assert overlay-owned elements stay in bounds.
 
-    // Overlap rule: when has-comments && !narrow, cards must sit to the right
-    // of the article (article.right <= card.left).
+    // Wide comment rules: pinned mode keeps the document centered in the
+    // viewport. If cards are visible, they still must sit to the right of the
+    // article without overlapping prose.
     if (m.hasComments && !m.narrow && m.article) {
-      const readerCenter = (m.innerWidth - 360) / 2;
+      const expectedCenter = m.pinsMode ? (m.innerWidth / 2) : ((m.innerWidth - 360) / 2);
       const articleCenter = (m.article.left + m.article.right) / 2;
-      if (Math.abs(articleCenter - readerCenter) > 2) {
-        errs.push(`article center=${articleCenter.toFixed(0)} not centered in reading area center=${readerCenter.toFixed(0)}`);
+      if (Math.abs(articleCenter - expectedCenter) > 2) {
+        const scope = m.pinsMode ? 'viewport' : 'reading area';
+        errs.push(`article center=${articleCenter.toFixed(0)} not centered in ${scope} center=${expectedCenter.toFixed(0)}`);
       }
       for (const c of m.cards) {
         if (c.right > m.innerWidth + 1) errs.push(`card right=${c.right.toFixed(0)} overflows viewport ${m.innerWidth}`);

--- a/test/publish.test.js
+++ b/test/publish.test.js
@@ -10,8 +10,10 @@ const { spawn } = require('child_process');
 const fs = require('fs');
 const path = require('path');
 const os = require('os');
+const net = require('net');
 
-const PORT = 7895;
+const HOST = '127.0.0.1';
+let PORT = 0;
 const TMP = fs.mkdtempSync(path.join(os.tmpdir(), 'tdoc-pub-'));
 const SLUG = 'publish-test';
 const DOC_DIR = path.join(TMP, SLUG, 'v1');
@@ -26,10 +28,19 @@ function ok(n) { console.log(`  ✓ ${n}`); pass++; }
 function bad(n, e) { console.log(`  ✗ ${n}\n    ${e.stack || e.message || e}`); fail++; }
 async function t(name, fn) { try { await fn(); ok(name); } catch (e) { bad(name, e); } }
 
+function freePort() {
+  return new Promise((resolve, reject) => {
+    const s = net.createServer();
+    s.listen(0, HOST, () => { const p = s.address().port; s.close(() => resolve(p)); });
+    s.on('error', reject);
+  });
+}
+
 (async () => {
+  PORT = await freePort();
   const serverBin = path.join(__dirname, '..', 'server', 'server.js');
   const proc = spawn('node', [serverBin], {
-    env: { ...process.env, TDOC_PORT: String(PORT), TDOC_DIR: TMP, TDOC_DRY_PUBLISH: '1' },
+    env: { ...process.env, TDOC_PORT: String(PORT), TDOC_HOST: HOST, TDOC_DIR: TMP, TDOC_DRY_PUBLISH: '1' },
     stdio: ['ignore', 'pipe', 'pipe'],
   });
   // Wait for "tdoc server:" line
@@ -45,7 +56,7 @@ async function t(name, fn) { try { await fn(); ok(name); } catch (e) { bad(name,
     viewport: { width: 1400, height: 900 },
   });
   const page = await ctx.newPage();
-  await page.goto(`http://localhost:${PORT}/d/${SLUG}/v/1`, { waitUntil: 'networkidle' });
+  await page.goto(`http://${HOST}:${PORT}/d/${SLUG}/v/1`, { waitUntil: 'networkidle' });
 
   await t('Publish button visible on local doc', async () => {
     const btn = await page.$('#tdoc-publish-btn');
@@ -77,7 +88,7 @@ async function t(name, fn) { try { await fn(); ok(name); } catch (e) { bad(name,
   });
 
   await t('GET /api/publish-style smoke (POST dry-run returns ok)', async () => {
-    const r = await fetch(`http://localhost:${PORT}/api/publish`, {
+    const r = await fetch(`http://${HOST}:${PORT}/api/publish`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ slug: SLUG }),
@@ -88,7 +99,7 @@ async function t(name, fn) { try { await fn(); ok(name); } catch (e) { bad(name,
   });
 
   await t('Invalid slug rejected by /api/publish', async () => {
-    const r = await fetch(`http://localhost:${PORT}/api/publish`, {
+    const r = await fetch(`http://${HOST}:${PORT}/api/publish`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ slug: 'bad slug!' }),

--- a/test/ui.test.js
+++ b/test/ui.test.js
@@ -40,6 +40,17 @@ async function tPub(name, fn) {
 
   await page.goto(URL, { waitUntil: 'networkidle' });
 
+  async function openFirstCommentCard() {
+    const card = await page.$('.tdoc-margin-comment');
+    if (!card) return null;
+    if (await card.isVisible()) return card;
+    const pin = await page.$('.tdoc-pin');
+    if (!pin) return card;
+    await pin.click();
+    await page.waitForSelector('.tdoc-margin-comment.tdoc-floating-open', { timeout: 1000 });
+    return page.$('.tdoc-margin-comment.tdoc-floating-open');
+  }
+
   await t('top bar renders', async () => {
     await page.waitForSelector('.tdoc-bar', { timeout: 5000 });
   });
@@ -252,7 +263,7 @@ async function tPub(name, fn) {
   });
 
   await t('Click on existing comment card adds .active to card + anchor', async () => {
-    const card = await page.$('.tdoc-margin-comment');
+    const card = await openFirstCommentCard();
     if (!card) { console.log('  (no comments to test, skipping)'); return; }
     // Click the author row (text), not the body — avoids hitting reaction chips
     // and other interactive children that stopPropagation.
@@ -292,7 +303,7 @@ async function tPub(name, fn) {
 
   await t('Clicking outside any card / anchor deselects the active card', async () => {
     // Activate a card via its author row (avoid reaction chip stopPropagation)
-    const card = await page.$('.tdoc-margin-comment');
+    const card = await openFirstCommentCard();
     if (!card) { console.log('  (no cards, skipping)'); return; }
     const author = await card.$('.author');
     if (author) await author.click();
@@ -313,14 +324,14 @@ async function tPub(name, fn) {
   });
 
   await t('Comment card renders Reply button', async () => {
-    const card = await page.$('.tdoc-margin-comment, #tdoc-comment-layer .tdoc-margin-comment');
+    const card = await openFirstCommentCard();
     if (!card) { console.log('  (no comments on this doc, skipping)'); return; }
     const reply = await page.$('.tdoc-reply-toggle');
     if (!reply) throw new Error('no Reply button on comment card');
   });
 
   await t('Comment card renders + React button', async () => {
-    const card = await page.$('.tdoc-margin-comment, #tdoc-comment-layer .tdoc-margin-comment');
+    const card = await openFirstCommentCard();
     if (!card) { console.log('  (no comments on this doc, skipping)'); return; }
     const addReact = await page.$('.tdoc-react-add');
     if (!addReact) throw new Error('no + React button on comment card');
@@ -342,6 +353,7 @@ async function tPub(name, fn) {
   });
 
   await t('Clicking replies toggle expands replies', async () => {
+    await openFirstCommentCard();
     const toggle = await page.$('.tdoc-replies-toggle');
     if (!toggle) { console.log('  (no replies in fixture, skipping)'); return; }
     await toggle.click();


### PR DESCRIPTION
## Summary

Fixes the published reader layout regression Julie called out on `tdoc-hosted-product-model`: wide comment mode was reserving a 360px right rail on `body`, so the document stayed centered in the reduced reading area but appeared 180px left of the viewport center at 1440px.

This PR treats comment pins/cards as provider chrome instead of document layout:

- keep the document centered in the viewport when wide pinned comments are visible
- let the existing layout evaluator switch to the drawer when comment UI cannot fit beside the article
- make narrow-mode top-bar controls follow `body.tdoc-narrow`, not only viewport media queries
- record the provider-enforcement rule in `AGENTS.md`
- update browser tests to assert viewport centering and to open hidden cards through visible pins
- harden `publish.test.js` to use an isolated `127.0.0.1` port instead of fixed `localhost`

## Root Cause

PR #97 centered the article in the reader area by applying `padding-right: 360px` to `body.tdoc-has-comments`. That was correct for the older always-visible comment rail, but after wide mode moved to pins with cards hidden until opened, the same padding still shifted every commented doc left even though there was no persistent rail to reserve.

## Validation

- `node test/responsive.test.js`
- `node test/dimensions-audit.js`
- `node test/publish.test.js`
- `node test/ui.test.js`
- `node test/run.js`
- `node test/run.js --all`

`node test/run.js --all` passes all 26 suites locally.
