### PR TITLE
Add hosted publish target

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,9 +101,10 @@ Publishing has one hosted target and two self-host targets; pick one on your
 first publish and it sticks (saved in `~/.tdoc/published.json`):
 
 - **Hosted** — `/tdoc publish --platform hosted <slug>` uploads to a
-  tdoc-managed host such as `tdoc.dev`. This path skips user deploy setup. In
-  hosted v1, the upload token is configured out-of-band with
-  `TDOC_HOSTED_UPLOAD_TOKEN`; account/token issuance is the next product layer.
+  tdoc-managed host such as `tdoc.dev`. This path skips user deploy setup. On
+  first use, the hosted service issues an account-scoped upload token and the
+  CLI stores it in `~/.tdoc/published.json`; that token can only mutate docs it
+  owns.
 - **Cloudflare (default)** — Worker + R2 + KV, with a Durable Object
   serializing concurrent comment writes. The most battle-tested target.
 - **Vercel** — `/tdoc publish --platform vercel <slug>` deploys a catch-all

--- a/README.md
+++ b/README.md
@@ -25,8 +25,8 @@ Claude-specific tools are unavailable. See [Using tdoc with Codex](#using-tdoc-w
 ```
 You:  /tdoc new "an explainer with a slider showing how interest compounds"
 Claude: <generates doc, opens it locally>
-You:  /tdoc publish
-Claude: https://tdoc.yourname.workers.dev/d/compound-interest/v/1
+You:  /tdoc publish --platform hosted
+Claude: https://tdoc.dev/d/compound-interest/v/1
 ```
 
 Anyone with the link reads it instantly and comments on any sentence, image, or
@@ -79,7 +79,7 @@ What is *not* yet first-class on Codex: native slash-command registration (`/tdo
 |---|---|
 | `/tdoc new <prompt>` | Generate a new doc + open locally |
 | `/tdoc edit <slug>` | New version from open comments; replies on each with ✅/🟡/❓ status |
-| `/tdoc publish <slug>` | Deploy to your Cloudflare Worker (or Vercel, `--platform vercel`), get a public URL |
+| `/tdoc publish <slug>` | Publish a doc and get a public URL; hosted service is available with `--platform hosted`, self-host remains Cloudflare/Vercel |
 | `/tdoc pull <slug>` | Sync comments from the published doc back to local |
 | `/tdoc fork <slug>` | Copy a doc to a new slug |
 | `/tdoc unpublish <slug>` | Remove a published doc from your Worker |
@@ -90,13 +90,20 @@ What is *not* yet first-class on Codex: native slash-command registration (`/tdo
 
 ## Cost
 
-**$0 for normal use.** Cloudflare Workers + R2 + KV all have generous free tiers that personal usage will never come close to. The same goes for the Vercel target (Functions + Blob + Upstash Redis free tiers). You own your account; nobody else (including the maintainer) sees your traffic or pays your bills.
+**$0 for normal personal use.** Hosted publishing can use tdoc-managed
+infrastructure, so a first-time user does not need to configure Cloudflare,
+Vercel, R2, KV, Workers, or an OAuth app. Self-host targets still use your own
+Cloudflare or Vercel account.
 
 ## Hosting targets
 
-Publishing deploys the **same worker code** to a host you own; pick one on your
+Publishing has one hosted target and two self-host targets; pick one on your
 first publish and it sticks (saved in `~/.tdoc/published.json`):
 
+- **Hosted** — `/tdoc publish --platform hosted <slug>` uploads to a
+  tdoc-managed host such as `tdoc.dev`. This path skips user deploy setup. In
+  hosted v1, the upload token is configured out-of-band with
+  `TDOC_HOSTED_UPLOAD_TOKEN`; account/token issuance is the next product layer.
 - **Cloudflare (default)** — Worker + R2 + KV, with a Durable Object
   serializing concurrent comment writes. The most battle-tested target.
 - **Vercel** — `/tdoc publish --platform vercel <slug>` deploys a catch-all

--- a/SKILL.md
+++ b/SKILL.md
@@ -398,7 +398,7 @@ echo "tdoc server: http://localhost:7878"
 pkill -f "$SKILL_DIR/server/server.js"
 ```
 
-### `/tdoc publish <slug>` — publish to your Cloudflare Worker (or Vercel)
+### `/tdoc publish <slug>` — publish to hosted tdoc, Cloudflare, or Vercel
 
 Publishes the latest version of `<slug>` to a public URL.
 
@@ -406,6 +406,13 @@ Local always stays $0/anonymous; publishing is opt-in. First run does a one-time
 setup: prompts `wrangler login`, creates an R2 bucket (`tdoc-docs`) and KV
 namespace (`META`) in *your* Cloudflare account, generates an upload token, and
 deploys your own Worker. Config is saved to `~/.tdoc/published.json`.
+
+**Hosted target**: `tdoc-publish --platform hosted <slug>` uploads to the
+tdoc-managed host (default `https://tdoc.dev`) and does not ask the user to
+configure Cloudflare, Vercel, R2, KV, Workers, or an OAuth app. On first use,
+the hosted Worker issues an account-scoped upload token and the CLI stores it
+in `~/.tdoc/published.json`; server routes enforce that token can only mutate
+docs it owns.
 
 **Alternative host — Vercel**: `tdoc-publish --platform vercel <slug>` (first
 publish only; the choice is persisted). Needs the `vercel` CLI (`npm i -g

--- a/bin/tdoc-publish
+++ b/bin/tdoc-publish
@@ -1,12 +1,13 @@
 #!/usr/bin/env bash
 # tdoc-publish — first-time setup + upload doc to the user's own hosting.
 #
-# Usage: tdoc-publish [--platform cloudflare|vercel] <slug>
+# Usage: tdoc-publish [--platform cloudflare|vercel|hosted] <slug>
 #
 # Two publish targets share one flow (the worker code and the /api/upload
 # contract are identical on both):
 #   cloudflare (default) — wrangler deploy to a Worker + R2 + KV
 #   vercel               — vercel deploy of the vercel/ template + Blob + Upstash KV
+#   hosted               — upload to a tdoc-managed host; no user deploy
 # The platform is chosen ONCE, on the first publish (flag or TDOC_PLATFORM
 # env), then persisted in ~/.tdoc/published.json and read from there.
 #
@@ -30,7 +31,7 @@ usage() {
 usage: tdoc-publish [options] <slug>
 
 Options:
-  --platform cloudflare|vercel
+  --platform cloudflare|vercel|hosted
   --visibility public|unlisted|private   (default for new access block: unlisted)
   --history owner|invited|public         (default for new access block: owner)
   --commenting owner|invited|signed_in|off  (default: signed_in)
@@ -196,6 +197,32 @@ require_vercel() {
     fail_with_agent_prompt "the vercel CLI is not installed" \
       "Install the Vercel CLI globally so tdoc can publish: run 'npm i -g vercel' (or 'pnpm add -g vercel'). After it's installed, run '/tdoc publish $SLUG' again."
   fi
+}
+
+first_time_setup_hosted() {
+  local base="${TDOC_HOSTED_BASE:-https://tdoc.dev}"
+  local token="${TDOC_HOSTED_UPLOAD_TOKEN:-}"
+  base="${base%/}"
+  if [ -z "$token" ]; then
+    fail_with_agent_prompt "hosted upload token is not configured" \
+      "Configure hosted publish by setting TDOC_HOSTED_UPLOAD_TOKEN, then run '/tdoc publish --platform hosted $SLUG' again. This uses tdoc's hosted service, so it does not require Cloudflare, Vercel, R2, KV, Workers, or OAuth app setup."
+  fi
+  case "$base" in
+    http://*|https://*) ;;
+    *) echo "[tdoc] TDOC_HOSTED_BASE must start with http:// or https:// (got '$base')." >&2; exit 1 ;;
+  esac
+  local public_host="${base#http://}"
+  public_host="${public_host#https://}"
+  cat > "$CONFIG_FILE" <<EOF
+{
+  "platform": "hosted",
+  "base": "$base",
+  "public_host": "$public_host",
+  "upload_token": "$token"
+}
+EOF
+  chmod 600 "$CONFIG_FILE"
+  echo "[tdoc] hosted publish configured: $base"
 }
 if ! command -v jq >/dev/null 2>&1; then
   fail_with_agent_prompt "jq is not installed" \
@@ -586,7 +613,8 @@ if [ ! -f "$CONFIG_FILE" ]; then
   case "${PLATFORM_FLAG:-cloudflare}" in
     cloudflare) SKILL_DIR="$SKILL_DIR" first_time_setup ;;
     vercel)     SKILL_DIR="$SKILL_DIR" first_time_setup_vercel ;;
-    *) echo "[tdoc] unknown platform '${PLATFORM_FLAG}' — use 'cloudflare' or 'vercel'." >&2; exit 1 ;;
+    hosted)     first_time_setup_hosted ;;
+    *) echo "[tdoc] unknown platform '${PLATFORM_FLAG}' — use 'cloudflare', 'vercel', or 'hosted'." >&2; exit 1 ;;
   esac
 fi
 
@@ -599,7 +627,20 @@ fi
 
 TOKEN="$(jq -r .upload_token "$CONFIG_FILE")"
 
-if [ "$PLATFORM" = "vercel" ]; then
+if [ "$PLATFORM" = "hosted" ]; then
+  BASE="$(jq -r '.base // empty' "$CONFIG_FILE")"
+  PUBLIC_HOST="$(jq -r '.public_host // empty' "$CONFIG_FILE")"
+  for _f in TOKEN:upload_token BASE:base PUBLIC_HOST:public_host; do
+    _var="${_f%%:*}"; _key="${_f##*:}"; _val="$(eval "printf '%s' \"\$$_var\"")"
+    if [ -z "$_val" ] || [ "$_val" = "null" ]; then
+      echo "[tdoc] $CONFIG_FILE is missing or has a null '$_key'. Delete it and re-run /tdoc publish --platform hosted to re-setup." >&2
+      exit 1
+    fi
+  done
+  UPLOAD_BASE="$BASE"
+  PUBLIC_BASE="$BASE"
+  CUSTOM_DOMAIN=""
+elif [ "$PLATFORM" = "vercel" ]; then
   BASE="$(jq -r '.base // empty' "$CONFIG_FILE")"
   # Validate like the cloudflare branch below: a corrupt or partial
   # published.json must fail loudly, not publish to "null".

--- a/bin/tdoc-publish
+++ b/bin/tdoc-publish
@@ -21,6 +21,11 @@
 #
 # First run (vercel): see first_time_setup_vercel below.
 #
+# First run (hosted):
+#   1. Ask the tdoc-managed host for an account-scoped upload token
+#   2. Save the hosted base + token to ~/.tdoc/published.json
+#   3. Upload the doc. No Cloudflare/Vercel/OAuth app setup.
+#
 # Subsequent runs:
 #   Just upload the requested slug via /api/upload.
 
@@ -201,16 +206,36 @@ require_vercel() {
 
 first_time_setup_hosted() {
   local base="${TDOC_HOSTED_BASE:-https://tdoc.dev}"
-  local token="${TDOC_HOSTED_UPLOAD_TOKEN:-}"
   base="${base%/}"
-  if [ -z "$token" ]; then
-    fail_with_agent_prompt "hosted upload token is not configured" \
-      "Configure hosted publish by setting TDOC_HOSTED_UPLOAD_TOKEN, then run '/tdoc publish --platform hosted $SLUG' again. This uses tdoc's hosted service, so it does not require Cloudflare, Vercel, R2, KV, Workers, or OAuth app setup."
-  fi
   case "$base" in
     http://*|https://*) ;;
     *) echo "[tdoc] TDOC_HOSTED_BASE must start with http:// or https:// (got '$base')." >&2; exit 1 ;;
   esac
+  local resp http payload token account_id
+  resp="$(curl -sS --connect-timeout 10 --max-time 30 -w $'\n%{http_code}' \
+    -X POST "$base/api/hosted/token" -H "Content-Type: application/json" \
+    -d "{\"label\":\"$(printf '%s' "$SLUG" | sed 's/"/\\"/g')\"}" 2>&1)" || {
+      fail_with_agent_prompt "hosted service is unreachable" \
+        "The hosted tdoc service at $base did not respond. Retry '/tdoc publish --platform hosted $SLUG' later, or set TDOC_HOSTED_BASE to the correct hosted URL."
+    }
+  http="${resp##*$'\n'}"
+  payload="${resp%$'\n'*}"
+  if ! printf '%s' "$http" | grep -qE '^2[0-9][0-9]$'; then
+    if printf '%s' "$payload" | grep -q 'hosted_registration_disabled'; then
+      fail_with_agent_prompt "hosted registration is not enabled on $base" \
+        "The hosted service exists, but self-serve publish signup is not enabled yet. Ask the tdoc host owner to enable TDOC_HOSTED_REGISTRATION=1, then run '/tdoc publish --platform hosted $SLUG' again."
+    fi
+    echo "[tdoc] hosted token request returned HTTP $http" >&2
+    printf '%s\n' "$payload" | head -c 400 >&2; echo >&2
+    exit 1
+  fi
+  token="$(printf '%s' "$payload" | jq -r '.token // empty')"
+  account_id="$(printf '%s' "$payload" | jq -r '.account_id // empty')"
+  if [ -z "$token" ] || [ -z "$account_id" ]; then
+    echo "[tdoc] hosted token response was missing token/account_id." >&2
+    printf '%s\n' "$payload" | head -c 400 >&2; echo >&2
+    exit 1
+  fi
   local public_host="${base#http://}"
   public_host="${public_host#https://}"
   cat > "$CONFIG_FILE" <<EOF
@@ -218,6 +243,7 @@ first_time_setup_hosted() {
   "platform": "hosted",
   "base": "$base",
   "public_host": "$public_host",
+  "account_id": "$account_id",
   "upload_token": "$token"
 }
 EOF

--- a/bin/tdoc-pull
+++ b/bin/tdoc-pull
@@ -30,10 +30,10 @@ if [ ! -f "$CONFIG_FILE" ]; then
 fi
 if ! command -v jq >/dev/null 2>&1; then echo "needs jq" >&2; exit 1; fi
 
-# Resolve the API base for the configured platform: vercel configs store the
-# deployment URL directly in `.base`; cloudflare configs derive workers.dev.
+# Resolve the API base for the configured platform: hosted/vercel configs store
+# the URL directly in `.base`; cloudflare configs derive workers.dev.
 PLATFORM="$(jq -r '.platform // "cloudflare"' "$CONFIG_FILE")"
-if [ "$PLATFORM" = "vercel" ]; then
+if [ "$PLATFORM" = "hosted" ] || [ "$PLATFORM" = "vercel" ]; then
   BASE="$(jq -r '.base // empty' "$CONFIG_FILE")"
   if [ -z "$BASE" ] || [ "$BASE" = "null" ]; then
     echo "[tdoc] $CONFIG_FILE has no '.base' — delete it and re-run /tdoc publish to re-setup." >&2

--- a/bin/tdoc-unpublish
+++ b/bin/tdoc-unpublish
@@ -21,10 +21,10 @@ fi
 if ! command -v jq >/dev/null 2>&1; then echo "needs jq" >&2; exit 1; fi
 
 TOKEN="$(jq -r .upload_token "$CONFIG_FILE")"
-# Resolve the API base for the configured platform: vercel configs store the
-# deployment URL directly in `.base`; cloudflare configs derive workers.dev.
+# Resolve the API base for the configured platform: hosted/vercel configs store
+# the URL directly in `.base`; cloudflare configs derive workers.dev.
 PLATFORM="$(jq -r '.platform // "cloudflare"' "$CONFIG_FILE")"
-if [ "$PLATFORM" = "vercel" ]; then
+if [ "$PLATFORM" = "hosted" ] || [ "$PLATFORM" = "vercel" ]; then
   BASE="$(jq -r '.base // empty' "$CONFIG_FILE")"
   if [ -z "$BASE" ] || [ "$BASE" = "null" ]; then
     echo "[tdoc] $CONFIG_FILE has no '.base' — delete it and re-run /tdoc publish to re-setup." >&2

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -55,6 +55,20 @@ t('tdoc-publish does not let an older-version failure abort the latest', () => {
   assert(/FATAL: latest version/.test(src), 'latest-version hard-fail missing');
 });
 
+t('tdoc-publish exposes hosted as a no-user-deploy platform', () => {
+  const src = readBin('tdoc-publish');
+  assert(/cloudflare\|vercel\|hosted/.test(src), 'usage does not include hosted platform');
+  assert(/first_time_setup_hosted\(\)/.test(src), 'hosted setup function missing');
+  assert(/TDOC_HOSTED_UPLOAD_TOKEN/.test(src), 'hosted setup does not read hosted upload token');
+  assert(/TDOC_HOSTED_BASE:-https:\/\/tdoc\.dev/.test(src), 'hosted setup does not default to tdoc.dev');
+  assert(/platform": "hosted"/.test(src), 'hosted setup does not persist hosted platform');
+  assert(/if \[ "\$PLATFORM" = "hosted" \]/.test(src), 'hosted platform branch missing');
+  assert(/UPLOAD_BASE="\$BASE"/.test(src), 'hosted branch should upload to configured base');
+  assert(/PUBLIC_BASE="\$BASE"/.test(src), 'hosted branch should emit configured hosted base links');
+  assert(/does not require Cloudflare, Vercel, R2, KV, Workers, or OAuth app setup/.test(src),
+    'hosted failure prompt should explain that user deploy setup is not required');
+});
+
 t('tdoc-new fails loudly if the local server never comes up', () => {
   const src = readBin('tdoc-new');
   assert(/SERVER_UP/.test(src) && /failed to start/.test(src),

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -59,14 +59,25 @@ t('tdoc-publish exposes hosted as a no-user-deploy platform', () => {
   const src = readBin('tdoc-publish');
   assert(/cloudflare\|vercel\|hosted/.test(src), 'usage does not include hosted platform');
   assert(/first_time_setup_hosted\(\)/.test(src), 'hosted setup function missing');
-  assert(/TDOC_HOSTED_UPLOAD_TOKEN/.test(src), 'hosted setup does not read hosted upload token');
+  assert(/\/api\/hosted\/token/.test(src), 'hosted setup does not request a provider-issued token');
+  assert(!/TDOC_HOSTED_UPLOAD_TOKEN/.test(src), 'hosted setup must not require an out-of-band upload token');
   assert(/TDOC_HOSTED_BASE:-https:\/\/tdoc\.dev/.test(src), 'hosted setup does not default to tdoc.dev');
   assert(/platform": "hosted"/.test(src), 'hosted setup does not persist hosted platform');
+  assert(/"account_id": "\$account_id"/.test(src), 'hosted setup does not persist account_id');
   assert(/if \[ "\$PLATFORM" = "hosted" \]/.test(src), 'hosted platform branch missing');
   assert(/UPLOAD_BASE="\$BASE"/.test(src), 'hosted branch should upload to configured base');
   assert(/PUBLIC_BASE="\$BASE"/.test(src), 'hosted branch should emit configured hosted base links');
-  assert(/does not require Cloudflare, Vercel, R2, KV, Workers, or OAuth app setup/.test(src),
-    'hosted failure prompt should explain that user deploy setup is not required');
+  assert(/hosted_registration_disabled/.test(src),
+    'hosted setup should explain disabled provider registration');
+});
+
+t('pull/unpublish read hosted base from published.json', () => {
+  for (const f of ['tdoc-pull', 'tdoc-unpublish']) {
+    const src = readBin(f);
+    assert(/PLATFORM="\$\(jq -r '\.platform \/\/ "cloudflare"'/.test(src), `${f}: platform detection missing`);
+    assert(/"\$PLATFORM" = "hosted"/.test(src), `${f}: hosted platform branch missing`);
+    assert(/BASE="\$\(jq -r '\.base \/\/ empty'/.test(src), `${f}: hosted/vercel branch should read .base`);
+  }
 });
 
 t('tdoc-new fails loudly if the local server never comes up', () => {

--- a/test/hosted-oob-behavior.test.js
+++ b/test/hosted-oob-behavior.test.js
@@ -1,0 +1,191 @@
+// Hosted OOB behavioral tests against worker.js with fake KV/R2/DO bindings.
+//
+// These cover the cross-tenant write bugs a static grep test cannot prove:
+// missing-meta upload must still persist hosted ownership; a second hosted
+// token must not overwrite that slug; and legacy/orphan docs with no ownership
+// must fail closed for destructive/admin routes.
+
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const { webcrypto } = require('crypto');
+
+if (typeof globalThis.crypto === 'undefined') globalThis.crypto = webcrypto;
+
+if (typeof Response !== 'undefined' && !Response.json) {
+  Response.json = (body, init = {}) => new Response(JSON.stringify(body), {
+    ...init,
+    headers: { 'Content-Type': 'application/json', ...(init.headers || {}) },
+  });
+}
+
+let pass = 0, fail = 0;
+function ok(n) { console.log(`  ✓ ${n}`); pass++; }
+function bad(n, e) { console.log(`  ✗ ${n}\n    ${e.stack || e.message || e}`); fail++; }
+async function t(n, fn) { try { await fn(); ok(n); } catch (e) { bad(n, e); } }
+function assert(c, m) { if (!c) throw new Error(m || 'assertion failed'); }
+
+class FakeKV {
+  constructor() { this.map = new Map(); }
+  async get(k) { return this.map.has(k) ? this.map.get(k) : null; }
+  async put(k, v) { this.map.set(k, String(v)); }
+  async delete(k) { this.map.delete(k); }
+  async list({ prefix = '' } = {}) {
+    return {
+      keys: [...this.map.keys()].filter(k => k.startsWith(prefix)).map(name => ({ name })),
+      list_complete: true,
+    };
+  }
+}
+
+class FakeR2 {
+  constructor() { this.map = new Map(); }
+  async put(k, v) { this.map.set(k, String(v)); }
+  async get(k) {
+    if (!this.map.has(k)) return null;
+    const v = this.map.get(k);
+    return { text: async () => v };
+  }
+  async head(k) {
+    if (!this.map.has(k)) return null;
+    return { size: Buffer.byteLength(this.map.get(k)) };
+  }
+  async delete(k) { this.map.delete(k); }
+  async list({ prefix = '' } = {}) {
+    return {
+      objects: [...this.map.keys()].filter(k => k.startsWith(prefix)).map(key => ({ key })),
+      truncated: false,
+    };
+  }
+}
+
+class FakeStorage {
+  constructor() { this.map = new Map(); }
+  async transaction(fn) {
+    const txn = {
+      get: async (k) => this.map.get(k),
+      put: async (k, v) => { this.map.set(k, v); },
+    };
+    return fn(txn);
+  }
+}
+
+class FakeDurableNamespace {
+  constructor(env, StoreClass) {
+    this.env = env;
+    this.StoreClass = StoreClass;
+    this.states = new Map();
+  }
+  idFromName(name) { return name; }
+  stateFor(id) {
+    if (!this.states.has(id)) this.states.set(id, { storage: new FakeStorage() });
+    return this.states.get(id);
+  }
+  get(id) {
+    return {
+      fetch: async (url, init = {}) => {
+        const store = new this.StoreClass(this.stateFor(id), this.env);
+        return store.fetch(new Request(url, init));
+      },
+    };
+  }
+}
+
+async function loadWorker() {
+  const src = fs.readFileSync(path.join(__dirname, '..', 'worker', 'worker.js'), 'utf8');
+  const tmp = path.join(os.tmpdir(), `tdoc-worker-${Date.now()}-${Math.random().toString(16).slice(2)}.mjs`);
+  fs.writeFileSync(tmp, src);
+  const mod = await import(`file://${tmp}`);
+  try { fs.unlinkSync(tmp); } catch {}
+  return mod;
+}
+
+function makeEnv(StoreClass) {
+  const env = {
+    META: new FakeKV(),
+    DOCS: new FakeR2(),
+    TDOC_HOSTED_REGISTRATION: '1',
+  };
+  env.COMMENTS = new FakeDurableNamespace(env, StoreClass);
+  return env;
+}
+
+function req(pathname, { method = 'GET', token = '', body = null } = {}) {
+  return new Request(`https://tdoc.dev${pathname}`, {
+    method,
+    headers: {
+      ...(token ? { Authorization: `Bearer ${token}` } : {}),
+      ...(body ? { 'Content-Type': 'application/json' } : {}),
+    },
+    body: body ? JSON.stringify(body) : undefined,
+  });
+}
+
+async function issue(worker, env, label = 'test') {
+  const r = await worker.fetch(req('/api/hosted/token', { method: 'POST', body: { label } }), env, {});
+  const data = await r.json();
+  assert(r.status === 200 && data.token && data.account_id, `token issue failed ${r.status}: ${JSON.stringify(data)}`);
+  return data;
+}
+
+(async () => {
+  const mod = await loadWorker();
+  const worker = mod.default;
+  console.log('hosted OOB behavior');
+
+  await t('missing-meta hosted upload still persists owner; second token cannot overwrite', async () => {
+    const env = makeEnv(mod.CommentsStore);
+    const a = await issue(worker, env, 'a');
+    const b = await issue(worker, env, 'b');
+    const first = await worker.fetch(req('/api/upload', {
+      method: 'POST', token: a.token,
+      body: { slug: 'owned-doc', version: 1, html: '<h1>A</h1>' },
+    }), env, {});
+    assert(first.status === 200, `first upload ${first.status}: ${await first.text()}`);
+    const meta = JSON.parse(await env.META.get('meta:owned-doc'));
+    assert(meta.hosted.account_id === a.account_id, 'first upload did not persist hosted owner meta');
+
+    const second = await worker.fetch(req('/api/upload', {
+      method: 'POST', token: b.token,
+      body: { slug: 'owned-doc', version: 1, html: '<h1>B</h1>' },
+    }), env, {});
+    assert(second.status === 403, `second token should be denied, got ${second.status}`);
+    const doc = await env.DOCS.get('docs/owned-doc/v1/index.html');
+    assert((await doc.text()).includes('A'), 'denied second upload overwrote document bytes');
+  });
+
+  await t('hosted token cannot delete legacy/orphan R2 doc with no meta/owner', async () => {
+    const env = makeEnv(mod.CommentsStore);
+    const tok = await issue(worker, env, 'deleter');
+    await env.DOCS.put('docs/legacy-no-meta/v1/index.html', '<h1>legacy</h1>');
+    const r = await worker.fetch(req('/api/doc?slug=legacy-no-meta', { method: 'DELETE', token: tok.token }), env, {});
+    assert(r.status !== 200, `delete should fail closed, got ${r.status}`);
+    assert(await env.DOCS.head('docs/legacy-no-meta/v1/index.html'), 'legacy doc bytes were deleted');
+  });
+
+  await t('hosted token cannot wipe comments for legacy/no-meta slug', async () => {
+    const env = makeEnv(mod.CommentsStore);
+    const tok = await issue(worker, env, 'wiper');
+    const state = env.COMMENTS.stateFor('legacy-comments').storage.map;
+    state.set('list', [{ id: 'c1', events: [{ kind: 'created', at_version: 1, text: 'keep' }] }]);
+    const r = await worker.fetch(req('/api/comments?slug=legacy-comments&all=1', { method: 'DELETE', token: tok.token }), env, {});
+    assert(r.status !== 200, `wipe should fail closed, got ${r.status}`);
+    assert(state.get('list').length === 1, 'comment list was wiped');
+  });
+
+  await t('hosted token cannot agent-reply on legacy/no-meta slug', async () => {
+    const env = makeEnv(mod.CommentsStore);
+    const tok = await issue(worker, env, 'agent');
+    const state = env.COMMENTS.stateFor('legacy-reply').storage.map;
+    state.set('list', [{ id: 'c1', events: [{ kind: 'created', at_version: 1, text: 'parent' }] }]);
+    const r = await worker.fetch(req('/api/agent/reply', {
+      method: 'POST', token: tok.token,
+      body: { slug: 'legacy-reply', parent_id: 'c1', text: 'should not write', status: 'applied' },
+    }), env, {});
+    assert(r.status !== 200, `agent reply should fail closed, got ${r.status}`);
+    assert(state.get('list')[0].events.length === 1, 'agent reply mutated comments');
+  });
+
+  console.log(`\n${pass} passed, ${fail} failed`);
+  process.exit(fail ? 1 : 0);
+})();

--- a/test/hosted-oob-behavior.test.js
+++ b/test/hosted-oob-behavior.test.js
@@ -26,9 +26,18 @@ async function t(n, fn) { try { await fn(); ok(n); } catch (e) { bad(n, e); } }
 function assert(c, m) { if (!c) throw new Error(m || 'assertion failed'); }
 
 class FakeKV {
-  constructor() { this.map = new Map(); }
+  constructor() {
+    this.map = new Map();
+    this.failPutOnce = new Set();
+  }
   async get(k) { return this.map.has(k) ? this.map.get(k) : null; }
-  async put(k, v) { this.map.set(k, String(v)); }
+  async put(k, v) {
+    if (this.failPutOnce.has(k)) {
+      this.failPutOnce.delete(k);
+      throw new Error(`forced KV put failure: ${k}`);
+    }
+    this.map.set(k, String(v));
+  }
   async delete(k) { this.map.delete(k); }
   async list({ prefix = '' } = {}) {
     return {
@@ -39,8 +48,15 @@ class FakeKV {
 }
 
 class FakeR2 {
-  constructor() { this.map = new Map(); }
-  async put(k, v) { this.map.set(k, String(v)); }
+  constructor() {
+    this.map = new Map();
+    this.throwList = false;
+    this.putCalls = 0;
+  }
+  async put(k, v) {
+    this.putCalls++;
+    this.map.set(k, String(v));
+  }
   async get(k) {
     if (!this.map.has(k)) return null;
     const v = this.map.get(k);
@@ -52,6 +68,7 @@ class FakeR2 {
   }
   async delete(k) { this.map.delete(k); }
   async list({ prefix = '' } = {}) {
+    if (this.throwList) throw new Error('forced R2 list failure');
     return {
       objects: [...this.map.keys()].filter(k => k.startsWith(prefix)).map(key => ({ key })),
       truncated: false,
@@ -152,6 +169,41 @@ async function issue(worker, env, label = 'test') {
     assert(second.status === 403, `second token should be denied, got ${second.status}`);
     const doc = await env.DOCS.get('docs/owned-doc/v1/index.html');
     assert((await doc.text()).includes('A'), 'denied second upload overwrote document bytes');
+  });
+
+  await t('R2 list failure during first claim fails closed before DO claim or R2 put', async () => {
+    const env = makeEnv(mod.CommentsStore);
+    const tok = await issue(worker, env, 'list-fails');
+    env.DOCS.throwList = true;
+    const r = await worker.fetch(req('/api/upload', {
+      method: 'POST', token: tok.token,
+      body: { slug: 'list-fails', version: 1, html: '<h1>nope</h1>' },
+    }), env, {});
+    assert(r.status >= 400, `list failure should not succeed, got ${r.status}`);
+    assert(env.DOCS.putCalls === 0, 'R2 put ran despite failed existence check');
+    assert(!env.COMMENTS.stateFor('list-fails').storage.map.has('hostedOwner'), 'DO owner claim was persisted despite failed existence check');
+  });
+
+  await t('same hosted owner can retry after META write failure and repair ownership meta', async () => {
+    const env = makeEnv(mod.CommentsStore);
+    const tok = await issue(worker, env, 'repair');
+    env.META.failPutOnce.add('meta:repair-doc');
+    const first = await worker.fetch(req('/api/upload', {
+      method: 'POST', token: tok.token,
+      body: { slug: 'repair-doc', version: 1, html: '<h1>first</h1>' },
+    }), env, {});
+    assert(first.status >= 400, `first upload should report failed meta write, got ${first.status}`);
+    assert(await env.DOCS.head('docs/repair-doc/v1/index.html'), 'first upload did not leave the reproduced partial R2 write');
+    assert(!await env.META.get('meta:repair-doc'), 'test setup expected meta write to fail');
+    assert(env.COMMENTS.stateFor('repair-doc').storage.map.get('hostedOwner') === tok.account_id, 'test setup expected DO claim to persist');
+
+    const retry = await worker.fetch(req('/api/upload', {
+      method: 'POST', token: tok.token,
+      body: { slug: 'repair-doc', version: 1, html: '<h1>retry</h1>' },
+    }), env, {});
+    assert(retry.status === 200, `same owner retry should repair meta, got ${retry.status}: ${await retry.text()}`);
+    const repaired = JSON.parse(await env.META.get('meta:repair-doc'));
+    assert(repaired.hosted.account_id === tok.account_id, 'retry did not repair hosted ownership meta');
   });
 
   await t('hosted token cannot delete legacy/orphan R2 doc with no meta/owner', async () => {

--- a/test/hosted-oob.test.js
+++ b/test/hosted-oob.test.js
@@ -1,0 +1,85 @@
+// Hosted out-of-box publish guards.
+//
+// Hosted publish must not hand users the provider-wide TDOC_UPLOAD_TOKEN.
+// Instead, the Worker mints account-scoped tokens and write routes enforce
+// slug ownership before writing document bytes, access policy, comments, or
+// deletes.
+
+const fs = require('fs');
+const path = require('path');
+
+let pass = 0, fail = 0;
+function ok(n) { console.log(`  ✓ ${n}`); pass++; }
+function bad(n, e) { console.log(`  ✗ ${n}\n    ${e}`); fail++; }
+function t(n, fn) { try { fn(); ok(n); } catch (e) { bad(n, e.message); } }
+function assert(c, m) { if (!c) throw new Error(m || 'assertion failed'); }
+
+const worker = fs.readFileSync(path.join(__dirname, '..', 'worker', 'worker.js'), 'utf8');
+
+function block(startNeedle, endNeedle) {
+  const start = worker.indexOf(startNeedle);
+  const end = worker.indexOf(endNeedle, start);
+  if (start < 0 || end < 0 || end <= start) throw new Error(`block missing: ${startNeedle}`);
+  return worker.slice(start, end);
+}
+
+const hostedRoute = block("if (p === '/api/hosted/token' && method === 'POST')", '// ---- comments ----');
+const uploadRoute = block("if (p === '/api/upload' && method === 'POST')", '// ---- admin access mutation ----');
+const accessRoute = block("if (p === '/api/doc/access' && method === 'PATCH')", '// ---- admin delete ----');
+const deleteRoute = block("if (p === '/api/doc' && method === 'DELETE')", "return text('Not found'");
+const wipeRoute = block("url.searchParams.get('all') === '1'", '// Soft-delete:');
+const agentReplyRoute = block("if (p === '/api/agent/reply' && method === 'POST')", '// ---- admin upload');
+
+console.log('hosted out-of-box publish');
+
+t('Worker exposes provider-gated hosted token bootstrap', () => {
+  assert(hostedRoute.includes('hostedRegistrationEnabled(env)'), 'hosted route must be registration-gated');
+  assert(hostedRoute.includes('issueHostedToken(env, body)'), 'hosted route must mint a token server-side');
+  assert(hostedRoute.includes("hosted_registration_disabled"), 'hosted route must return disabled registration error');
+  assert(hostedRoute.includes('account_id'), 'hosted route must return account_id');
+});
+
+t('Hosted tokens are stored hashed, not in cleartext', () => {
+  assert(worker.includes('sha256Hex(token)'), 'token hash helper usage missing');
+  assert(worker.includes('hosted-token:${tokenHash}'), 'hosted token records must be keyed by token hash');
+  assert(!worker.includes('hosted-token:${token}`'), 'raw hosted tokens must not be KV keys');
+});
+
+t('Upload auth accepts either provider admin token or hosted account token', () => {
+  assert(worker.includes("actor: { kind: 'admin' }"), 'admin actor branch missing');
+  assert(worker.includes("hostedTokenActor(env, token)"), 'hosted token actor branch missing');
+  assert(worker.includes("kind: 'hosted'"), 'hosted actor kind missing');
+});
+
+t('Hosted upload stamps remote meta ownership before writing', () => {
+  assert(uploadRoute.includes('requireDocWriteAccess(env, auth.actor, slug)'), 'upload must enforce write access');
+  assert(uploadRoute.includes('stampHostedOwnership(incoming, auth.actor)'), 'upload must stamp hosted owner');
+  const gate = uploadRoute.indexOf('requireDocWriteAccess(env, auth.actor, slug)');
+  const r2 = uploadRoute.indexOf('env.DOCS.put');
+  const meta = uploadRoute.indexOf('env.META.put(`meta:${slug}`');
+  assert(gate >= 0 && gate < r2, 'upload must enforce owner before R2 write');
+  assert(gate < meta, 'upload must enforce owner before META write');
+});
+
+t('Access mutation and delete are scoped to token-owned docs', () => {
+  for (const [name, route] of [['access', accessRoute], ['delete', deleteRoute]]) {
+    assert(route.includes('requireDocWriteAccess(env, auth.actor, slug)'), `${name}: owner gate missing`);
+    const gate = route.indexOf('requireDocWriteAccess(env, auth.actor, slug)');
+    const metaWrite = route.indexOf('env.META.put');
+    const docDelete = route.indexOf('env.DOCS.delete');
+    const firstWrite = [metaWrite, docDelete].filter(i => i >= 0).sort((a, b) => a - b)[0];
+    assert(firstWrite === undefined || gate < firstWrite, `${name}: owner gate must precede writes`);
+  }
+});
+
+t('Admin comment wipe and agent reply are also token-owned-doc scoped', () => {
+  for (const [name, route] of [['wipe', wipeRoute], ['agent reply', agentReplyRoute]]) {
+    assert(route.includes('requireDocWriteAccess(env, auth.actor, slug)'), `${name}: owner gate missing`);
+    const gate = route.indexOf('requireDocWriteAccess(env, auth.actor, slug)');
+    const mutate = route.indexOf('mutateComments(env, slug');
+    assert(gate >= 0 && mutate >= 0 && gate < mutate, `${name}: owner gate must precede comment mutation`);
+  }
+});
+
+console.log(`\n${pass} passed, ${fail} failed`);
+process.exit(fail ? 1 : 0);

--- a/test/hosted-oob.test.js
+++ b/test/hosted-oob.test.js
@@ -52,13 +52,21 @@ t('Upload auth accepts either provider admin token or hosted account token', () 
 });
 
 t('Hosted upload stamps remote meta ownership before writing', () => {
-  assert(uploadRoute.includes('requireDocWriteAccess(env, auth.actor, slug)'), 'upload must enforce write access');
+  assert(uploadRoute.includes('requireDocWriteAccess(env, auth.actor, slug, { create: true })'), 'upload must enforce create/claim write access');
   assert(uploadRoute.includes('stampHostedOwnership(incoming, auth.actor)'), 'upload must stamp hosted owner');
-  const gate = uploadRoute.indexOf('requireDocWriteAccess(env, auth.actor, slug)');
+  const gate = uploadRoute.indexOf('requireDocWriteAccess(env, auth.actor, slug, { create: true })');
   const r2 = uploadRoute.indexOf('env.DOCS.put');
   const meta = uploadRoute.indexOf('env.META.put(`meta:${slug}`');
   assert(gate >= 0 && gate < r2, 'upload must enforce owner before R2 write');
   assert(gate < meta, 'upload must enforce owner before META write');
+});
+
+t('Hosted slug ownership claim is backed by per-slug Durable Object storage', () => {
+  assert(worker.includes('hostedOwner'), 'Durable Object owner storage key missing');
+  assert(worker.includes("u.pathname === '/owner'"), 'Durable Object owner endpoint missing');
+  assert(worker.includes("kind: 'claim_owner'"), 'atomic owner claim op missing');
+  assert(worker.includes("kind: 'verify_owner'"), 'owner verify op missing');
+  assert(worker.includes('hostedOwnerOp(env, slug'), 'write gate must use Durable Object owner op');
 });
 
 t('Access mutation and delete are scoped to token-owned docs', () => {

--- a/test/remote-access-route.test.js
+++ b/test/remote-access-route.test.js
@@ -43,7 +43,7 @@ t('PATCH /api/doc/access authenticates before parsing body or writing meta', () 
 });
 
 t('PATCH /api/doc/access only writes remote meta, never document bytes', () => {
-  assert(route.includes('applyAccessPatch(meta, access)'), 'route must use access-only helper');
+  assert(route.includes('applyAccessPatch(writeGate.meta, access)'), 'route must use access-only helper');
   assert(route.includes('env.META.put(`meta:${slug}`'), 'route must write updated meta');
   assert(!route.includes('env.DOCS.put'), 'route must not write R2 document HTML');
   assert(!route.includes('env.DOCS.delete'), 'route must not delete R2 document HTML');

--- a/test/run.js
+++ b/test/run.js
@@ -26,6 +26,7 @@ const OFFLINE = [
   'me-management.test.js',    // /me remote SoT management UI guard
   'runtime-provenance.test.js', // release provenance + content-hash redeploy
   'hosted-oob.test.js',       // hosted token bootstrap + scoped writes
+  'hosted-oob-behavior.test.js', // hosted token ownership behavior with fake bindings
   'oldver-strip.test.js',     // old-version banner predicate
   'cli.test.js',              // CLI resilience (drives bash hermetically)
   'no-drift.test.js',         // duplicated-helper drift guard

--- a/test/run.js
+++ b/test/run.js
@@ -25,6 +25,7 @@ const OFFLINE = [
   'remote-access-route.test.js', // remote access mutation auth + meta-only guard
   'me-management.test.js',    // /me remote SoT management UI guard
   'runtime-provenance.test.js', // release provenance + content-hash redeploy
+  'hosted-oob.test.js',       // hosted token bootstrap + scoped writes
   'oldver-strip.test.js',     // old-version banner predicate
   'cli.test.js',              // CLI resilience (drives bash hermetically)
   'no-drift.test.js',         // duplicated-helper drift guard

--- a/worker/worker.js
+++ b/worker/worker.js
@@ -1548,13 +1548,73 @@ async function timingSafeEqual(a, b) {
   return diff === 0;
 }
 
+async function sha256Hex(s) {
+  const buf = await crypto.subtle.digest('SHA-256', new TextEncoder().encode(String(s || '')));
+  return [...new Uint8Array(buf)].map(b => b.toString(16).padStart(2, '0')).join('');
+}
+
+function hostedRegistrationEnabled(env) {
+  const v = String(env.TDOC_HOSTED_REGISTRATION || env.TDOC_HOSTED_SIGNUP || '').toLowerCase();
+  return v === '1' || v === 'true' || v === 'yes';
+}
+
+async function issueHostedToken(env, body = {}) {
+  const token = `tdoc_${rand(24)}`;
+  const tokenHash = await sha256Hex(token);
+  const record = {
+    account_id: `acct_${rand(12)}`,
+    created: new Date().toISOString(),
+  };
+  if (typeof body.label === 'string' && body.label.trim()) {
+    record.label = body.label.trim().slice(0, 80);
+  }
+  await env.META.put(`hosted-token:${tokenHash}`, JSON.stringify(record));
+  return { token, record };
+}
+
+async function hostedTokenActor(env, token) {
+  const tokenHash = await sha256Hex(token);
+  let record = null;
+  try {
+    const raw = await env.META.get(`hosted-token:${tokenHash}`);
+    if (raw) record = JSON.parse(raw);
+  } catch {}
+  if (!record || typeof record.account_id !== 'string' || !record.account_id) return null;
+  return { kind: 'hosted', account_id: record.account_id, token_hash: tokenHash };
+}
+
 async function requireUploadAuth(req, env) {
   const auth = req.headers.get('authorization') || '';
   const m = auth.match(/^Bearer\s+(.+)$/);
-  if (!m || !env.TDOC_UPLOAD_TOKEN || !(await timingSafeEqual(m[1], env.TDOC_UPLOAD_TOKEN))) {
-    return json({ error: 'unauthorized' }, { status: 401 });
+  if (!m) return { ok: false, response: json({ error: 'unauthorized' }, { status: 401 }) };
+  const token = m[1];
+  if (env.TDOC_UPLOAD_TOKEN && await timingSafeEqual(token, env.TDOC_UPLOAD_TOKEN)) {
+    return { ok: true, actor: { kind: 'admin' } };
   }
-  return null;
+  const hostedActor = await hostedTokenActor(env, token);
+  if (hostedActor) return { ok: true, actor: hostedActor };
+  return { ok: false, response: json({ error: 'unauthorized' }, { status: 401 }) };
+}
+
+async function requireDocWriteAccess(env, actor, slug) {
+  const meta = await loadDocMeta(env, slug);
+  if (!actor || actor.kind === 'admin') return { ok: true, meta };
+  const accountId = meta && meta.hosted && meta.hosted.account_id;
+  if (!meta) return { ok: true, meta: null };
+  if (!accountId) return { ok: false, response: json({ error: 'slug_taken' }, { status: 409 }) };
+  if (accountId !== actor.account_id) return { ok: false, response: json({ error: 'not_doc_owner' }, { status: 403 }) };
+  return { ok: true, meta };
+}
+
+function stampHostedOwnership(meta, actor) {
+  if (!actor || actor.kind !== 'hosted') return meta;
+  return {
+    ...(meta || {}),
+    hosted: {
+      ...((meta && meta.hosted && typeof meta.hosted === 'object') ? meta.hosted : {}),
+      account_id: actor.account_id,
+    },
+  };
 }
 
 // ===========================================================================
@@ -2095,6 +2155,27 @@ export default {
       return json({ ok: true }, { headers: { 'Set-Cookie': 'tdoc_sid=; Path=/; Max-Age=0' } });
     }
 
+    // ---- hosted publish token bootstrap ----
+    // Hosted/OOB users should not create Cloudflare resources or receive the
+    // provider-wide TDOC_UPLOAD_TOKEN. The central Worker mints an account-
+    // scoped upload token, and server write routes enforce slug ownership for
+    // that token. Registration is provider-gated by env so deployments can
+    // close signup without changing client code.
+    if (p === '/api/hosted/token' && method === 'POST') {
+      if (!hostedRegistrationEnabled(env)) {
+        return json({ error: 'hosted_registration_disabled' }, { status: 403 });
+      }
+      let body = {};
+      try { body = await req.json(); } catch {}
+      const issued = await issueHostedToken(env, body);
+      return json({
+        ok: true,
+        token: issued.token,
+        account_id: issued.record.account_id,
+        base: url.origin,
+      });
+    }
+
     // ---- comments ----
     if (p === '/api/comments' && method === 'GET') {
       const slug = url.searchParams.get('slug');
@@ -2168,14 +2249,17 @@ export default {
 
     // Admin: wipe ALL comments for a slug (doc owner only — uses the same
     // upload token as /api/upload, so it can be invoked from the publish
-    // tooling or an agent that holds the token; the worker's KV is single-
-    // tenant so this is safe). Triggered by ?all=1 on DELETE /api/comments.
+    // tooling or an agent that holds that doc's hosted token). Triggered by
+    // ?all=1 on DELETE /api/comments.
     if (p === '/api/comments' && method === 'DELETE'
         && url.searchParams.get('all') === '1') {
-      const unauth = await requireUploadAuth(req, env);
-      if (unauth) return unauth;
+      const auth = await requireUploadAuth(req, env);
+      if (!auth.ok) return auth.response;
       const slug = url.searchParams.get('slug');
       if (!slug) return json({ error: 'slug required' }, { status: 400 });
+      if (!isValidSlug(slug)) return json({ error: 'invalid_slug' }, { status: 400 });
+      const writeGate = await requireDocWriteAccess(env, auth.actor, slug);
+      if (!writeGate.ok) return writeGate.response;
       // Serialized wipe (through the DO) so it can't race a concurrent mutation.
       const res = await mutateComments(env, slug, { kind: 'wipe', slug });
       return json(res.body, { status: res.status });
@@ -2258,13 +2342,16 @@ export default {
     // a visible badge on the reply and also flips the parent comment's
     // status to 'applied' / 'open' so the dashboard reflects it.
     if (p === '/api/agent/reply' && method === 'POST') {
-      const unauth = await requireUploadAuth(req, env);
-      if (unauth) return unauth;
+      const auth = await requireUploadAuth(req, env);
+      if (!auth.ok) return auth.response;
       let body = {};
       try { body = await req.json(); } catch {}
       const { slug, parent_id, text: replyText, status: agentStatus, applied_in,
               bind_anchor_aid } = body;
       if (!slug || !parent_id || !replyText) return json({ error: 'slug, parent_id, text required' }, { status: 400 });
+      if (!isValidSlug(slug)) return json({ error: 'invalid_slug' }, { status: 400 });
+      const writeGate = await requireDocWriteAccess(env, auth.actor, slug);
+      if (!writeGate.ok) return writeGate.response;
       // Resolve parent + its current anchor up front (the optional rebind needs
       // the folded anchor for label/fallback). agent/reply is upload-token-authed
       // (owner-only), so concurrency here is negligible; the serialized write
@@ -2307,8 +2394,8 @@ export default {
 
     // ---- admin upload (from `tdoc publish`) ----
     if (p === '/api/upload' && method === 'POST') {
-      const unauth = await requireUploadAuth(req, env);
-      if (unauth) return unauth;
+      const auth = await requireUploadAuth(req, env);
+      if (!auth.ok) return auth.response;
       let body = {};
       try { body = await req.json(); } catch {}
       const { slug, version, html: doc, meta, comments: localComments } = body;
@@ -2322,16 +2409,14 @@ export default {
       if (!isValidSlug(slug)) return json({ error: 'invalid_slug' }, { status: 400 });
       const verNum = Number(version);
       if (!Number.isInteger(verNum) || verNum < 1) return json({ error: 'invalid_version' }, { status: 400 });
+      const writeGate = await requireDocWriteAccess(env, auth.actor, slug);
+      if (!writeGate.ok) return writeGate.response;
       // Validate write-side access policy before writing doc bytes. Read paths
       // stay tolerant for legacy/corrupt stored meta; writes must fail closed.
       let incoming = null;
       if (meta) {
         incoming = (meta && typeof meta === 'object') ? { ...meta } : {};
-        let prev = null;
-        try {
-          const prevRaw = await env.META.get(`meta:${slug}`);
-          if (prevRaw) prev = JSON.parse(prevRaw);
-        } catch {}
+        const prev = writeGate.meta;
         if (!incoming.access && prev && prev.access) {
           incoming.access = prev.access;
         }
@@ -2342,6 +2427,7 @@ export default {
           }
           incoming.access = normalizeAccess(validatedAccess.access, { legacy: false });
         }
+        incoming = stampHostedOwnership(incoming, auth.actor);
       }
       // Identity-stamp every commentable artifact with a content-hashed
       // data-tdoc-aid. The SAME artifact in a different version has the
@@ -2407,8 +2493,8 @@ export default {
     // without a local meta.json or full document re-upload. Authenticated with
     // the same upload token as /api/upload and /api/doc DELETE.
     if (p === '/api/doc/access' && method === 'PATCH') {
-      const unauth = await requireUploadAuth(req, env);
-      if (unauth) return unauth;
+      const auth = await requireUploadAuth(req, env);
+      if (!auth.ok) return auth.response;
       let body = {};
       try { body = await req.json(); } catch {}
       const topKeys = Object.keys(body || {});
@@ -2417,9 +2503,10 @@ export default {
       const { slug, access } = body || {};
       if (!slug) return json({ error: 'slug required' }, { status: 400 });
       if (!isValidSlug(slug)) return json({ error: 'invalid_slug' }, { status: 400 });
-      const meta = await loadDocMeta(env, slug);
-      if (!meta) return json({ error: 'not_found' }, { status: 404 });
-      const next = applyAccessPatch(meta, access);
+      const writeGate = await requireDocWriteAccess(env, auth.actor, slug);
+      if (!writeGate.ok) return writeGate.response;
+      if (!writeGate.meta) return json({ error: 'not_found' }, { status: 404 });
+      const next = applyAccessPatch(writeGate.meta, access);
       if (next.error) {
         return json({ error: next.error, ...(next.field ? { field: next.field } : {}), ...(next.fields ? { fields: next.fields } : {}) }, { status: 400 });
       }
@@ -2429,10 +2516,13 @@ export default {
 
     // ---- admin delete ----
     if (p === '/api/doc' && method === 'DELETE') {
-      const unauth = await requireUploadAuth(req, env);
-      if (unauth) return unauth;
+      const auth = await requireUploadAuth(req, env);
+      if (!auth.ok) return auth.response;
       const slug = url.searchParams.get('slug');
       if (!slug) return json({ error: 'slug required' }, { status: 400 });
+      if (!isValidSlug(slug)) return json({ error: 'invalid_slug' }, { status: 400 });
+      const writeGate = await requireDocWriteAccess(env, auth.actor, slug);
+      if (!writeGate.ok) return writeGate.response;
       // delete all R2 versions
       let cursor;
       do {

--- a/worker/worker.js
+++ b/worker/worker.js
@@ -1585,7 +1585,7 @@ async function hostedTokenActor(env, token) {
 
 async function hostedOwnerOp(env, slug, op) {
   if (!env.COMMENTS) {
-    return { ok: false, response: json({ error: 'hosted_owner_store_unavailable' }, { status: 503 }) };
+    return { ok: false, status: 503, error: 'hosted_owner_store_unavailable' };
   }
   const stub = env.COMMENTS.get(env.COMMENTS.idFromName(slug));
   const r = await stub.fetch('https://do/owner', {
@@ -1598,9 +1598,9 @@ async function hostedOwnerOp(env, slug, op) {
 async function docBytesExist(env, slug) {
   try {
     const r = await env.DOCS.list({ prefix: `docs/${slug}/` });
-    return Array.isArray(r.objects) && r.objects.length > 0;
-  } catch {
-    return false;
+    return { ok: true, exists: Array.isArray(r.objects) && r.objects.length > 0 };
+  } catch (e) {
+    return { ok: false, response: json({ error: 'doc_bytes_check_failed', message: e.message || String(e) }, { status: 503 }) };
   }
 }
 
@@ -1622,8 +1622,14 @@ async function requireDocWriteAccess(env, actor, slug, opts = {}) {
   if (!actor || actor.kind === 'admin') return { ok: true, meta };
   const accountId = meta && meta.hosted && meta.hosted.account_id;
   if (opts.create) {
-    if (!meta && await docBytesExist(env, slug)) {
-      return { ok: false, response: json({ error: 'slug_taken' }, { status: 409 }) };
+    if (!meta) {
+      const bytes = await docBytesExist(env, slug);
+      if (!bytes.ok) return { ok: false, response: bytes.response };
+      if (bytes.exists) {
+        const verified = await hostedOwnerOp(env, slug, { kind: 'verify_owner', account_id: actor.account_id });
+        if (verified.ok) return { ok: true, meta: null };
+        return { ok: false, response: json({ error: verified.error || 'slug_taken' }, { status: verified.status || 409 }) };
+      }
     }
     if (meta && !accountId) return { ok: false, response: json({ error: 'slug_taken' }, { status: 409 }) };
     if (accountId && accountId !== actor.account_id) {
@@ -2523,7 +2529,12 @@ export default {
         return json({ error: 'r2_write_lost', message: 'PUT succeeded but the key is not readable. Re-deploy the worker; the R2 binding may be stale.' }, { status: 500 });
       }
       if (incoming) {
-        await env.META.put(`meta:${slug}`, JSON.stringify(incoming));
+        try {
+          await env.META.put(`meta:${slug}`, JSON.stringify(incoming));
+        } catch (e) {
+          console.error('[upload] META put failed:', e.message);
+          return json({ error: 'meta_put_failed', message: e.message || String(e) }, { status: 500 });
+        }
       }
       // Reconcile existing open comments against the new artifact set:
       // bind by aid where possible; mark lost where the artifact is gone

--- a/worker/worker.js
+++ b/worker/worker.js
@@ -1583,6 +1583,27 @@ async function hostedTokenActor(env, token) {
   return { kind: 'hosted', account_id: record.account_id, token_hash: tokenHash };
 }
 
+async function hostedOwnerOp(env, slug, op) {
+  if (!env.COMMENTS) {
+    return { ok: false, response: json({ error: 'hosted_owner_store_unavailable' }, { status: 503 }) };
+  }
+  const stub = env.COMMENTS.get(env.COMMENTS.idFromName(slug));
+  const r = await stub.fetch('https://do/owner', {
+    method: 'POST', headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ slug, op }),
+  });
+  return r.json();
+}
+
+async function docBytesExist(env, slug) {
+  try {
+    const r = await env.DOCS.list({ prefix: `docs/${slug}/` });
+    return Array.isArray(r.objects) && r.objects.length > 0;
+  } catch {
+    return false;
+  }
+}
+
 async function requireUploadAuth(req, env) {
   const auth = req.headers.get('authorization') || '';
   const m = auth.match(/^Bearer\s+(.+)$/);
@@ -1596,13 +1617,27 @@ async function requireUploadAuth(req, env) {
   return { ok: false, response: json({ error: 'unauthorized' }, { status: 401 }) };
 }
 
-async function requireDocWriteAccess(env, actor, slug) {
+async function requireDocWriteAccess(env, actor, slug, opts = {}) {
   const meta = await loadDocMeta(env, slug);
   if (!actor || actor.kind === 'admin') return { ok: true, meta };
   const accountId = meta && meta.hosted && meta.hosted.account_id;
-  if (!meta) return { ok: true, meta: null };
+  if (opts.create) {
+    if (!meta && await docBytesExist(env, slug)) {
+      return { ok: false, response: json({ error: 'slug_taken' }, { status: 409 }) };
+    }
+    if (meta && !accountId) return { ok: false, response: json({ error: 'slug_taken' }, { status: 409 }) };
+    if (accountId && accountId !== actor.account_id) {
+      return { ok: false, response: json({ error: 'not_doc_owner' }, { status: 403 }) };
+    }
+    const claimed = await hostedOwnerOp(env, slug, { kind: 'claim_owner', account_id: actor.account_id });
+    if (!claimed.ok) return { ok: false, response: json({ error: claimed.error || 'owner_claim_failed' }, { status: claimed.status || 409 }) };
+    return { ok: true, meta };
+  }
+  if (!meta) return { ok: false, response: json({ error: 'not_found' }, { status: 404 }) };
   if (!accountId) return { ok: false, response: json({ error: 'slug_taken' }, { status: 409 }) };
   if (accountId !== actor.account_id) return { ok: false, response: json({ error: 'not_doc_owner' }, { status: 403 }) };
+  const verified = await hostedOwnerOp(env, slug, { kind: 'verify_owner', account_id: actor.account_id });
+  if (!verified.ok) return { ok: false, response: json({ error: verified.error || 'not_doc_owner' }, { status: verified.status || 403 }) };
   return { ok: true, meta };
 }
 
@@ -1854,6 +1889,42 @@ export class CommentsStore {
     let payload;
     try { payload = await req.json(); } catch { return Response.json({ list: [] }); }
     const { slug, op } = payload;
+
+    // OWNER: atomic hosted slug ownership claim/verification. This intentionally
+    // lives in the same per-slug Durable Object as comments so first hosted
+    // publish claim is strongly serialized; KV is not used as the authority.
+    if (u.pathname === '/owner') {
+      let out = { ok: false, status: 400, error: 'bad_owner_op' };
+      try {
+        await this.state.storage.transaction(async (txn) => {
+          const current = await txn.get('hostedOwner');
+          const accountId = op && typeof op.account_id === 'string' ? op.account_id : '';
+          if (!accountId) {
+            out = { ok: false, status: 400, error: 'account_id_required' };
+            return;
+          }
+          if (op.kind === 'claim_owner') {
+            if (current === undefined) {
+              await txn.put('hostedOwner', accountId);
+              out = { ok: true };
+            } else if (current === accountId) {
+              out = { ok: true };
+            } else {
+              out = { ok: false, status: 403, error: 'not_doc_owner' };
+            }
+            return;
+          }
+          if (op.kind === 'verify_owner') {
+            if (current === accountId) out = { ok: true };
+            else if (current === undefined) out = { ok: false, status: 403, error: 'not_doc_owner' };
+            else out = { ok: false, status: 403, error: 'not_doc_owner' };
+          }
+        });
+      } catch (e) {
+        return Response.json({ ok: false, status: 409, error: 'owner_store_conflict', message: e.message || String(e) });
+      }
+      return Response.json(out);
+    }
 
     // READ: resolve inside a transaction so a concurrent first-touch mutation
     // can't commit between a non-transactional get and a write-back (Codex P1:
@@ -2409,12 +2480,12 @@ export default {
       if (!isValidSlug(slug)) return json({ error: 'invalid_slug' }, { status: 400 });
       const verNum = Number(version);
       if (!Number.isInteger(verNum) || verNum < 1) return json({ error: 'invalid_version' }, { status: 400 });
-      const writeGate = await requireDocWriteAccess(env, auth.actor, slug);
+      const writeGate = await requireDocWriteAccess(env, auth.actor, slug, { create: true });
       if (!writeGate.ok) return writeGate.response;
       // Validate write-side access policy before writing doc bytes. Read paths
       // stay tolerant for legacy/corrupt stored meta; writes must fail closed.
       let incoming = null;
-      if (meta) {
+      if (meta || (auth.actor && auth.actor.kind === 'hosted')) {
         incoming = (meta && typeof meta === 'object') ? { ...meta } : {};
         const prev = writeGate.meta;
         if (!incoming.access && prev && prev.access) {


### PR DESCRIPTION
## Summary

Adds the JUL-30 hosted/out-of-box publish slice: `/tdoc publish --platform hosted <slug>`.

This gives the publish CLI a tdoc-managed target that skips user-owned deploy setup:

- no Wrangler requirement
- no Vercel CLI requirement
- no R2/KV/Worker/Vercel project setup by the user
- no OAuth app setup by the user
- defaults hosted base to `https://tdoc.dev`, overridable with `TDOC_HOSTED_BASE`
- first hosted publish calls `POST /api/hosted/token` to get an account-scoped upload token
- persists `platform: "hosted"`, `base`, `public_host`, `account_id`, and `upload_token` in `~/.tdoc/published.json`
- reuses the existing `/api/upload` payload path, so access policy, versions, comments, and pure-publish behavior stay shared with self-host
- teaches `tdoc-pull` and `tdoc-unpublish` to use hosted `.base` instead of deriving a Cloudflare workers.dev URL

Server-side enforcement added in this PR:

- hosted tokens are stored as hashes in `META`, not as raw token keys
- provider admin token still works for existing single-tenant/self-host admin flows
- hosted tokens can create a new slug, then only mutate/delete/access-update/comment-wipe/agent-reply docs stamped with their `account_id`
- first hosted slug claim is serialized in the per-slug Durable Object (`hostedOwner`) rather than KV read-then-write
- hosted upload persists ownership even when the client omits `meta`
- R2 existence-check uncertainty fails closed before DO owner claim or R2 write
- same hosted owner can retry and repair ownership metadata after a partial R2-success / META-failure upload
- non-create hosted writes fail closed when remote ownership is absent; legacy/orphan docs with no meta cannot be deleted/wiped/replied to by arbitrary hosted tokens
- attempts to take an existing non-hosted slug return `slug_taken`; attempts to mutate another hosted account's slug return `not_doc_owner`
- provider can keep self-serve registration closed via env; `TDOC_HOSTED_REGISTRATION=1` enables `/api/hosted/token`

## Why

The existing `tdoc-publish` product story was still self-host first: first publish walked Cloudflare or Vercel resource setup. Julie's JUL-30 direction is hosted/out-of-box first, with self-host as an advanced path. This PR makes hosted publish self-provisioning without putting the provider-wide upload secret on user machines.

## Explicit Non-Goals

This does not add reader/comment identity beyond the existing GitHub flow. Hosted v1 remains link-share oriented; private allowlist and comment identity can be a later hosted-account layer.

This PR also does not change the default platform from Cloudflare yet. Hosted can become default after the provider intentionally enables registration and we smoke it on `tdoc.dev`.

## Validation

- `bash -n bin/tdoc-publish bin/tdoc-pull bin/tdoc-unpublish`
- `node test/cli.test.js`
- `node test/hosted-oob.test.js`
- `node test/hosted-oob-behavior.test.js`
- `node test/remote-access-route.test.js`
- `node test/publish.test.js`
- `node test/run.js` — all 24 offline suites green
- `node test/run.js --all` — all 28 suites green
