### PR TITLE
JUL-36/37: owner manage UX — no browser token (CSP), /me clean catalog, doc-page Share panel

### DIFF
--- a/server/overlay.js
+++ b/server/overlay.js
@@ -112,6 +112,9 @@
     --td-accent-ring-soft: rgba(22,82,240,0.18);
     --td-accent-wash: rgba(22,82,240,0.06);
     --td-accent-tint: #e8eeff;
+    --td-danger: #b42318;
+    --td-danger-hover: #931c14;
+    --td-danger-tint: #fdeceb;
     --td-ground: #fff;
     --td-ink: #1a1a1a;
     --td-heading: #1a1a1a;
@@ -543,6 +546,23 @@
   .tdoc-modal .danger { color: #c33; font-size: 13px; }
   .tdoc-modal code { background: #f5f6f8; padding: 1px 5px; border-radius: 3px; }
 
+  /* Manage-doc modal (JUL-36: Delete / Unpublish / visibility switch). */
+  .tdoc-modal .manage-section { margin: 16px 0; }
+  .tdoc-modal .manage-section:first-of-type { margin-top: 4px; }
+  .tdoc-modal label.field { display: block; font-size: 12px; color: #666; margin: 0 0 4px; font-weight: 600; }
+  .tdoc-modal input[type="password"] { width: 100%; box-sizing: border-box; border: 1px solid #ccc; border-radius: 6px; padding: 8px 10px; font: inherit; }
+  .tdoc-modal input[type="password"]:focus { outline: none; border-color: var(--td-accent); }
+  .tdoc-seg { display: inline-flex; border: 1px solid #ddd; border-radius: 8px; overflow: hidden; }
+  .tdoc-seg button { border: none; border-radius: 0; padding: 7px 14px; background: #fff; color: #444; }
+  .tdoc-seg button + button { border-left: 1px solid #ddd; }
+  .tdoc-seg button.active { background: var(--td-accent); color: #fff; }
+  .tdoc-modal .manage-hint { font-size: 12px; color: #888; margin: 6px 0 0; }
+  .tdoc-modal .manage-action { width: 100%; text-align: left; }
+  .tdoc-modal .manage-action.danger-btn { color: var(--td-danger); border-color: #f1b8b2; }
+  .tdoc-modal .manage-action.danger-btn:hover { background: var(--td-danger); color: #fff; border-color: var(--td-danger); }
+  .tdoc-modal button.danger { background: var(--td-danger); border-color: var(--td-danger); color: #fff; }
+  .tdoc-modal button.danger:hover { background: var(--td-danger-hover); border-color: var(--td-danger-hover); }
+
   /* Bar collapse breakpoints — tied to viewport width, not layout class.
      The bar progressively hides elements as the viewport tightens, so it
      stays elegant at every size.
@@ -883,6 +903,7 @@
           </button>
           <div class="tdoc-menu" id="tdoc-me-menu" role="menu">
             ${isOwner ? `<button id="tdoc-my-docs" role="menuitem">My docs</button>` : ''}
+            ${isOwner && cfg.ownerManage && isPublished ? `<button id="tdoc-manage-doc" role="menuitem">Manage this doc</button>` : ''}
             <button id="tdoc-signout" role="menuitem">Sign out</button>
           </div>
         </div>`;
@@ -896,6 +917,13 @@
       if (isOwner) {
         document.getElementById('tdoc-my-docs').onclick = () => {
           window.open('/me', '_blank', 'noopener');
+        };
+      }
+      if (isOwner && cfg.ownerManage && isPublished) {
+        document.getElementById('tdoc-manage-doc').onclick = (e) => {
+          e.stopPropagation();
+          meMenu.classList.remove('open');
+          showManageModal();
         };
       }
       document.getElementById('tdoc-signout').onclick = async () => {
@@ -2347,6 +2375,187 @@
       navigator.clipboard?.writeText(e.currentTarget.textContent);
     };
   }
+  // ========== Owner manage (Delete / Unpublish / visibility switch) ==========
+  // JUL-36. Gated on cfg.ownerManage, which the worker only populates in the
+  // per-request boot config when THIS request's session passed
+  // isOwnerSession() server-side (worker.js's /d/ route). A non-owner's
+  // config carries cfg.ownerManage === null — every function below bails
+  // before creating any DOM, so there is no hidden button, just nothing
+  // rendered for them.
+  //
+  // A published doc is arbitrary HTML the owner authored, not a fully
+  // trusted execution context on this origin — so, exactly like /me, these
+  // mutations require the admin token (typed fresh here, kept only in this
+  // closure's `mgmtToken` var, never written to storage/cookies) rather than
+  // accepting the owner's session cookie alone. See
+  // test/me-management.test.js for why cookie-only admin writes are rejected.
+  let mgmtToken = '';
+  const VIS_OPTIONS = [['public', 'Public'], ['unlisted', 'Unlisted'], ['private', 'Private']];
+  function closeManageModal() {
+    const m = document.getElementById('tdoc-manage-modal');
+    if (m) m.remove();
+  }
+  function closeManageConfirm() {
+    const m = document.getElementById('tdoc-manage-confirm');
+    if (m) m.remove();
+  }
+  function showManageConfirm({ title, body, confirmLabel, danger, onConfirm }) {
+    closeManageConfirm();
+    const bg = document.createElement('div');
+    bg.className = 'tdoc-modal-bg';
+    bg.id = 'tdoc-manage-confirm';
+    bg.innerHTML = `
+      <div class="tdoc-modal">
+        <h3>${escapeHtml(title)}</h3>
+        <p>${body}</p>
+        <div class="status" id="tdoc-manage-confirm-status" style="display:none;"></div>
+        <div class="actions">
+          <button type="button" id="tdoc-manage-confirm-cancel">Cancel</button>
+          <button type="button" id="tdoc-manage-confirm-go" class="${danger ? 'danger' : 'primary'}">${escapeHtml(confirmLabel)}</button>
+        </div>
+      </div>`;
+    document.body.appendChild(bg);
+    document.getElementById('tdoc-manage-confirm-cancel').onclick = closeManageConfirm;
+    bg.addEventListener('click', (e) => { if (e.target === bg) closeManageConfirm(); });
+    document.getElementById('tdoc-manage-confirm-go').onclick = async () => {
+      const status = document.getElementById('tdoc-manage-confirm-status');
+      const go = document.getElementById('tdoc-manage-confirm-go');
+      go.disabled = true;
+      status.style.display = 'block';
+      status.textContent = 'Working…';
+      try {
+        await onConfirm(status);
+      } catch (e) {
+        status.textContent = 'Failed: ' + e.message;
+        go.disabled = false;
+      }
+    };
+  }
+  async function mgmtFetch(url, opts) {
+    if (!mgmtToken) throw new Error('Admin token is required.');
+    const headers = { 'Content-Type': 'application/json', 'Authorization': 'Bearer ' + mgmtToken, ...(opts.headers || {}) };
+    const r = await fetch(url, { ...opts, headers });
+    if (!r.ok) {
+      const err = await r.json().catch(() => ({}));
+      throw new Error(err.error || err.message || ('HTTP ' + r.status));
+    }
+    return r.json().catch(() => ({}));
+  }
+  function renderVisSeg(current) {
+    const seg = document.getElementById('tdoc-vis-seg');
+    if (!seg) return;
+    seg.querySelectorAll('button').forEach(b => b.classList.toggle('active', b.dataset.value === current));
+  }
+  function showManageModal() {
+    if (!cfg.ownerManage) return; // no owner data for this request → nothing to render
+    closeAuxModal();
+    const om = cfg.ownerManage;
+    const access = { ...(om.access || { visibility: 'unlisted' }) };
+    const plural = (n, word) => n + ' ' + word + (n === 1 ? '' : 's');
+    const bg = document.createElement('div');
+    bg.className = 'tdoc-modal-bg';
+    bg.id = 'tdoc-manage-modal';
+    bg.innerHTML = `
+      <div class="tdoc-modal">
+        <h3>Manage this doc</h3>
+        <p class="muted">${escapeHtml(slug)} · ${plural(om.versionCount, 'version')} · ${plural(om.commentCount, 'comment')}</p>
+        <label class="field" for="tdoc-mgmt-token">Admin token</label>
+        <input type="password" id="tdoc-mgmt-token" autocomplete="off" placeholder="Required — same token used to publish this doc" value="${escapeHtml(mgmtToken)}">
+        <div class="manage-section">
+          <label class="field">Visibility</label><br>
+          <div class="tdoc-seg" id="tdoc-vis-seg">
+            ${VIS_OPTIONS.map(([v, l]) => `<button type="button" data-value="${v}">${l}</button>`).join('')}
+          </div>
+          <p class="manage-hint" id="tdoc-vis-status">&nbsp;</p>
+        </div>
+        <div class="manage-section">
+          <button type="button" id="tdoc-mgmt-unpublish" class="manage-action">Unpublish</button>
+          <p class="manage-hint">Sets this doc to Private. Versions and comments are kept — republish anytime.</p>
+        </div>
+        <div class="manage-section">
+          <button type="button" id="tdoc-mgmt-delete" class="manage-action danger-btn">Delete doc…</button>
+          <p class="manage-hint">Permanently removes this doc, every version, and every comment. No undo.</p>
+        </div>
+        <div class="actions"><button type="button" id="tdoc-manage-close">Close</button></div>
+      </div>`;
+    document.body.appendChild(bg);
+    renderVisSeg(access.visibility);
+    document.getElementById('tdoc-manage-close').onclick = closeManageModal;
+    bg.addEventListener('click', (e) => { if (e.target === bg) closeManageModal(); });
+    const tokenInput = document.getElementById('tdoc-mgmt-token');
+    tokenInput.oninput = () => { mgmtToken = tokenInput.value.trim(); };
+
+    document.getElementById('tdoc-vis-seg').querySelectorAll('button').forEach(b => {
+      b.onclick = async () => {
+        const value = b.dataset.value;
+        if (value === access.visibility) return;
+        const status = document.getElementById('tdoc-vis-status');
+        const commit = async () => {
+          status.textContent = 'Saving…';
+          try {
+            await mgmtFetch('/api/doc/access', {
+              method: 'PATCH',
+              body: JSON.stringify({ slug, access: { visibility: value } }),
+            });
+            access.visibility = value;
+            renderVisSeg(value);
+            status.textContent = 'Saved: ' + VIS_OPTIONS.find(([v]) => v === value)[1];
+          } catch (e) {
+            status.textContent = 'Failed: ' + e.message;
+          }
+        };
+        // Switching TO private is the same effect as Unpublish (takes the
+        // doc offline) — worth a confirm even though it's reversible.
+        if (value === 'private') {
+          showManageConfirm({
+            title: 'Switch to Private?',
+            body: 'Only you (and anyone on the allowlist) will be able to open this doc.',
+            confirmLabel: 'Switch to Private',
+            onConfirm: async (confirmStatus) => {
+              await commit();
+              confirmStatus.textContent = 'Done.';
+              closeManageConfirm();
+            },
+          });
+        } else {
+          await commit();
+        }
+      };
+    });
+
+    document.getElementById('tdoc-mgmt-unpublish').onclick = () => {
+      showManageConfirm({
+        title: 'Take this doc offline?',
+        body: 'This sets visibility to <b>Private</b> — only you can open it until you publish again. Comments and version history are kept.',
+        confirmLabel: 'Unpublish',
+        onConfirm: async (status) => {
+          await mgmtFetch('/api/doc/access', {
+            method: 'PATCH',
+            body: JSON.stringify({ slug, access: { visibility: 'private' } }),
+          });
+          access.visibility = 'private';
+          renderVisSeg('private');
+          status.textContent = 'Unpublished.';
+          setTimeout(closeManageConfirm, 700);
+        },
+      });
+    };
+
+    document.getElementById('tdoc-mgmt-delete').onclick = () => {
+      showManageConfirm({
+        title: 'Delete this doc?',
+        body: `This permanently removes <b>${escapeHtml(slug)}</b> — all <b>${plural(om.versionCount, 'version')}</b> and <b>${plural(om.commentCount, 'comment')}</b> are deleted. This cannot be undone.`,
+        confirmLabel: 'Delete',
+        danger: true,
+        onConfirm: async (status) => {
+          await mgmtFetch(`/api/doc?slug=${encodeURIComponent(slug)}`, { method: 'DELETE' });
+          status.textContent = 'Deleted. Redirecting…';
+          setTimeout(() => { window.location.href = 'https://github.com/tornado-doc/tdoc'; }, 900);
+        },
+      });
+    };
+  }
+
   async function pollDevice(device_code) {
     const status = document.getElementById('tdoc-poll-status');
     pollTimer = null;

--- a/server/overlay.js
+++ b/server/overlay.js
@@ -529,7 +529,7 @@
 
   /* Modal (sign-in) */
   .tdoc-modal-bg { position: fixed; inset: 0; background: rgba(0,0,0,0.55); z-index: 1000000; display: flex; align-items: center; justify-content: center; font: 14px system-ui, sans-serif; }
-  .tdoc-modal { background: #fff; color: #111; border-radius: 12px; padding: 28px; width: 460px; box-shadow: 0 20px 60px rgba(0,0,0,0.3); }
+  .tdoc-modal { background: #fff; color: #111; border-radius: 12px; padding: 28px; width: min(460px, calc(100vw - 32px)); box-shadow: 0 20px 60px rgba(0,0,0,0.3); }
   .tdoc-modal h3 { margin: 0 0 8px; font-size: 20px; }
   .tdoc-modal p { margin: 0 0 14px; color: #444; line-height: 1.5; }
   .tdoc-modal .code { background: #0a0a0a; color: #fff; padding: 18px; border-radius: 8px; font: 24px ui-monospace, "SF Mono", Menlo, monospace; letter-spacing: 0.15em; text-align: center; margin: 0 0 14px; user-select: all; cursor: copy; }
@@ -599,7 +599,7 @@
   body.tdoc-narrow .tdoc-fab { position: fixed; bottom: 16px; right: 16px; z-index: 999997; background: var(--td-accent); color: #fff; border: none; border-radius: 999px; padding: 10px 16px; font: 13px system-ui; font-weight: 600; box-shadow: 0 4px 16px var(--td-accent-ring); cursor: pointer; display: inline-flex; align-items: center; gap: 6px; }
   body.tdoc-narrow .tdoc-fab:active { transform: scale(0.96); }
   body.tdoc-narrow .tdoc-popup { width: calc(100vw - 24px); max-width: 320px; left: 12px !important; }
-  body.tdoc-narrow .tdoc-modal { width: calc(100vw - 32px); padding: 20px; }
+  body.tdoc-narrow .tdoc-modal { padding: 20px; }
   body.tdoc-narrow .tdoc-modal .code { font-size: 20px; }
   body.tdoc-narrow .tdoc-hover-outline, body.tdoc-narrow .tdoc-comment-pill, body.tdoc-narrow .tdoc-drag-marquee { display: none; }
   body.tdoc-narrow .tdoc-emoji-picker { grid-template-columns: repeat(6, 36px); }

--- a/server/overlay.js
+++ b/server/overlay.js
@@ -34,6 +34,21 @@
 
   const HIGHLIGHT_API = typeof CSS !== 'undefined' && CSS.highlights && typeof Highlight === 'function';
 
+  // Broken-avatar fallback, delegated (CSP-safe). Doc responses now carry a
+  // nonce-based script-src CSP (see worker.js cspHeader()) with no
+  // 'unsafe-inline', so an inline `onerror="..."` attribute — which this used
+  // to be — can never run. `error` events on <img> don't bubble, so this must
+  // be a CAPTURE-phase listener on document, not a delegated bubble listener.
+  // avatarHTML() below marks fallback-eligible images with
+  // data-tdoc-fallback-anon instead of an inline handler.
+  document.addEventListener('error', (e) => {
+    const img = e.target;
+    if (!img || img.tagName !== 'IMG' || !img.dataset || !img.dataset.tdocFallbackAnon) return;
+    const span = document.createElement('span');
+    span.className = img.dataset.tdocFallbackAnon;
+    img.replaceWith(span);
+  }, true);
+
   // Phones need this or they render at a virtual ~980px viewport.
   if (!document.querySelector('meta[name="viewport"]')) {
     const m = document.createElement('meta');
@@ -546,13 +561,14 @@
   .tdoc-modal .danger { color: #c33; font-size: 13px; }
   .tdoc-modal code { background: #f5f6f8; padding: 1px 5px; border-radius: 3px; }
 
-  /* Manage-doc modal (JUL-36: Delete / Unpublish / visibility switch). */
+  /* Share panel (JUL-36, reworked 2026-08-13: visibility/history/commenting/
+     allowed_users + Delete/Unpublish — no admin token, session-authorized). */
   .tdoc-modal .manage-section { margin: 16px 0; }
   .tdoc-modal .manage-section:first-of-type { margin-top: 4px; }
   .tdoc-modal label.field { display: block; font-size: 12px; color: #666; margin: 0 0 4px; font-weight: 600; }
-  .tdoc-modal input[type="password"] { width: 100%; box-sizing: border-box; border: 1px solid #ccc; border-radius: 6px; padding: 8px 10px; font: inherit; }
-  .tdoc-modal input[type="password"]:focus { outline: none; border-color: var(--td-accent); }
-  .tdoc-seg { display: inline-flex; border: 1px solid #ddd; border-radius: 8px; overflow: hidden; }
+  .tdoc-modal input[type="password"], .tdoc-modal input[type="text"] { width: 100%; box-sizing: border-box; border: 1px solid #ccc; border-radius: 6px; padding: 8px 10px; font: inherit; }
+  .tdoc-modal input[type="password"]:focus, .tdoc-modal input[type="text"]:focus { outline: none; border-color: var(--td-accent); }
+  .tdoc-seg { display: inline-flex; border: 1px solid #ddd; border-radius: 8px; overflow: hidden; flex-wrap: wrap; }
   .tdoc-seg button { border: none; border-radius: 0; padding: 7px 14px; background: #fff; color: #444; }
   .tdoc-seg button + button { border-left: 1px solid #ddd; }
   .tdoc-seg button.active { background: var(--td-accent); color: #fff; }
@@ -903,7 +919,7 @@
           </button>
           <div class="tdoc-menu" id="tdoc-me-menu" role="menu">
             ${isOwner ? `<button id="tdoc-my-docs" role="menuitem">My docs</button>` : ''}
-            ${isOwner && cfg.ownerManage && isPublished ? `<button id="tdoc-manage-doc" role="menuitem">Manage this doc</button>` : ''}
+            ${isOwner && cfg.ownerManage && isPublished ? `<button id="tdoc-manage-doc" role="menuitem">Share settings</button>` : ''}
             <button id="tdoc-signout" role="menuitem">Sign out</button>
           </div>
         </div>`;
@@ -1807,10 +1823,12 @@
 
   function avatarHTML(author, anonClass) {
     const url = author?.avatar_url;
-    // onerror: if the avatar 404s / is CORS-blocked, swap the broken <img> for
-    // the anon placeholder so the pin/row never shows a broken-image glyph.
+    // If the avatar 404s / is CORS-blocked, the document-level capture-phase
+    // 'error' listener installed at boot swaps the broken <img> for the anon
+    // placeholder (data-tdoc-fallback-anon carries which class to use) — no
+    // inline onerror= attribute, which a nonce-based CSP would block anyway.
     return url
-      ? `<img src="${escapeHtml(url)}" alt="" onerror="this.outerHTML='&lt;span class=&quot;${anonClass}&quot;&gt;&lt;/span&gt;'">`
+      ? `<img src="${escapeHtml(url)}" alt="" data-tdoc-fallback-anon="${anonClass}">`
       : `<span class="${anonClass}"></span>`;
   }
 
@@ -2375,22 +2393,23 @@
       navigator.clipboard?.writeText(e.currentTarget.textContent);
     };
   }
-  // ========== Owner manage (Delete / Unpublish / visibility switch) ==========
-  // JUL-36. Gated on cfg.ownerManage, which the worker only populates in the
-  // per-request boot config when THIS request's session passed
-  // isOwnerSession() server-side (worker.js's /d/ route). A non-owner's
-  // config carries cfg.ownerManage === null — every function below bails
-  // before creating any DOM, so there is no hidden button, just nothing
-  // rendered for them.
+  // ========== Owner manage / Share panel (Delete / Unpublish / access) =====
+  // JUL-36, reworked 2026-08-13 (julie: browser owner management should work
+  // off the GitHub login, like Google Docs — no pasted token). Gated on
+  // cfg.ownerManage, which the worker only populates in the per-request boot
+  // config when THIS request's session passed isOwnerSession() server-side
+  // (worker.js's /d/ route). A non-owner's config carries
+  // cfg.ownerManage === null — every function below bails before creating
+  // any DOM, so there is no hidden button, just nothing rendered for them.
   //
-  // A published doc is arbitrary HTML the owner authored, not a fully
-  // trusted execution context on this origin — so, exactly like /me, these
-  // mutations require the admin token (typed fresh here, kept only in this
-  // closure's `mgmtToken` var, never written to storage/cookies) rather than
-  // accepting the owner's session cookie alone. See
-  // test/me-management.test.js for why cookie-only admin writes are rejected.
-  let mgmtToken = '';
-  const VIS_OPTIONS = [['public', 'Public'], ['unlisted', 'Unlisted'], ['private', 'Private']];
+  // A published doc is arbitrary HTML the owner authored, so this being
+  // session-authorized (no token) is safe ONLY because the worker now sends
+  // a CSP (see worker.js cspHeader()) on every doc response that blocks
+  // author <script>/onclick content outright — a doc can't ride the owner's
+  // session cookie into these routes anymore. ownerFetch() below relies on
+  // the browser's default same-origin credential behavior (cookie sent
+  // automatically); `credentials: 'same-origin'` is passed explicitly for
+  // clarity, not because it changes behavior here.
   function closeManageModal() {
     const m = document.getElementById('tdoc-manage-modal');
     if (m) m.remove();
@@ -2431,18 +2450,22 @@
       }
     };
   }
-  async function mgmtFetch(url, opts) {
-    if (!mgmtToken) throw new Error('Admin token is required.');
-    const headers = { 'Content-Type': 'application/json', 'Authorization': 'Bearer ' + mgmtToken, ...(opts.headers || {}) };
-    const r = await fetch(url, { ...opts, headers });
+  // No Authorization header, no token — the owner's session cookie is sent
+  // automatically on this same-origin request (see doc comment above).
+  async function ownerFetch(url, opts) {
+    const headers = { 'Content-Type': 'application/json', ...(opts.headers || {}) };
+    const r = await fetch(url, { ...opts, headers, credentials: 'same-origin' });
     if (!r.ok) {
       const err = await r.json().catch(() => ({}));
       throw new Error(err.error || err.message || ('HTTP ' + r.status));
     }
     return r.json().catch(() => ({}));
   }
-  function renderVisSeg(current) {
-    const seg = document.getElementById('tdoc-vis-seg');
+  const VIS_OPTIONS = [['public', 'Public'], ['unlisted', 'Unlisted'], ['private', 'Private']];
+  const HISTORY_OPTIONS = [['owner', 'Owner only'], ['invited', 'Invited'], ['public', 'Everyone']];
+  const COMMENTING_OPTIONS = [['signed_in', 'Signed in'], ['invited', 'Invited'], ['owner', 'Owner only'], ['off', 'Off']];
+  function renderSeg(id, current) {
+    const seg = document.getElementById(id);
     if (!seg) return;
     seg.querySelectorAll('button').forEach(b => b.classList.toggle('active', b.dataset.value === current));
   }
@@ -2450,23 +2473,41 @@
     if (!cfg.ownerManage) return; // no owner data for this request → nothing to render
     closeAuxModal();
     const om = cfg.ownerManage;
-    const access = { ...(om.access || { visibility: 'unlisted' }) };
+    const access = {
+      visibility: 'unlisted', history_visibility: 'owner', commenting: 'signed_in', allowed_users: [],
+      ...(om.access || {}),
+    };
     const plural = (n, word) => n + ' ' + word + (n === 1 ? '' : 's');
     const bg = document.createElement('div');
     bg.className = 'tdoc-modal-bg';
     bg.id = 'tdoc-manage-modal';
     bg.innerHTML = `
       <div class="tdoc-modal">
-        <h3>Manage this doc</h3>
+        <h3>Share settings</h3>
         <p class="muted">${escapeHtml(slug)} · ${plural(om.versionCount, 'version')} · ${plural(om.commentCount, 'comment')}</p>
-        <label class="field" for="tdoc-mgmt-token">Admin token</label>
-        <input type="password" id="tdoc-mgmt-token" autocomplete="off" placeholder="Required — same token used to publish this doc" value="${escapeHtml(mgmtToken)}">
         <div class="manage-section">
-          <label class="field">Visibility</label><br>
+          <label class="field">Visibility</label>
           <div class="tdoc-seg" id="tdoc-vis-seg">
             ${VIS_OPTIONS.map(([v, l]) => `<button type="button" data-value="${v}">${l}</button>`).join('')}
           </div>
           <p class="manage-hint" id="tdoc-vis-status">&nbsp;</p>
+        </div>
+        <div class="manage-section">
+          <label class="field">Who can see version history</label>
+          <div class="tdoc-seg" id="tdoc-hist-seg">
+            ${HISTORY_OPTIONS.map(([v, l]) => `<button type="button" data-value="${v}">${l}</button>`).join('')}
+          </div>
+        </div>
+        <div class="manage-section">
+          <label class="field">Who can comment</label>
+          <div class="tdoc-seg" id="tdoc-comment-seg">
+            ${COMMENTING_OPTIONS.map(([v, l]) => `<button type="button" data-value="${v}">${l}</button>`).join('')}
+          </div>
+        </div>
+        <div class="manage-section">
+          <label class="field" for="tdoc-mgmt-allowed">Allowed users (private / invited)</label>
+          <input type="text" id="tdoc-mgmt-allowed" autocomplete="off" placeholder="github-login, another-login" value="${escapeHtml((access.allowed_users || []).join(', '))}">
+          <p class="manage-hint" id="tdoc-allowed-status">&nbsp;</p>
         </div>
         <div class="manage-section">
           <button type="button" id="tdoc-mgmt-unpublish" class="manage-action">Unpublish</button>
@@ -2479,11 +2520,27 @@
         <div class="actions"><button type="button" id="tdoc-manage-close">Close</button></div>
       </div>`;
     document.body.appendChild(bg);
-    renderVisSeg(access.visibility);
+    renderSeg('tdoc-vis-seg', access.visibility);
+    renderSeg('tdoc-hist-seg', access.history_visibility);
+    renderSeg('tdoc-comment-seg', access.commenting);
     document.getElementById('tdoc-manage-close').onclick = closeManageModal;
     bg.addEventListener('click', (e) => { if (e.target === bg) closeManageModal(); });
-    const tokenInput = document.getElementById('tdoc-mgmt-token');
-    tokenInput.oninput = () => { mgmtToken = tokenInput.value.trim(); };
+
+    // Shared PATCH /api/doc/access helper — merges `patch` into the local
+    // `access` mirror on success so re-renders (renderSeg) reflect it.
+    async function patchAccess(patch, statusEl, successMsg) {
+      statusEl.textContent = 'Saving…';
+      try {
+        await ownerFetch('/api/doc/access', {
+          method: 'PATCH',
+          body: JSON.stringify({ slug, access: patch }),
+        });
+        Object.assign(access, patch);
+        statusEl.textContent = successMsg;
+      } catch (e) {
+        statusEl.textContent = 'Failed: ' + e.message;
+      }
+    }
 
     document.getElementById('tdoc-vis-seg').querySelectorAll('button').forEach(b => {
       b.onclick = async () => {
@@ -2491,18 +2548,8 @@
         if (value === access.visibility) return;
         const status = document.getElementById('tdoc-vis-status');
         const commit = async () => {
-          status.textContent = 'Saving…';
-          try {
-            await mgmtFetch('/api/doc/access', {
-              method: 'PATCH',
-              body: JSON.stringify({ slug, access: { visibility: value } }),
-            });
-            access.visibility = value;
-            renderVisSeg(value);
-            status.textContent = 'Saved: ' + VIS_OPTIONS.find(([v]) => v === value)[1];
-          } catch (e) {
-            status.textContent = 'Failed: ' + e.message;
-          }
+          await patchAccess({ visibility: value }, status, 'Saved: ' + VIS_OPTIONS.find(([v]) => v === value)[1]);
+          renderSeg('tdoc-vis-seg', access.visibility);
         };
         // Switching TO private is the same effect as Unpublish (takes the
         // doc offline) — worth a confirm even though it's reversible.
@@ -2523,19 +2570,38 @@
       };
     });
 
+    document.getElementById('tdoc-hist-seg').querySelectorAll('button').forEach(b => {
+      b.onclick = async () => {
+        const value = b.dataset.value;
+        if (value === access.history_visibility) return;
+        await patchAccess({ history_visibility: value }, document.getElementById('tdoc-vis-status'), 'Saved.');
+        renderSeg('tdoc-hist-seg', access.history_visibility);
+      };
+    });
+
+    document.getElementById('tdoc-comment-seg').querySelectorAll('button').forEach(b => {
+      b.onclick = async () => {
+        const value = b.dataset.value;
+        if (value === access.commenting) return;
+        await patchAccess({ commenting: value }, document.getElementById('tdoc-vis-status'), 'Saved.');
+        renderSeg('tdoc-comment-seg', access.commenting);
+      };
+    });
+
+    const allowedInput = document.getElementById('tdoc-mgmt-allowed');
+    allowedInput.addEventListener('change', async () => {
+      const list = allowedInput.value.split(/[\s,]+/).map(s => s.trim()).filter(Boolean);
+      await patchAccess({ allowed_users: list }, document.getElementById('tdoc-allowed-status'), 'Saved.');
+    });
+
     document.getElementById('tdoc-mgmt-unpublish').onclick = () => {
       showManageConfirm({
         title: 'Take this doc offline?',
         body: 'This sets visibility to <b>Private</b> — only you can open it until you publish again. Comments and version history are kept.',
         confirmLabel: 'Unpublish',
         onConfirm: async (status) => {
-          await mgmtFetch('/api/doc/access', {
-            method: 'PATCH',
-            body: JSON.stringify({ slug, access: { visibility: 'private' } }),
-          });
-          access.visibility = 'private';
-          renderVisSeg('private');
-          status.textContent = 'Unpublished.';
+          await patchAccess({ visibility: 'private' }, status, 'Unpublished.');
+          renderSeg('tdoc-vis-seg', 'private');
           setTimeout(closeManageConfirm, 700);
         },
       });
@@ -2548,7 +2614,7 @@
         confirmLabel: 'Delete',
         danger: true,
         onConfirm: async (status) => {
-          await mgmtFetch(`/api/doc?slug=${encodeURIComponent(slug)}`, { method: 'DELETE' });
+          await ownerFetch(`/api/doc?slug=${encodeURIComponent(slug)}`, { method: 'DELETE' });
           status.textContent = 'Deleted. Redirecting…';
           setTimeout(() => { window.location.href = 'https://github.com/tornado-doc/tdoc'; }, 900);
         },

--- a/server/overlay.js
+++ b/server/overlay.js
@@ -529,7 +529,7 @@
 
   /* Modal (sign-in) */
   .tdoc-modal-bg { position: fixed; inset: 0; background: rgba(0,0,0,0.55); z-index: 1000000; display: flex; align-items: center; justify-content: center; font: 14px system-ui, sans-serif; }
-  .tdoc-modal { background: #fff; color: #111; border-radius: 12px; padding: 28px; width: min(460px, calc(100vw - 32px)); box-shadow: 0 20px 60px rgba(0,0,0,0.3); }
+  .tdoc-modal { background: #fff; color: #111; border-radius: 12px; padding: 28px; width: min(460px, calc(100vw - 48px)); box-shadow: 0 20px 60px rgba(0,0,0,0.3); }
   .tdoc-modal h3 { margin: 0 0 8px; font-size: 20px; }
   .tdoc-modal p { margin: 0 0 14px; color: #444; line-height: 1.5; }
   .tdoc-modal .code { background: #0a0a0a; color: #fff; padding: 18px; border-radius: 8px; font: 24px ui-monospace, "SF Mono", Menlo, monospace; letter-spacing: 0.15em; text-align: center; margin: 0 0 14px; user-select: all; cursor: copy; }

--- a/server/server.js
+++ b/server/server.js
@@ -7,6 +7,7 @@ const http = require('http');
 const fs = require('fs');
 const path = require('path');
 const os = require('os');
+const crypto = require('crypto');
 const { spawn } = require('child_process');
 
 const PORT = process.env.TDOC_PORT ? Number(process.env.TDOC_PORT) : 7878;
@@ -114,7 +115,19 @@ function safeJsonForScript(obj) {
   return JSON.stringify(obj).replace(/<\/script>/gi, '<\\/script>').replace(/<!--/g, '<\\!--');
 }
 
-function injectOverlay(html, slug, version) {
+// CSP (owner-manage-via-session hardening, mirrors worker/worker.js).
+//
+// Local docs are anonymous/no-auth by design, so this route isn't guarding a
+// session cookie today — but the local server shares overlay.js with the
+// published worker, and a doc authored locally is the same bytes that later
+// get published. Blocking author <script>/onclick here too means what a doc
+// author sees locally matches what ships (no "worked in dev, XSS in prod"
+// surprise), and costs nothing since 0 published docs use <script>.
+function cspHeader(nonce) {
+  return `script-src 'nonce-${nonce}' 'strict-dynamic'; object-src 'none'; base-uri 'none';`;
+}
+
+function injectOverlay(html, slug, version, nonce) {
   const overlay = fs.readFileSync(OVERLAY_PATH, 'utf8');
   // Hand the overlay the full version list so the bar can offer a version
   // picker. Read straight from meta.json; ignore failures and fall back to
@@ -126,10 +139,14 @@ function injectOverlay(html, slug, version) {
       versions = meta.versions.map(v => ({ n: v.n, created: v.created || null }));
     }
   } catch {}
-  const cfg = `<script>window.__TDOC__ = ${safeJsonForScript({
+  // nonce is stamped onto BOTH injected <script> tags so only they run under
+  // the CSP set by cspHeader() above — author content in `html` has no nonce
+  // and is inert.
+  const nonceAttr = nonce ? ` nonce="${nonce}"` : '';
+  const cfg = `<script${nonceAttr}>window.__TDOC__ = ${safeJsonForScript({
     slug, version, identity: null, authConfigured: false, mode: 'local', versions,
   })};</script>`;
-  const inject = `${cfg}\n<script>${overlay}</script>`;
+  const inject = `${cfg}\n<script${nonceAttr}>${overlay}</script>`;
   if (html.includes('</body>')) return html.replace('</body>', `${inject}\n</body>`);
   return html + inject;
 }
@@ -310,7 +327,11 @@ const server = http.createServer(async (req, res) => {
     const file = path.join(ROOT, slug, `v${vStr}`, 'index.html');
     if (!fs.existsSync(file)) return send(res, 404, `Not found: ${slug} v${vStr}`);
     const html = fs.readFileSync(file, 'utf8');
-    return send(res, 200, injectOverlay(html, slug, Number(vStr)), { 'Content-Type': 'text/html; charset=utf-8' });
+    const nonce = crypto.randomBytes(16).toString('hex');
+    return send(res, 200, injectOverlay(html, slug, Number(vStr), nonce), {
+      'Content-Type': 'text/html; charset=utf-8',
+      'Content-Security-Policy': cspHeader(nonce),
+    });
   }
 
   // --- COMMENTS (anonymous) ---

--- a/server/server.js
+++ b/server/server.js
@@ -201,6 +201,7 @@ function indexPage() {
   const rows = slugs.map(slug => {
     const meta = readJson(path.join(ROOT, slug, 'meta.json'), { title: slug, versions: [] });
     const latest = meta.versions?.[meta.versions.length - 1]?.n || 1;
+    const versionCount = Array.isArray(meta.versions) && meta.versions.length ? meta.versions.length : 1;
     const comments = readCommentFile(path.join(ROOT, slug, 'comments.json'));
     const open = comments.filter(c => c.status === 'open').length;
     return `<tr>
@@ -208,35 +209,78 @@ function indexPage() {
       <td>${escHtml(slug)}</td>
       <td>v${latest}</td>
       <td>${open ? `<b>${open} open</b>` : '—'}</td>
-      <td><button class="del" data-slug="${escHtml(slug)}" data-versions="${latest}" data-comments="${comments.length}">Delete</button></td>
+      <td><button class="del" data-slug="${escHtml(slug)}" data-versions="${versionCount}" data-comments="${comments.length}">Delete</button></td>
     </tr>`;
   }).join('');
   return `<!doctype html><html><head><meta charset="utf-8"><title>tdoc</title>
 <style>
-  body { font: 15px system-ui, -apple-system, sans-serif; max-width: 760px; margin: 60px auto; padding: 0 20px; color: #111; }
-  h1 { font-size: 28px; margin: 0 0 4px; color: #1652f0; }
-  .sub { color: #666; margin: 0 0 32px; }
+  :root {
+    --td-accent: #1652f0; --td-accent-hover: #1245d0;
+    --td-danger: #b42318; --td-danger-hover: #931c14;
+    --td-ink: #111; --td-muted: #666; --td-line: #eee;
+  }
+  body { font: 15px system-ui, -apple-system, sans-serif; max-width: 760px; margin: 60px auto; padding: 0 20px; color: var(--td-ink); }
+  h1 { font-size: 28px; margin: 0 0 4px; color: var(--td-accent); }
+  .sub { color: var(--td-muted); margin: 0 0 32px; }
   table { width: 100%; border-collapse: collapse; }
-  th, td { text-align: left; padding: 10px 12px; border-bottom: 1px solid #eee; }
+  th, td { text-align: left; padding: 10px 12px; border-bottom: 1px solid var(--td-line); }
   th { font-size: 12px; text-transform: uppercase; color: #888; letter-spacing: 0.04em; }
-  a { color: #1652f0; text-decoration: none; }
+  a { color: var(--td-accent); text-decoration: none; }
   a:hover { text-decoration: underline; }
   .empty { color: #888; padding: 40px 0; text-align: center; }
-  .del { font: 12px system-ui; color: #a52323; background: none; border: 1px solid #e0c9c9; border-radius: 6px; padding: 3px 9px; cursor: pointer; }
-  .del:hover { background: #a52323; color: #fff; border-color: #a52323; }
+  .del { font: 12px system-ui; color: var(--td-danger); background: none; border: 1px solid #e0c9c9; border-radius: 6px; padding: 3px 9px; cursor: pointer; transition: background .12s, color .12s; }
+  .del:hover { background: var(--td-danger); color: #fff; border-color: var(--td-danger); }
+  /* Styled confirm modal — replaces window.confirm() (JUL-36). Standalone
+     copy of the doc overlay's .tdoc-modal-bg/.tdoc-modal visual language;
+     this page doesn't load overlay.js. */
+  .tdoc-modal-bg { position: fixed; inset: 0; background: rgba(0,0,0,0.55); z-index: 1000; display: flex; align-items: center; justify-content: center; font: 14px system-ui, sans-serif; }
+  .tdoc-modal { background: #fff; color: var(--td-ink); border-radius: 12px; padding: 26px; width: 420px; max-width: calc(100vw - 32px); box-shadow: 0 20px 60px rgba(0,0,0,0.3); }
+  .tdoc-modal h3 { margin: 0 0 10px; font-size: 18px; }
+  .tdoc-modal p { margin: 0 0 14px; color: #444; line-height: 1.5; }
+  .tdoc-modal .actions { display: flex; gap: 8px; justify-content: flex-end; margin-top: 6px; }
+  .tdoc-modal button { font: inherit; cursor: pointer; padding: 8px 16px; border-radius: 6px; border: 1px solid #ccc; background: #fff; }
+  .tdoc-modal button.danger { background: var(--td-danger); border-color: var(--td-danger); color: #fff; }
+  .tdoc-modal button.danger:hover { background: var(--td-danger-hover); border-color: var(--td-danger-hover); }
 </style></head><body>
 <h1>tdoc</h1><p class="sub">Prompt-native documents.</p>
 ${slugs.length === 0 ? '<p class="empty">No docs yet. Try <code>/tdoc new &lt;prompt&gt;</code>.</p>' :
   `<table><thead><tr><th>Title</th><th>Slug</th><th>Version</th><th>Comments</th><th></th></tr></thead><tbody>${rows}</tbody></table>`}
 <script>
+function showConfirm({ title, body, confirmLabel, danger }) {
+  return new Promise((resolve) => {
+    const bg = document.createElement('div');
+    bg.className = 'tdoc-modal-bg';
+    bg.innerHTML = '<div class="tdoc-modal">' +
+      '<h3></h3><p></p>' +
+      '<div class="actions">' +
+        '<button type="button" data-act="cancel">Cancel</button>' +
+        '<button type="button" data-act="go"></button>' +
+      '</div></div>';
+    bg.querySelector('h3').textContent = title;
+    bg.querySelector('p').innerHTML = body;
+    const goBtn = bg.querySelector('[data-act="go"]');
+    goBtn.textContent = confirmLabel;
+    if (danger) goBtn.className = 'danger';
+    const done = (v) => { bg.remove(); resolve(v); };
+    bg.querySelector('[data-act="cancel"]').onclick = () => done(false);
+    bg.addEventListener('click', (e) => { if (e.target === bg) done(false); });
+    goBtn.onclick = () => done(true);
+    document.body.appendChild(bg);
+  });
+}
 document.addEventListener('click', async (e) => {
   const b = e.target.closest('.del');
   if (!b) return;
   const slug = b.dataset.slug;
   // Irreversible: name exactly what disappears before acting.
-  const msg = 'Delete "' + slug + '"?\n\nThis permanently removes ' + b.dataset.versions +
-    ' version(s) and ' + b.dataset.comments + ' comment(s) — the local copy AND the published copy (if any). No undo.';
-  if (!confirm(msg)) return;
+  const proceed = await showConfirm({
+    title: 'Delete "' + slug + '"?',
+    body: 'This permanently removes <b>' + b.dataset.versions + ' version(s)</b> and <b>' + b.dataset.comments +
+      ' comment(s)</b> — the local copy AND the published copy (if any). No undo.',
+    confirmLabel: 'Delete',
+    danger: true,
+  });
+  if (!proceed) return;
   b.disabled = true; b.textContent = 'Deleting…';
   const r = await fetch('/api/delete', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ slug }) });
   if (r.ok) { b.closest('tr').remove(); }

--- a/test/csp-headers.test.js
+++ b/test/csp-headers.test.js
@@ -133,6 +133,44 @@ function get(port, p) {
     }
   });
 
+  // ── worker.js (PRODUCTION) CSP wiring — hermetic source check ────────────
+  // Everything above runs against server/server.js. Production is the
+  // Cloudflare Worker, which the offline suite can't boot — but the whole
+  // reason browser owner-writes dropped the admin token is that the WORKER
+  // sets this CSP. Without a guard here, renaming/removing the header in
+  // worker.js passes every test while silently reopening the XSS channel the
+  // token removal relies on being closed. Guard it by source: drop the header
+  // on either doc-serving route → this goes red. (小cc PR #110 review.)
+  const workerSrc = fs.readFileSync(path.join(__dirname, '..', 'worker', 'worker.js'), 'utf8');
+
+  await t('worker cspHeader() returns the strict nonce policy (no unsafe-inline; object-src/base-uri none)', async () => {
+    const s = workerSrc.indexOf('function cspHeader(nonce)');
+    if (s < 0) throw new Error('worker cspHeader() not found');
+    // Fixed window, not indexOf('}') — the return string contains ${nonce},
+    // whose brace would truncate the slice before 'strict-dynamic'.
+    const body = workerSrc.slice(s, s + 220);
+    if (!body.includes("script-src 'nonce-${nonce}' 'strict-dynamic'")) throw new Error(`cspHeader missing nonce/strict-dynamic: ${body}`);
+    if (!body.includes("object-src 'none'")) throw new Error("cspHeader must set object-src 'none'");
+    if (!body.includes("base-uri 'none'")) throw new Error("cspHeader must set base-uri 'none'");
+    if (body.includes('unsafe-inline')) throw new Error("cspHeader must not include 'unsafe-inline'");
+  });
+
+  await t('worker doc-view route sets the CSP header on its response', async () => {
+    const s = workerSrc.indexOf('// ---- doc view ----');
+    const e = workerSrc.indexOf('// ---- doc export / fork ----', s);
+    if (s < 0 || e < 0) throw new Error('doc-view route block not found');
+    if (!workerSrc.slice(s, e).includes("'Content-Security-Policy': cspHeader(nonce)"))
+      throw new Error("doc-view response must set 'Content-Security-Policy': cspHeader(nonce) — dropping it reopens the XSS channel the token removal relies on being closed");
+  });
+
+  await t('worker export/fork route sets the CSP header too (same author-HTML surface as /d/)', async () => {
+    const s = workerSrc.indexOf('// ---- doc export / fork ----');
+    if (s < 0) throw new Error('export/fork route block not found');
+    const eNext = workerSrc.indexOf('// ---- ', s + 30);
+    if (!workerSrc.slice(s, eNext > s ? eNext : s + 4000).includes("'Content-Security-Policy': cspHeader(nonce)"))
+      throw new Error("export/fork response must set 'Content-Security-Policy': cspHeader(nonce) — else /export bypasses the CSP that /d/ carries");
+  });
+
   console.log(`\n${pass} passed, ${fail} failed`);
   shutdown();
   process.exit(fail ? 1 : 0);

--- a/test/csp-headers.test.js
+++ b/test/csp-headers.test.js
@@ -109,7 +109,7 @@ function get(port, p) {
   });
 
   await t('both overlay-injected <script> tags carry the CSP nonce', async () => {
-    const scriptTags = [...res.body.matchAll(/<script([^>]*)>/g)];
+    const scriptTags = [...res.body.matchAll(/<script([^>]*)>/gi)];
     // Expect: window.__TDOC__ boot script + the overlay bundle script — both
     // injected by injectOverlay()/injectOverlayCfg(), both nonced.
     const nonced = scriptTags.filter(m => m[1].includes(`nonce="${nonce}"`));

--- a/test/csp-headers.test.js
+++ b/test/csp-headers.test.js
@@ -1,0 +1,139 @@
+// CSP header + nonce plumbing — hermetic, no browser needed.
+//
+// 2026-08-13: browser owner mutations (DELETE /api/doc, PATCH /api/doc/access)
+// now authorize off the owner's session cookie alone (authorizeOwnerMutation,
+// see jul36-owner-manage.test.js). That's only safe because every doc-serving
+// response carries a CSP that blocks author <script>/onclick content — a doc
+// can't ride the cookie into those routes anymore. This file checks the wire
+// contract: the header is present with a nonce, and the overlay's OWN
+// injected <script> tags carry that exact nonce (so they — and only they —
+// are allowed to run). The actual "does the browser really block it" check
+// (needs a real DOM) lives in test/csp-xss.test.js (gated: playwright).
+//
+// Covers the local server (server/server.js). worker.js runs the identical
+// cspHeader()/injectOverlayCfg() logic — see server/overlay.js's nonce
+// plumbing comment; no live Cloudflare deploy needed to trust the shared code
+// path, but see csp-xss.test.js's fixture-server boot for the local proof.
+
+const fs = require('fs');
+const path = require('path');
+const os = require('os');
+const net = require('net');
+const http = require('http');
+const { spawn } = require('child_process');
+
+let pass = 0, fail = 0;
+function ok(name) { console.log(`  ✓ ${name}`); pass++; }
+function bad(name, err) { console.log(`  ✗ ${name}\n    ${err}`); fail++; }
+async function t(name, fn) { try { await fn(); ok(name); } catch (e) { bad(name, e.message); } }
+
+function freePort() {
+  return new Promise((resolve, reject) => {
+    const s = net.createServer();
+    s.listen(0, '127.0.0.1', () => { const p = s.address().port; s.close(() => resolve(p)); });
+    s.on('error', reject);
+  });
+}
+function waitReady(port, ms = 5000) {
+  const deadline = Date.now() + ms;
+  return new Promise((resolve, reject) => {
+    (function probe() {
+      const r = http.get({ host: '127.0.0.1', port, path: '/api/ping' }, (res) => { res.resume(); resolve(); });
+      r.on('error', () => { if (Date.now() > deadline) reject(new Error('server not ready')); else setTimeout(probe, 100); });
+    })();
+  });
+}
+function get(port, p) {
+  return new Promise((resolve, reject) => {
+    http.get({ host: '127.0.0.1', port, path: p }, (res) => {
+      let buf = '';
+      res.on('data', d => buf += d);
+      res.on('end', () => resolve({ status: res.statusCode, headers: res.headers, body: buf }));
+    }).on('error', reject);
+  });
+}
+
+(async () => {
+  const TMP_DIR = fs.mkdtempSync(path.join(os.tmpdir(), 'tdoc-csp-'));
+  const PORT = await freePort();
+  const serverPath = path.join(__dirname, '..', 'server', 'server.js');
+  const srv = spawn(process.execPath, [serverPath], {
+    env: { ...process.env, TDOC_DIR: TMP_DIR, TDOC_PORT: String(PORT), TDOC_HOST: '127.0.0.1' },
+    stdio: 'ignore',
+  });
+  const shutdown = () => { try { srv.kill('SIGKILL'); } catch {} try { fs.rmSync(TMP_DIR, { recursive: true, force: true }); } catch {} };
+  process.on('exit', shutdown);
+  await waitReady(PORT);
+  console.log(`csp headers (hermetic, TDOC_DIR=${TMP_DIR})\n`);
+
+  const SLUG = 'csp-fixture';
+  const docDir = path.join(TMP_DIR, SLUG);
+  fs.mkdirSync(path.join(docDir, 'v1'), { recursive: true });
+  // The doc under test embeds an author <script> and an inline onclick= — the
+  // exact shape the CSP must neutralize. This file only checks headers/markup
+  // (no JS execution); csp-xss.test.js drives this same shape in a real
+  // browser and asserts the payload never runs.
+  fs.writeFileSync(path.join(docDir, 'v1', 'index.html'),
+    '<!doctype html><html><head><title>CSP fixture</title></head><body>' +
+    '<script>window.__XSS__=1;</script>' +
+    '<button id="xss-btn" onclick="window.__XSS__=2">click</button>' +
+    '<p>hello</p></body></html>');
+  fs.writeFileSync(path.join(docDir, 'meta.json'), JSON.stringify({ title: 'CSP fixture', versions: [{ n: 1 }] }));
+  fs.writeFileSync(path.join(docDir, 'comments.json'), '[]');
+
+  let res;
+  await t('doc response carries a Content-Security-Policy header', async () => {
+    res = await get(PORT, `/d/${SLUG}/v/1`);
+    if (res.status !== 200) throw new Error(`status ${res.status}`);
+    const csp = res.headers['content-security-policy'];
+    if (!csp) throw new Error('no Content-Security-Policy header');
+  });
+
+  let nonce;
+  await t('CSP blocks author scripts (no unsafe-inline) and locks down object-src/base-uri', async () => {
+    const csp = res.headers['content-security-policy'];
+    const m = /script-src 'nonce-([a-f0-9]+)' 'strict-dynamic'/.exec(csp);
+    if (!m) throw new Error(`CSP script-src missing/malformed nonce directive: ${csp}`);
+    nonce = m[1];
+    if (nonce.length < 16) throw new Error(`nonce looks too short/predictable: ${nonce}`);
+    if (csp.includes('unsafe-inline')) throw new Error("CSP must not include 'unsafe-inline' (would re-allow inline scripts/handlers)");
+    if (!csp.includes("object-src 'none'")) throw new Error("CSP must set object-src 'none'");
+    if (!csp.includes("base-uri 'none'")) throw new Error("CSP must set base-uri 'none'");
+  });
+
+  await t('a fresh nonce is generated per response (not reused across requests)', async () => {
+    const res2 = await get(PORT, `/d/${SLUG}/v/1`);
+    const m2 = /script-src 'nonce-([a-f0-9]+)'/.exec(res2.headers['content-security-policy']);
+    if (!m2) throw new Error('second response missing nonce');
+    if (m2[1] === nonce) throw new Error('nonce was reused across two separate responses — must be per-request random');
+  });
+
+  await t('both overlay-injected <script> tags carry the CSP nonce', async () => {
+    const scriptTags = [...res.body.matchAll(/<script([^>]*)>/g)];
+    // Expect: window.__TDOC__ boot script + the overlay bundle script — both
+    // injected by injectOverlay()/injectOverlayCfg(), both nonced.
+    const nonced = scriptTags.filter(m => m[1].includes(`nonce="${nonce}"`));
+    if (nonced.length < 2) {
+      throw new Error(`expected >=2 nonced <script> tags (boot cfg + overlay bundle), found ${nonced.length} of ${scriptTags.length} total`);
+    }
+  });
+
+  await t('the author <script> in the doc body does NOT carry the nonce (stays inert under the CSP)', async () => {
+    const idx = res.body.indexOf('window.__XSS__=1');
+    if (idx < 0) throw new Error('fixture author script not found in response body — test setup broken');
+    const tagStart = res.body.lastIndexOf('<script', idx);
+    const tagOpenEnd = res.body.indexOf('>', tagStart);
+    const openTag = res.body.slice(tagStart, tagOpenEnd + 1);
+    if (openTag.includes('nonce=')) throw new Error(`author <script> must not carry a nonce: ${openTag}`);
+  });
+
+  await t('the author onclick= attribute is left as plain markup (CSP blocks it at execution time, not by stripping)', async () => {
+    if (!res.body.includes('onclick="window.__XSS__=2"')) {
+      throw new Error('fixture onclick handler not found — test setup broken, or something is now stripping it (unexpected either way)');
+    }
+  });
+
+  console.log(`\n${pass} passed, ${fail} failed`);
+  shutdown();
+  process.exit(fail ? 1 : 0);
+})().catch((e) => { console.error(e); process.exit(1); });

--- a/test/csp-xss.test.js
+++ b/test/csp-xss.test.js
@@ -1,0 +1,136 @@
+// CSP live-browser proof: author <script>/onclick never execute, overlay does.
+//
+// test/csp-headers.test.js checks the wire contract (header + nonce
+// placement) hermetically. This file is the "gold standard" check the
+// header-only test can't do: actually load the doc in a real browser and
+// observe that window.__XSS__ stays undefined while the overlay (loaded via
+// the SAME injection path, just nonced) fully boots and works.
+//
+// Gated: needs playwright. Skips loudly (exit 0) if it's not installed —
+// never a silent pass. Run with: node test/csp-xss.test.js
+// (or `node test/run.js --all`).
+
+const fs = require('fs');
+const path = require('path');
+const os = require('os');
+const net = require('net');
+const http = require('http');
+const { spawn } = require('child_process');
+const { requirePlaywrightOrSkip } = require('./helpers/fixture-server');
+const { chromium } = requirePlaywrightOrSkip('csp-xss.test.js');
+
+let pass = 0, fail = 0;
+function ok(name) { console.log(`  ✓ ${name}`); pass++; }
+function bad(name, err) { console.log(`  ✗ ${name}\n    ${err}`); fail++; }
+async function t(name, fn) { try { await fn(); ok(name); } catch (e) { bad(name, e.message); } }
+
+function freePort() {
+  return new Promise((resolve, reject) => {
+    const s = net.createServer();
+    s.listen(0, '127.0.0.1', () => { const p = s.address().port; s.close(() => resolve(p)); });
+    s.on('error', reject);
+  });
+}
+function waitReady(port, ms = 5000) {
+  const deadline = Date.now() + ms;
+  return new Promise((resolve, reject) => {
+    (function probe() {
+      const r = http.get({ host: '127.0.0.1', port, path: '/api/ping' }, (res) => { res.resume(); resolve(); });
+      r.on('error', () => { if (Date.now() > deadline) reject(new Error('server not ready')); else setTimeout(probe, 100); });
+    })();
+  });
+}
+
+(async () => {
+  const TMP_DIR = fs.mkdtempSync(path.join(os.tmpdir(), 'tdoc-csp-xss-'));
+  const PORT = await freePort();
+  const serverPath = path.join(__dirname, '..', 'server', 'server.js');
+  const srv = spawn(process.execPath, [serverPath], {
+    env: { ...process.env, TDOC_DIR: TMP_DIR, TDOC_PORT: String(PORT), TDOC_HOST: '127.0.0.1' },
+    stdio: 'ignore',
+  });
+  let browser;
+  const shutdown = () => {
+    try { srv.kill('SIGKILL'); } catch {}
+    try { fs.rmSync(TMP_DIR, { recursive: true, force: true }); } catch {}
+  };
+  process.on('exit', shutdown);
+  await waitReady(PORT);
+
+  const SLUG = 'xss-fixture';
+  const docDir = path.join(TMP_DIR, SLUG);
+  fs.mkdirSync(path.join(docDir, 'v1'), { recursive: true });
+  // A realistic-shaped doc: normal commentable content PLUS an author
+  // <script> and an inline onclick=, exactly the injection the CSP exists to
+  // stop. If either runs, window.__XSS__ flips from undefined.
+  fs.writeFileSync(path.join(docDir, 'v1', 'index.html'), `<!doctype html>
+<html><head><title>XSS fixture</title></head><body>
+  <div class="wrap">
+    <h1>XSS fixture</h1>
+    <script>window.__XSS__ = 1;</script>
+    <p>Some prose above the target block.</p>
+    <pre id="target">a commentable code block</pre>
+    <button id="xss-btn" onclick="window.__XSS__ = 2">click me</button>
+  </div>
+</body></html>`);
+  fs.writeFileSync(path.join(docDir, 'meta.json'), JSON.stringify({ title: 'XSS fixture', versions: [{ n: 1 }] }));
+  fs.writeFileSync(path.join(docDir, 'comments.json'), '[]');
+
+  console.log(`csp-xss (live browser, TDOC_DIR=${TMP_DIR}, port=${PORT})\n`);
+
+  browser = await chromium.launch({ headless: true });
+  const page = await browser.newPage();
+  const consoleMsgs = [];
+  page.on('console', (m) => consoleMsgs.push(m.text()));
+
+  await page.goto(`http://127.0.0.1:${PORT}/d/${SLUG}/v/1`, { waitUntil: 'networkidle' });
+
+  await t('author <script> tag never executes — window.__XSS__ stays undefined after load', async () => {
+    const v = await page.evaluate(() => window.__XSS__);
+    if (v !== undefined) throw new Error(`window.__XSS__ = ${v} — author <script> ran, CSP failed to block it`);
+  });
+
+  await t('CSP violation was actually reported for the blocked script (proves the browser enforced it, not luck)', async () => {
+    const reported = consoleMsgs.some((m) => /content security policy|csp/i.test(m));
+    if (!reported) throw new Error(`no CSP violation logged; console had: ${JSON.stringify(consoleMsgs.slice(0, 10))}`);
+  });
+
+  await t('author inline onclick= never fires — clicking the button leaves window.__XSS__ undefined', async () => {
+    await page.click('#xss-btn');
+    await page.waitForTimeout(150);
+    const v = await page.evaluate(() => window.__XSS__);
+    if (v !== undefined) throw new Error(`window.__XSS__ = ${v} — inline onclick ran, CSP failed to block it`);
+  });
+
+  await t('the nonced overlay script DID execute — the tdoc bar renders', async () => {
+    await page.waitForSelector('.tdoc-bar', { timeout: 2000 });
+    const markText = await page.$eval('.tdoc-bar-mark', (el) => el.textContent);
+    if (!markText || !markText.trim()) throw new Error('tdoc bar mark is empty — overlay may not have booted');
+  });
+
+  await t('commenting still works end-to-end under the CSP (drag INTO the element opens the popup, submit persists)', async () => {
+    // Mirrors ui.test.js's canvas drag-to-comment gesture: drag from outside
+    // the artifact into it so the mouseup handler resolves an element anchor.
+    const pre = await page.$('#target');
+    const box = await pre.boundingBox();
+    const startX = Math.max(20, box.x - 30);
+    const startY = box.y + box.height / 2;
+    await page.mouse.move(startX, startY);
+    await page.mouse.down();
+    await page.mouse.move(box.x + box.width / 2, box.y + box.height / 2, { steps: 10 });
+    await page.mouse.up();
+    await page.waitForSelector('.tdoc-popup', { timeout: 2000 });
+    await page.fill('.tdoc-popup textarea', 'csp smoke comment');
+    await page.click('.tdoc-popup .submit');
+    await page.waitForSelector('.tdoc-margin-comment', { timeout: 2000 });
+  });
+
+  await browser.close();
+
+  console.log(`\n${pass} passed, ${fail} failed`);
+  shutdown();
+  process.exit(fail ? 1 : 0);
+})().catch(async (e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/test/csp-xss.test.js
+++ b/test/csp-xss.test.js
@@ -125,6 +125,50 @@ function waitReady(port, ms = 5000) {
     await page.waitForSelector('.tdoc-margin-comment', { timeout: 2000 });
   });
 
+  // --- nonce hardening (小cc PR review): a CSP nonce only protects if it is
+  // freshly random PER RESPONSE. If it were constant or derived from
+  // slug/version, an author could embed that exact nonce on their own <script>
+  // and it would run — CSP defeated. The XSS tests above use un-nonced author
+  // scripts (trivially blocked); these two test the real threat model: a nonce
+  // an attacker HAS. ---
+  function fetchCSP(p) {
+    return new Promise((resolve, reject) => {
+      http.get({ host: '127.0.0.1', port: PORT, path: p }, (res) => {
+        res.resume();
+        resolve(res.headers['content-security-policy'] || '');
+      }).on('error', reject);
+    });
+  }
+  const nonceOf = (csp) => { const m = csp.match(/'nonce-([^']+)'/); return m && m[1]; };
+
+  let capturedNonce = null;
+  await t('nonce is freshly random per response — two requests to the same doc get different nonces', async () => {
+    const a = nonceOf(await fetchCSP(`/d/${SLUG}/v/1`));
+    const b = nonceOf(await fetchCSP(`/d/${SLUG}/v/1`));
+    if (!a || !b) throw new Error(`missing nonce in CSP: a=${a} b=${b}`);
+    if (a === b) throw new Error(`nonce reused across responses (${a}) — an author could embed it and bypass CSP`);
+    capturedNonce = a;
+  });
+
+  await t('author <script> carrying a REAL captured nonce is STILL blocked (per-response-random, non-replayable)', async () => {
+    // The insidious case: an author embeds a nonce lifted from a prior response.
+    // With a constant/predictable nonce this <script> would EXECUTE. It must not.
+    const slug2 = 'xss-nonce-replay';
+    const d2 = path.join(TMP_DIR, slug2, 'v1');
+    fs.mkdirSync(d2, { recursive: true });
+    fs.writeFileSync(path.join(d2, 'index.html'), `<!doctype html><html><head><title>replay</title></head><body>
+  <div class="wrap"><h1>replay</h1>
+  <script nonce="${capturedNonce}">window.__XSS_REPLAY__ = 1;</script>
+  <pre id="target">block</pre></div></body></html>`);
+    fs.writeFileSync(path.join(TMP_DIR, slug2, 'meta.json'), JSON.stringify({ title: 'replay', versions: [{ n: 1 }] }));
+    fs.writeFileSync(path.join(TMP_DIR, slug2, 'comments.json'), '[]');
+    const p2 = await browser.newPage();
+    await p2.goto(`http://127.0.0.1:${PORT}/d/${slug2}/v/1`, { waitUntil: 'networkidle' });
+    const v = await p2.evaluate(() => window.__XSS_REPLAY__);
+    await p2.close();
+    if (v !== undefined) throw new Error(`window.__XSS_REPLAY__ = ${v} — author reused a captured nonce and the script RAN; nonce is not per-response-random`);
+  });
+
   await browser.close();
 
   console.log(`\n${pass} passed, ${fail} failed`);

--- a/test/jul36-owner-manage.test.js
+++ b/test/jul36-owner-manage.test.js
@@ -1,0 +1,189 @@
+// JUL-36 — owner manage UX (Delete / Unpublish / visibility switch) guard.
+//
+// Product ask: the doc-view top bar exposes owner-only manage controls
+// directly (not just on /me), with a styled confirm modal instead of native
+// confirm(). Security constraint from review: owner gating is SERVER-side
+// (the overlay never render-then-hides a dead button), and every mutation
+// route re-checks auth INSIDE itself — this ticket must not weaken that by
+// adding a cookie-only admin-write path (see test/me-management.test.js,
+// which already forbids `requireAdminAuth` / `isSameOriginRequest`).
+//
+// Two tests mirror what the reviewer said she'll write herself:
+//   (a) a non-owner's doc-view response can never carry manage data.
+//   (b) the admin mutation gate (shared by DELETE /api/doc and
+//       PATCH /api/doc/access) returns 401 for anonymous/wrong-token calls
+//       and passes for the correct token — i.e. it is NOT satisfied by a
+//       session cookie alone.
+// Plus: owner-succeeds coverage for the same gate.
+
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+
+let pass = 0, fail = 0;
+function ok(n) { console.log(`  ✓ ${n}`); pass++; }
+function bad(n, e) { console.log(`  ✗ ${n}\n    ${e}`); fail++; }
+function t(n, fn) { try { fn(); ok(n); } catch (e) { bad(n, e.message); } }
+async function tAsync(n, fn) { try { await fn(); ok(n); } catch (e) { bad(n, e.message); } }
+function assert(c, m) { if (!c) throw new Error(m || 'assertion failed'); }
+
+const worker = fs.readFileSync(path.join(__dirname, '..', 'worker', 'worker.js'), 'utf8');
+const overlay = fs.readFileSync(path.join(__dirname, '..', 'server', 'overlay.js'), 'utf8');
+
+console.log('JUL-36 owner manage UX');
+
+// ── (a) non-owner doc-view response can never carry manage data ──────────
+
+const docViewStart = worker.indexOf("// ---- doc view ----");
+const docViewEnd = worker.indexOf("// ---- doc export / fork ----", docViewStart);
+if (docViewStart < 0 || docViewEnd < 0) throw new Error('doc-view route block missing');
+const docViewRoute = worker.slice(docViewStart, docViewEnd);
+
+t('doc-view route computes isOwner server-side from the session, not the client', () => {
+  assert(docViewRoute.includes('const isOwner = isOwnerSession(env, session);'),
+    'isOwner must be derived from isOwnerSession(env, session) on THIS request');
+});
+
+t('doc-view route only builds ownerManage data inside an isOwner guard', () => {
+  const decl = docViewRoute.indexOf('let ownerManage = null;');
+  const guard = docViewRoute.indexOf('if (isOwner) {', decl);
+  assert(decl >= 0, 'ownerManage must default to null');
+  assert(guard >= 0 && guard > decl, 'ownerManage must only be populated inside `if (isOwner)`');
+});
+
+const injectOverlayStart = worker.indexOf('function injectOverlay(rawHtml, slug, version, identity, versions, isOwner, ownerManage) {');
+const injectOverlayEnd = worker.indexOf('\n}', injectOverlayStart);
+if (injectOverlayStart < 0) throw new Error('injectOverlay() signature not found — did it change?');
+const injectOverlayFn = worker.slice(injectOverlayStart, injectOverlayEnd);
+
+t('injectOverlay re-checks isOwner itself before embedding ownerManage (defense in depth)', () => {
+  // Even if a future caller passed real data with isOwner falsy, this line
+  // must still force null — the boot config a non-owner receives can never
+  // carry manage data, regardless of what upstream computed.
+  assert(injectOverlayFn.includes('ownerManage: isOwner ? (ownerManage || null) : null'),
+    'injectOverlay must force ownerManage to null whenever isOwner is falsy');
+});
+
+t('overlay renderIdentity() only emits the manage menu item behind isOwner && cfg.ownerManage', () => {
+  const idx = overlay.indexOf('id="tdoc-manage-doc"');
+  assert(idx >= 0, 'manage menu item markup not found in overlay.js');
+  const templateStart = overlay.lastIndexOf('${isOwner && cfg.ownerManage', idx);
+  assert(templateStart >= 0 && templateStart < idx,
+    'the manage-doc button must be gated by `${isOwner && cfg.ownerManage ...}` — never unconditional');
+});
+
+t('showManageModal() bails before creating any DOM when cfg.ownerManage is absent', () => {
+  const fnStart = overlay.indexOf('function showManageModal() {');
+  assert(fnStart >= 0, 'showManageModal not found');
+  const guardIdx = overlay.indexOf('if (!cfg.ownerManage) return;', fnStart);
+  const firstDomWrite = overlay.indexOf('document.createElement', fnStart);
+  assert(guardIdx >= 0, 'showManageModal must guard on cfg.ownerManage before rendering');
+  assert(guardIdx < firstDomWrite, 'the ownerManage guard must run BEFORE any DOM node is created — never render-then-hide');
+});
+
+// ── (b) admin mutation gate: 401 anonymous/wrong token; owner-succeeds ───
+
+const uploadAuthStart = worker.indexOf('async function requireUploadAuth(req, env) {');
+const uploadAuthEnd = worker.indexOf('\n}', uploadAuthStart) + 2;
+const timingEqualStart = worker.indexOf('async function timingSafeEqual(a, b) {');
+const timingEqualEnd = worker.indexOf('\n}', timingEqualStart) + 2;
+if (uploadAuthStart < 0 || timingEqualStart < 0) throw new Error('auth helpers not found');
+const authSrc = worker.slice(timingEqualStart, timingEqualEnd) + '\n' + worker.slice(uploadAuthStart, uploadAuthEnd);
+
+const deleteStart = worker.indexOf("if (p === '/api/doc' && method === 'DELETE')");
+const deleteEnd = worker.indexOf("return text('Not found'", deleteStart);
+const deleteRoute = worker.slice(deleteStart, deleteEnd);
+
+const accessPatchStart = worker.indexOf("if (p === '/api/doc/access' && method === 'PATCH')");
+const accessPatchEnd = worker.indexOf('// ---- admin delete ----', accessPatchStart);
+const accessPatchRoute = worker.slice(accessPatchStart, accessPatchEnd);
+
+t('DELETE /api/doc and PATCH /api/doc/access are gated ONLY by requireUploadAuth (not a session/cookie path)', () => {
+  assert(deleteRoute.includes('await requireUploadAuth(req, env)'), 'DELETE /api/doc must call requireUploadAuth');
+  assert(accessPatchRoute.includes('await requireUploadAuth(req, env)'), 'PATCH /api/doc/access must call requireUploadAuth');
+  // JUL-36 must not introduce a cookie-only admin-write bypass. A published
+  // doc is arbitrary HTML on this same origin — trusting the owner's session
+  // cookie alone here would let doc content silently trigger admin writes.
+  assert(!worker.includes('requireAdminAuth'), 'worker must not add a cookie-based admin auth path');
+  assert(!worker.includes('isSameOriginRequest'), 'same-origin is not sufficient — docs are arbitrary same-origin HTML');
+});
+
+const box = { console, TextEncoder, crypto, Response };
+vm.createContext(box);
+vm.runInContext(`
+  function json(obj, init = {}) {
+    return new Response(JSON.stringify(obj), { status: (init && init.status) || 200 });
+  }
+` + authSrc, box);
+
+function fakeReq(bearer) {
+  return { headers: { get: (name) => (name.toLowerCase() === 'authorization' && bearer) ? ('Bearer ' + bearer) : null } };
+}
+
+async function main() {
+  await tAsync('requireUploadAuth: anonymous request (no Authorization header) → 401', async () => {
+    const res = await box.requireUploadAuth({ headers: { get: () => null } }, { TDOC_UPLOAD_TOKEN: 'secret-token' });
+    assert(res !== null, 'must not pass through');
+    assert(res.status === 401, `expected 401, got ${res.status}`);
+  });
+
+  await tAsync('requireUploadAuth: wrong bearer token → 401', async () => {
+    const res = await box.requireUploadAuth(fakeReq('not-the-token'), { TDOC_UPLOAD_TOKEN: 'secret-token' });
+    assert(res !== null, 'must not pass through');
+    assert(res.status === 401, `expected 401, got ${res.status}`);
+  });
+
+  await tAsync('requireUploadAuth: no TDOC_UPLOAD_TOKEN configured → always 401 (fail closed)', async () => {
+    const res = await box.requireUploadAuth(fakeReq('anything'), {});
+    assert(res !== null && res.status === 401, 'must fail closed when no token is configured');
+  });
+
+  await tAsync('requireUploadAuth: correct bearer token → passes (owner-succeeds coverage)', async () => {
+    const res = await box.requireUploadAuth(fakeReq('secret-token'), { TDOC_UPLOAD_TOKEN: 'secret-token' });
+    assert(res === null, 'a correct token must pass through (return null)');
+  });
+
+  // ── styled confirm modal replaces native confirm() (no native confirm left) ─
+
+  const serverJs = fs.readFileSync(path.join(__dirname, '..', 'server', 'server.js'), 'utf8');
+
+  // Matches an actual native-confirm CALL (`confirm(` not preceded by "show"
+  // or another identifier char, and not inside a `// ... confirm() ...`
+  // prose comment praising its removal) — not just the word appearing in a
+  // comment.
+  const nativeConfirmCall = /(?:^|[^\w.])confirm\(/m;
+  function stripLineComments(src) {
+    return src.split('\n').filter(l => !l.trim().startsWith('//') && !l.trim().startsWith('*')).join('\n');
+  }
+
+  t('worker /me page no longer uses window.confirm() for delete', () => {
+    const idxStart = worker.indexOf('async function indexHtml(env, session)');
+    const idxEnd = worker.indexOf('// ─────────────────────────────────────────────────────────────────────────', idxStart);
+    const indexHtmlSrc = worker.slice(idxStart, idxEnd);
+    assert(!nativeConfirmCall.test(stripLineComments(indexHtmlSrc)), '/me must not call the native confirm()');
+    assert(indexHtmlSrc.includes('showConfirm('), '/me must use the styled showConfirm() modal');
+    assert(indexHtmlSrc.includes('dataset.versions'),
+      'delete confirm copy should be built from data-versions/data-comments (honest N/M copy)');
+  });
+
+  t('local server index page no longer uses window.confirm() for delete', () => {
+    const idxStart = serverJs.indexOf('function indexPage()');
+    const indexPageSrc = serverJs.slice(idxStart, serverJs.indexOf('const server = http.createServer'));
+    assert(!nativeConfirmCall.test(stripLineComments(indexPageSrc)), 'local index page must not call the native confirm()');
+    assert(indexPageSrc.includes('showConfirm('), 'local index page must use the styled showConfirm() modal');
+  });
+
+  t('overlay.js manage flow never uses window.confirm() either', () => {
+    const start = overlay.indexOf('// ========== Owner manage');
+    const end = overlay.indexOf('async function pollDevice');
+    const section = overlay.slice(start, end);
+    assert(start >= 0 && end > start, 'owner manage section not found');
+    assert(!nativeConfirmCall.test(stripLineComments(section)), 'owner manage flow must use showManageConfirm(), not native confirm()');
+    assert(section.includes('showManageConfirm('), 'owner manage flow must build a styled confirm modal');
+  });
+
+  console.log(`\n${pass} passed, ${fail} failed`);
+  process.exit(fail ? 1 : 0);
+}
+
+main();

--- a/test/jul36-owner-manage.test.js
+++ b/test/jul36-owner-manage.test.js
@@ -1,20 +1,24 @@
-// JUL-36 — owner manage UX (Delete / Unpublish / visibility switch) guard.
+// JUL-36 — owner manage UX (Delete / Unpublish / Share settings) guard.
 //
 // Product ask: the doc-view top bar exposes owner-only manage controls
 // directly (not just on /me), with a styled confirm modal instead of native
 // confirm(). Security constraint from review: owner gating is SERVER-side
 // (the overlay never render-then-hides a dead button), and every mutation
-// route re-checks auth INSIDE itself — this ticket must not weaken that by
-// adding a cookie-only admin-write path (see test/me-management.test.js,
-// which already forbids `requireAdminAuth` / `isSameOriginRequest`).
+// route re-checks auth INSIDE itself.
+//
+// 2026-08-13 tail: browser owner mutations now authorize off the owner's
+// SESSION COOKIE (no more pasted admin token) via the shared
+// authorizeOwnerMutation() gate, which is safe ONLY because every doc
+// response now carries a CSP (worker.js cspHeader()) that blocks author
+// <script>/onclick content — see test/csp.test.js. The CLI keeps using the
+// upload bearer token unchanged; authorizeOwnerMutation accepts EITHER.
 //
 // Two tests mirror what the reviewer said she'll write herself:
 //   (a) a non-owner's doc-view response can never carry manage data.
 //   (b) the admin mutation gate (shared by DELETE /api/doc and
-//       PATCH /api/doc/access) returns 401 for anonymous/wrong-token calls
-//       and passes for the correct token — i.e. it is NOT satisfied by a
-//       session cookie alone.
-// Plus: owner-succeeds coverage for the same gate.
+//       PATCH /api/doc/access) returns 401 for anonymous/non-owner-no-token
+//       calls, and passes for EITHER an owner session OR the correct
+//       upload token.
 
 const fs = require('fs');
 const path = require('path');
@@ -71,7 +75,7 @@ t('doc-view never leaks private doc metadata (version count) to non-owners via t
     'the non-history branch must collapse `versions` to the single viewed version, not the full list');
 });
 
-const injectOverlayStart = worker.indexOf('function injectOverlay(rawHtml, slug, version, identity, versions, isOwner, ownerManage) {');
+const injectOverlayStart = worker.indexOf('function injectOverlay(rawHtml, slug, version, identity, versions, isOwner, ownerManage, nonce) {');
 const injectOverlayEnd = worker.indexOf('\n}', injectOverlayStart);
 if (injectOverlayStart < 0) throw new Error('injectOverlay() signature not found — did it change?');
 const injectOverlayFn = worker.slice(injectOverlayStart, injectOverlayEnd);
@@ -101,14 +105,37 @@ t('showManageModal() bails before creating any DOM when cfg.ownerManage is absen
   assert(guardIdx < firstDomWrite, 'the ownerManage guard must run BEFORE any DOM node is created — never render-then-hide');
 });
 
-// ── (b) admin mutation gate: 401 anonymous/wrong token; owner-succeeds ───
+// ── (b) admin mutation gate: session-OR-token, never neither ─────────────
+//
+// 2026-08-13: DELETE /api/doc and PATCH /api/doc/access now authorize via
+// authorizeOwnerMutation (owner session OR upload token), not
+// requireUploadAuth alone. Verify both routes call the shared gate, and unit
+// test the gate itself: anonymous/non-owner-no-token → 401; owner session
+// alone → authorized (the new browser capability); upload token alone →
+// still authorized (CLI unchanged); wrong token + non-owner session → 401.
 
 const uploadAuthStart = worker.indexOf('async function requireUploadAuth(req, env) {');
 const uploadAuthEnd = worker.indexOf('\n}', uploadAuthStart) + 2;
 const timingEqualStart = worker.indexOf('async function timingSafeEqual(a, b) {');
 const timingEqualEnd = worker.indexOf('\n}', timingEqualStart) + 2;
-if (uploadAuthStart < 0 || timingEqualStart < 0) throw new Error('auth helpers not found');
-const authSrc = worker.slice(timingEqualStart, timingEqualEnd) + '\n' + worker.slice(uploadAuthStart, uploadAuthEnd);
+const parseCookieStart = worker.indexOf('function parseCookie(req) {');
+const parseCookieEnd = worker.indexOf('\n}', parseCookieStart) + 2;
+const getSessionStart = worker.indexOf('async function getSession(env, req) {');
+const getSessionEnd = worker.indexOf('\n}', getSessionStart) + 2;
+const isOwnerSessionStart = worker.indexOf('function isOwnerSession(env, session) {');
+const isOwnerSessionEnd = worker.indexOf('\n}', isOwnerSessionStart) + 2;
+const authorizeStart = worker.indexOf('async function authorizeOwnerMutation(req, env) {');
+const authorizeEnd = worker.indexOf('\n}', authorizeStart) + 2;
+if (uploadAuthStart < 0 || timingEqualStart < 0 || parseCookieStart < 0 || getSessionStart < 0
+  || isOwnerSessionStart < 0 || authorizeStart < 0) throw new Error('auth helpers not found');
+const authSrc = [
+  worker.slice(timingEqualStart, timingEqualEnd),
+  worker.slice(uploadAuthStart, uploadAuthEnd),
+  worker.slice(parseCookieStart, parseCookieEnd),
+  worker.slice(getSessionStart, getSessionEnd),
+  worker.slice(isOwnerSessionStart, isOwnerSessionEnd),
+  worker.slice(authorizeStart, authorizeEnd),
+].join('\n');
 
 const deleteStart = worker.indexOf("if (p === '/api/doc' && method === 'DELETE')");
 const deleteEnd = worker.indexOf("return text('Not found'", deleteStart);
@@ -118,14 +145,22 @@ const accessPatchStart = worker.indexOf("if (p === '/api/doc/access' && method =
 const accessPatchEnd = worker.indexOf('// ---- admin delete ----', accessPatchStart);
 const accessPatchRoute = worker.slice(accessPatchStart, accessPatchEnd);
 
-t('DELETE /api/doc and PATCH /api/doc/access are gated ONLY by requireUploadAuth (not a session/cookie path)', () => {
-  assert(deleteRoute.includes('await requireUploadAuth(req, env)'), 'DELETE /api/doc must call requireUploadAuth');
-  assert(accessPatchRoute.includes('await requireUploadAuth(req, env)'), 'PATCH /api/doc/access must call requireUploadAuth');
-  // JUL-36 must not introduce a cookie-only admin-write bypass. A published
-  // doc is arbitrary HTML on this same origin — trusting the owner's session
-  // cookie alone here would let doc content silently trigger admin writes.
-  assert(!worker.includes('requireAdminAuth'), 'worker must not add a cookie-based admin auth path');
+t('DELETE /api/doc and PATCH /api/doc/access both go through the shared authorizeOwnerMutation gate', () => {
+  assert(deleteRoute.includes('await authorizeOwnerMutation(req, env)'), 'DELETE /api/doc must call authorizeOwnerMutation');
+  assert(accessPatchRoute.includes('await authorizeOwnerMutation(req, env)'), 'PATCH /api/doc/access must call authorizeOwnerMutation');
+  // The session path must go through the ONE shared, tested gate — not a
+  // bespoke same-origin/cookie check bolted onto just one route.
+  assert(!worker.includes('requireAdminAuth'), 'worker must not add a separate cookie-based admin-auth function');
   assert(!worker.includes('isSameOriginRequest'), 'same-origin is not sufficient — docs are arbitrary same-origin HTML');
+});
+
+t('authorizeOwnerMutation gate itself calls isOwnerSession, then falls back to requireUploadAuth', () => {
+  const fnSrc = worker.slice(authorizeStart, authorizeEnd);
+  const ownerCheck = fnSrc.indexOf('isOwnerSession(env, session)');
+  const tokenCheck = fnSrc.indexOf('requireUploadAuth(req, env)');
+  assert(ownerCheck >= 0, 'must check isOwnerSession');
+  assert(tokenCheck >= 0, 'must fall back to requireUploadAuth');
+  assert(ownerCheck < tokenCheck, 'owner-session check must come before the token fallback');
 });
 
 const box = { console, TextEncoder, crypto, Response };
@@ -138,6 +173,29 @@ vm.runInContext(`
 
 function fakeReq(bearer) {
   return { headers: { get: (name) => (name.toLowerCase() === 'authorization' && bearer) ? ('Bearer ' + bearer) : null } };
+}
+
+// Fake env + req for authorizeOwnerMutation, which additionally needs a
+// session cookie resolved through env.META.get('session:<sid>').
+function fakeEnv({ owner, token, sessions = {} } = {}) {
+  return {
+    TDOC_OWNER: owner,
+    TDOC_UPLOAD_TOKEN: token,
+    META: { async get(key) {
+      const m = /^session:(.+)$/.exec(key);
+      const s = m && sessions[m[1]];
+      return s ? JSON.stringify(s) : null;
+    } },
+  };
+}
+function fakeSessionReq({ bearer, sid } = {}) {
+  const cookie = sid ? `tdoc_sid=${sid}` : null;
+  return { headers: { get: (name) => {
+    const n = name.toLowerCase();
+    if (n === 'authorization') return bearer ? ('Bearer ' + bearer) : null;
+    if (n === 'cookie') return cookie;
+    return null;
+  } } };
 }
 
 async function main() {
@@ -161,6 +219,41 @@ async function main() {
   await tAsync('requireUploadAuth: correct bearer token → passes (owner-succeeds coverage)', async () => {
     const res = await box.requireUploadAuth(fakeReq('secret-token'), { TDOC_UPLOAD_TOKEN: 'secret-token' });
     assert(res === null, 'a correct token must pass through (return null)');
+  });
+
+  // ── authorizeOwnerMutation: session-OR-token ──────────────────────────
+
+  await tAsync('authorizeOwnerMutation: fully anonymous (no cookie, no bearer) → 401', async () => {
+    const env = fakeEnv({ owner: 'julie', token: 'secret-token' });
+    const res = await box.authorizeOwnerMutation(fakeSessionReq({}), env);
+    assert(res.ok === false, 'must not authorize an anonymous caller');
+    assert(res.response.status === 401, `expected 401, got ${res.response.status}`);
+  });
+
+  await tAsync('authorizeOwnerMutation: signed in as a NON-owner, no token → 401', async () => {
+    const env = fakeEnv({ owner: 'julie', token: 'secret-token', sessions: { deadbeef: { login: 'mallory' } } });
+    const res = await box.authorizeOwnerMutation(fakeSessionReq({ sid: 'deadbeef' }), env);
+    assert(res.ok === false, 'a non-owner session must not authorize');
+    assert(res.response.status === 401, `expected 401, got ${res.response.status}`);
+  });
+
+  await tAsync('authorizeOwnerMutation: OWNER session, NO token → authorized (the new browser capability)', async () => {
+    const env = fakeEnv({ owner: 'julie', token: 'secret-token', sessions: { deadbeef: { login: 'julie' } } });
+    const res = await box.authorizeOwnerMutation(fakeSessionReq({ sid: 'deadbeef' }), env);
+    assert(res.ok === true, 'the configured owner’s session alone must authorize (case-insensitive login match)');
+  });
+
+  await tAsync('authorizeOwnerMutation: no session, correct upload token → authorized (CLI unchanged)', async () => {
+    const env = fakeEnv({ owner: 'julie', token: 'secret-token' });
+    const res = await box.authorizeOwnerMutation(fakeSessionReq({ bearer: 'secret-token' }), env);
+    assert(res.ok === true, 'the CLI token path must keep working with no session at all');
+  });
+
+  await tAsync('authorizeOwnerMutation: non-owner session + WRONG token → 401 (neither credential is valid)', async () => {
+    const env = fakeEnv({ owner: 'julie', token: 'secret-token', sessions: { deadbeef: { login: 'mallory' } } });
+    const res = await box.authorizeOwnerMutation(fakeSessionReq({ sid: 'deadbeef', bearer: 'not-the-token' }), env);
+    assert(res.ok === false, 'a non-owner session plus a wrong token must still be 401');
+    assert(res.response.status === 401, `expected 401, got ${res.response.status}`);
   });
 
   // ── styled confirm modal replaces native confirm() (no native confirm left) ─

--- a/test/jul36-owner-manage.test.js
+++ b/test/jul36-owner-manage.test.js
@@ -51,6 +51,26 @@ t('doc-view route only builds ownerManage data inside an isOwner guard', () => {
   assert(guard >= 0 && guard > decl, 'ownerManage must only be populated inside `if (isOwner)`');
 });
 
+t('doc-view never leaks private doc metadata (version count) to non-owners via the shared bootCfg', () => {
+  // The reviewer's refined bar: button-label strings live in the shared,
+  // open-source overlay bundle and protect nothing — but a slug's *version
+  // count* is private metadata. `commentCount` and `allowed_users` only ride
+  // inside ownerManage (already forced null for non-owners above), so the one
+  // channel that reaches EVERY viewer is the `versions` array. Its length must
+  // therefore follow the access policy: only callers cleared by canSeeHistory
+  // get the full list; everyone else collapses to just the version they asked
+  // for, so `versions.length` can never betray how many versions exist.
+  const full = docViewRoute.indexOf('meta.versions.map(');
+  const gate = docViewRoute.lastIndexOf('canSeeHistory(', full);
+  const gateStmt = docViewRoute.lastIndexOf('if (', full);
+  assert(full >= 0, 'doc-view must build the version list from meta.versions');
+  assert(gate >= 0 && gate < full && gate > gateStmt,
+    'the full version list must be gated by canSeeHistory(...) in the SAME if — never handed out unconditionally');
+  const collapse = docViewRoute.indexOf('versions = [{ n: Number(vStr)', full);
+  assert(collapse >= 0,
+    'the non-history branch must collapse `versions` to the single viewed version, not the full list');
+});
+
 const injectOverlayStart = worker.indexOf('function injectOverlay(rawHtml, slug, version, identity, versions, isOwner, ownerManage) {');
 const injectOverlayEnd = worker.indexOf('\n}', injectOverlayStart);
 if (injectOverlayStart < 0) throw new Error('injectOverlay() signature not found — did it change?');

--- a/test/me-management.test.js
+++ b/test/me-management.test.js
@@ -1,9 +1,19 @@
-// Owner catalog remote-management guard.
+// Owner catalog (/me) guard.
 //
-// /me is the product management surface for remote source-of-truth docs. Since
-// published docs are arbitrary HTML on the same origin, remote writes must NOT
-// rely on the owner session cookie alone. The page asks for an admin token and
-// keeps it in memory only.
+// 2026-08-13 rework (julie: "删改实在是太丑了 uiux 请improve。而且不能只在/me page"):
+// /me is now a clean delete-only catalog — title/slug/version + Delete. The
+// per-row visibility/history/commenting/allowed_users dropdowns and the
+// admin-token input are GONE: access controls moved to the doc-page Share
+// panel (overlay.js showManageModal, see jul36-owner-manage.test.js), and
+// Delete now authorizes off the owner's session cookie instead of a pasted
+// token (safe only because of the CSP on every doc response — see
+// csp.test.js). /me is reachable only by the signed-in owner (route-level
+// isOwnerSession redirect), so its own same-origin fetches are already
+// cookied.
+//
+// Gate (小cc review #2): the /me HTML response must not contain access data
+// of any kind — especially `allowed_users` — since none of that is rendered
+// here anymore.
 
 const fs = require('fs');
 const path = require('path');
@@ -25,40 +35,55 @@ const deleteEnd = worker.indexOf("return text('Not found'", deleteStart);
 if (deleteStart < 0 || deleteEnd < 0 || deleteEnd <= deleteStart) throw new Error('/api/doc DELETE block missing');
 const deleteRoute = worker.slice(deleteStart, deleteEnd);
 
-console.log('/me remote management UI');
+console.log('/me owner catalog');
 
-t('/me exposes remote access controls for hosted docs', () => {
-  assert(index.includes('class="access-form"'), 'missing access form');
-  assert(index.includes('name="visibility"'), 'missing visibility control');
-  assert(index.includes('name="history_visibility"'), 'missing history visibility control');
-  assert(index.includes('name="commenting"'), 'missing commenting control');
-  assert(index.includes('name="allowed_users"'), 'missing allowed users control');
+t('/me no longer exposes the per-row access-control form', () => {
+  assert(!index.includes('class="access-form"'), '/me must not render the old access-form');
+  assert(!index.includes('name="visibility"'), '/me must not render a visibility control');
+  assert(!index.includes('name="history_visibility"'), '/me must not render a history-visibility control');
+  assert(!index.includes('name="commenting"'), '/me must not render a commenting control');
+  assert(!index.includes('name="allowed_users"'), '/me must not render an allowed-users control');
 });
 
-t('/me asks for an admin token without embedding the deployment secret', () => {
-  assert(index.includes('id="admin-token"'), 'missing admin token input');
-  assert(index.includes('type="password"'), 'admin token input should not be plain text');
-  assert(index.includes('autocomplete="off"'), 'admin token should not be browser-stored by default');
+t('/me no longer asks for an admin token', () => {
+  assert(!index.includes('id="admin-token"'), '/me must not render the admin-token input');
+  assert(!index.includes('Admin token'), '/me must not reference "Admin token" anywhere');
   assert(!index.includes('TDOC_UPLOAD_TOKEN'), '/me HTML must not reference TDOC_UPLOAD_TOKEN');
+  assert(!index.includes("'Authorization'"), '/me must not build an Authorization header');
 });
 
-t('/me saves access through the remote access endpoint with a bearer token', () => {
-  assert(index.includes("fetch('/api/doc/access'"), 'access form must call remote access endpoint');
-  assert(index.includes("method: 'PATCH'"), 'access form must PATCH');
-  assert(index.includes("'Authorization': 'Bearer ' + token"), 'access form must send bearer token');
-  assert(!index.includes("credentials: 'same-origin'"), 'remote writes must not rely on owner session cookies');
-  assert(index.includes('JSON.stringify({ slug, access })'), 'access form must send slug + access only');
+t('/me never computes or emits allowed_users (gate: no access data leaks into the catalog)', () => {
+  assert(!index.includes('allowed_users'), '/me source must not reference allowed_users at all');
+  assert(!index.includes('accessFromMeta'), '/me must not compute an access policy per row anymore');
 });
 
-t('/me deletes remote docs through DELETE /api/doc with a bearer token', () => {
+t('/me keeps only title, slug, version, and Delete per row', () => {
+  assert(index.includes('doc-title'), 'missing doc title link');
+  assert(index.includes('doc-meta'), 'missing slug/version meta line');
+  assert(index.includes('class="delete-doc"'), 'missing delete button');
+});
+
+t('/me deletes remote docs through DELETE /api/doc using the session (no token)', () => {
   assert(index.includes("fetch('/api/doc?slug=' + encodeURIComponent(slug)"), 'delete button must call remote delete endpoint');
   assert(index.includes("method: 'DELETE'"), 'delete button must use DELETE');
-  assert(index.includes("headers,"), 'delete button must send auth headers');
-  assert(deleteRoute.includes('await requireUploadAuth(req, env)'), 'remote delete must keep upload-token auth');
+  assert(index.includes("credentials: 'same-origin'"), 'delete fetch should be explicit about sending the session cookie');
+  assert(!index.includes("'Authorization': 'Bearer'"), 'delete must not send a bearer token');
+  assert(deleteRoute.includes('await authorizeOwnerMutation(req, env)'), 'remote delete must accept session-or-token auth');
 });
 
-t('/me does not introduce owner-cookie admin writes', () => {
-  assert(!worker.includes('requireAdminAuth'), 'worker must not add cookie-based admin writes on same origin as arbitrary docs');
+t('/me still uses the styled confirm modal, never native confirm()', () => {
+  const nativeConfirmCall = /(?:^|[^\w.])confirm\(/m;
+  const stripped = index.split('\n').filter(l => !l.trim().startsWith('//') && !l.trim().startsWith('*')).join('\n');
+  assert(!nativeConfirmCall.test(stripped), '/me must not call the native confirm()');
+  assert(index.includes('showConfirm('), '/me must use the styled showConfirm() modal');
+  assert(index.includes('dataset.versions'), 'delete confirm copy should be built from data-versions/data-comments (honest N/M copy)');
+});
+
+t('/me does not introduce a bespoke cookie-only admin-auth path', () => {
+  // The session path now used everywhere is the SHARED authorizeOwnerMutation
+  // gate (session OR token) — not a one-off same-origin/cookie check bolted
+  // onto just this route.
+  assert(!worker.includes('requireAdminAuth'), 'worker must not add a separate cookie-based admin-auth function');
   assert(!worker.includes('isSameOriginRequest'), 'same-origin is not sufficient when docs are arbitrary same-origin HTML');
 });
 

--- a/test/me-management.test.js
+++ b/test/me-management.test.js
@@ -57,10 +57,13 @@ t('/me never computes or emits allowed_users (gate: no access data leaks into th
   assert(!index.includes('accessFromMeta'), '/me must not compute an access policy per row anymore');
 });
 
-t('/me keeps only title, slug, version, and Delete per row', () => {
+t('/me keeps only title, slug, version, and a quiet ⋯ delete per row', () => {
   assert(index.includes('doc-title'), 'missing doc title link');
   assert(index.includes('doc-meta'), 'missing slug/version meta line');
-  assert(index.includes('class="delete-doc"'), 'missing delete button');
+  // Delete is tucked behind a ⋯ overflow menu, not a prominent per-row button.
+  assert(index.includes('class="row-menu-btn"'), 'missing ⋯ overflow trigger');
+  assert(index.includes('class="row-delete"'), 'missing delete item inside the menu');
+  assert(!index.includes('class="delete-doc"'), 'the loud standalone delete button should be gone');
 });
 
 t('/me deletes remote docs through DELETE /api/doc using the session (no token)', () => {

--- a/test/remote-access-route.test.js
+++ b/test/remote-access-route.test.js
@@ -31,11 +31,15 @@ t('CORS allows PATCH for remote access mutation', () => {
     'PATCH missing from Access-Control-Allow-Methods');
 });
 
-t('PATCH /api/doc/access authenticates before parsing body or writing meta', () => {
-  const auth = route.indexOf('await requireUploadAuth(req, env)');
+t('PATCH /api/doc/access authenticates (session-or-token) before parsing body or writing meta', () => {
+  // JUL-36 owner-manage-UX tail (2026-08-13): browser owner mutations now
+  // authorize off the owner's session cookie OR the CLI upload token, via
+  // the shared authorizeOwnerMutation() gate — see jul36-owner-manage.test.js
+  // for the gate's own unit coverage (session-only, token-only, neither).
+  const auth = route.indexOf('await authorizeOwnerMutation(req, env)');
   const body = route.indexOf('await req.json()');
   const write = route.indexOf('env.META.put(`meta:${slug}`');
-  assert(auth >= 0, 'route must call requireUploadAuth');
+  assert(auth >= 0, 'route must call authorizeOwnerMutation');
   assert(body >= 0, 'route should parse request JSON after auth');
   assert(write >= 0, 'route should persist meta after auth');
   assert(auth < body, 'auth must happen before body parse');

--- a/test/run.js
+++ b/test/run.js
@@ -35,6 +35,7 @@ const OFFLINE = [
   'comment-upload.test.js',   // local→worker comment merge (non-destructive)
   'comment-ops.test.js',      // #34 DO-serialized mutation ops
   'p3-hardening.test.js',     // #33 safeParseList + escapeHtml
+  'csp-headers.test.js',      // CSP header + nonce plumbing (hermetic, no browser)
   'stampaids.test.js',        // aid-stamp regex hardening (equivalence + edges)
   'vercel-shim.test.js',      // vercel storage shims (KV/R2 contract, rewrite URL)
   'api.test.js',              // hermetic: spawns its own server in a temp dir
@@ -47,6 +48,7 @@ const GATED = [
   'publish.test.js',     // dry-publish + (gated) real publish
   'responsive.test.js',  // playwright
   'ui.test.js',          // playwright
+  'csp-xss.test.js',     // playwright: author <script>/onclick blocked, overlay still works
 ];
 
 const runAll = process.argv.includes('--all');

--- a/test/run.js
+++ b/test/run.js
@@ -24,6 +24,7 @@ const OFFLINE = [
   'access.test.js',           // JUL-31 access policy (public/unlisted/private)
   'remote-access-route.test.js', // remote access mutation auth + meta-only guard
   'me-management.test.js',    // /me remote SoT management UI guard
+  'jul36-owner-manage.test.js', // JUL-36 owner manage UX: server-gated data, token-only mutations, no native confirm()
   'runtime-provenance.test.js', // release provenance + content-hash redeploy
   'oldver-strip.test.js',     // old-version banner predicate
   'cli.test.js',              // CLI resilience (drives bash hermetically)

--- a/worker/worker.js
+++ b/worker/worker.js
@@ -850,20 +850,54 @@ function reconcileAnchors(comments, aidsInVersion, V) {
   return comments;
 }
 
+// ─────────────────────────────────────────────────────────────────────────
+// CSP (owner-manage-via-session hardening)
+//
+// A published doc is arbitrary author HTML served on our own origin. Once
+// owner mutations (delete / access) can be authorized by the owner's SESSION
+// COOKIE alone (see authorizeOwnerMutation below), a malicious <script> or
+// onclick= embedded in a doc's HTML could ride that cookie to silently
+// delete/modify docs (confused-deputy) — the browser sends the cookie on any
+// same-origin fetch/XHR the page's own script issues, no user gesture needed.
+//
+// FIX: every doc-serving response carries a CSP that runs ONLY our own
+// nonced overlay script and blocks everything else — author <script> tags,
+// inline event-handler attributes (onclick=...), and javascript: URLs all
+// lack the nonce and there is no 'unsafe-inline' to fall back to. Verified
+// fact (2026-08): 0 of 36 published doc versions use <script>, so this
+// breaks no known content.
+//
+// 'strict-dynamic' lets the nonced overlay script load further scripts of
+// its own choosing (it doesn't today, but this keeps the policy from being
+// a maintenance trap if it ever needs to). object-src/base-uri are locked
+// down too (classic plugin/base-tag CSP-bypass vectors) — nothing else is
+// restricted, so author CSS/images/fonts/etc. are untouched.
+function cspHeader(nonce) {
+  return `script-src 'nonce-${nonce}' 'strict-dynamic'; object-src 'none'; base-uri 'none';`;
+}
+
 // Inject the overlay boot + an arbitrary cfg into a document. Single source of
 // truth for "put window.__TDOC__ + overlay.js before </body>" — used by both
 // the published view and the /fork view (which previously re-implemented this
 // inline, risking drift).
-function injectOverlayCfg(rawHtml, cfg) {
+//
+// `nonce` (when supplied) is stamped onto BOTH injected <script> tags so they
+// — and only they — run under the CSP set by cspHeader() above. Callers that
+// don't pass a nonce (there are none left in this file, but keep the param
+// optional so a future caller can't silently omit CSP without an explicit
+// choice) get unnonced tags, which simply won't execute under a nonce-based
+// CSP — fail closed, not fail open.
+function injectOverlayCfg(rawHtml, cfg, nonce) {
   const bootCfg = { ...cfg, runtime: cfg.runtime || runtimeInfo() };
+  const nonceAttr = nonce ? ` nonce="${nonce}"` : '';
   const inject =
-    `<script>window.__TDOC__ = ${safeJsonForScript(bootCfg)};</script>\n` +
-    `<script>${OVERLAY_JS}</script>`;
+    `<script${nonceAttr}>window.__TDOC__ = ${safeJsonForScript(bootCfg)};</script>\n` +
+    `<script${nonceAttr}>${OVERLAY_JS}</script>`;
   if (rawHtml.includes('</body>')) return rawHtml.replace('</body>', `${inject}\n</body>`);
   return rawHtml + inject;
 }
 
-function injectOverlay(rawHtml, slug, version, identity, versions, isOwner, ownerManage) {
+function injectOverlay(rawHtml, slug, version, identity, versions, isOwner, ownerManage, nonce) {
   return injectOverlayCfg(rawHtml, {
     slug, version,
     identity: identity || null,
@@ -874,7 +908,7 @@ function injectOverlay(rawHtml, slug, version, identity, versions, isOwner, owne
     authConfigured: true,
     mode: 'published',
     versions: Array.isArray(versions) && versions.length ? versions : [{ n: version }],
-  });
+  }, nonce);
 }
 
 // Neutral landing page served at `/`. No catalog, no slug list — just
@@ -900,6 +934,20 @@ function landingHtml() {
 </body></html>`;
 }
 
+// /me — the owner's doc catalog. JUL-36 tail (2026-08-13): this used to be a
+// dense access-control table (visibility/history/commenting/allowed_users
+// dropdowns + Save) gated by an admin-token field. Both are GONE now:
+//   - access controls moved to the doc-page Share panel (overlay.js
+//     showManageModal, PATCH /api/doc/access) — a single doc's own page is
+//     the right place to manage that doc, not a spreadsheet of every doc.
+//   - the admin-token field is gone because DELETE /api/doc now accepts the
+//     owner's session cookie (authorizeOwnerMutation) — safe because of the
+//     CSP set on every doc response (see cspHeader()). /me is only reachable
+//     by the signed-in owner in the first place (isOwnerSession gate in the
+//     route above), so its own fetches are already same-origin + cookied.
+// What's left: title, slug, version, Delete. No access data of any kind is
+// computed or emitted here (gate: response HTML must not contain
+// `allowed_users` — there is nothing here that could).
 async function indexHtml(env, session) {
   // List all `meta:` keys.
   let list = [];
@@ -918,9 +966,6 @@ async function indexHtml(env, session) {
     let meta = {};
     try { meta = JSON.parse(metaRaw || '{}'); } catch {}
     const latest = meta.versions?.[meta.versions.length - 1]?.n || 1;
-    const access = accessFromMeta(meta);
-    const selected = (value, current) => value === current ? ' selected' : '';
-    const allowlist = (access.allowed_users || []).join(', ');
     // Only list docs whose latest version actually exists in R2 — otherwise
     // the index advertises 404s. (We hit this when R2 writes silently failed
     // while KV meta updates succeeded; defense in depth.)
@@ -937,72 +982,36 @@ async function indexHtml(env, session) {
       }
     } catch {}
     const versionCount = Array.isArray(meta.versions) && meta.versions.length ? meta.versions.length : 1;
-    rows.push(`<tr>
-      <td><a href="/d/${encodeURIComponent(slug)}/v/${latest}">${escapeHtml(meta.title || slug)}</a></td>
-      <td>${escapeHtml(slug)}</td>
-      <td>v${latest}</td>
-      <td>
-        <form class="access-form" data-slug="${escapeHtml(slug)}">
-          <label>Visibility
-            <select name="visibility">
-              <option value="unlisted"${selected('unlisted', access.visibility)}>Unlisted</option>
-              <option value="private"${selected('private', access.visibility)}>Private</option>
-              <option value="public"${selected('public', access.visibility)}>Public</option>
-            </select>
-          </label>
-          <label>History
-            <select name="history_visibility">
-              <option value="owner"${selected('owner', access.history_visibility)}>Owner</option>
-              <option value="invited"${selected('invited', access.history_visibility)}>Invited</option>
-              <option value="public"${selected('public', access.history_visibility)}>Public</option>
-            </select>
-          </label>
-          <label>Comments
-            <select name="commenting">
-              <option value="signed_in"${selected('signed_in', access.commenting)}>Signed in</option>
-              <option value="invited"${selected('invited', access.commenting)}>Invited</option>
-              <option value="owner"${selected('owner', access.commenting)}>Owner</option>
-              <option value="off"${selected('off', access.commenting)}>Off</option>
-            </select>
-          </label>
-          <label>Allowed users
-            <input name="allowed_users" value="${escapeHtml(allowlist)}" placeholder="github-login, another-login">
-          </label>
-          <button type="submit">Save</button>
-        </form>
-      </td>
-      <td><button class="delete-doc" data-slug="${escapeHtml(slug)}" data-title="${escapeHtml(meta.title || slug)}" data-versions="${versionCount}" data-comments="${commentCount}">Delete</button></td>
-    </tr>`);
+    rows.push(`<div class="doc-row">
+      <div class="doc-info">
+        <a class="doc-title" href="/d/${encodeURIComponent(slug)}/v/${latest}">${escapeHtml(meta.title || slug)}</a>
+        <div class="doc-meta">${escapeHtml(slug)} · v${latest}</div>
+      </div>
+      <button class="delete-doc" data-slug="${escapeHtml(slug)}" data-title="${escapeHtml(meta.title || slug)}" data-versions="${versionCount}" data-comments="${commentCount}">Delete</button>
+    </div>`);
   }
 
   return `<!doctype html><html><head><meta charset="utf-8"><title>tdoc</title>
 <style>
   :root {
     --td-accent: #1652f0; --td-accent-hover: #1245d0; --td-accent-tint: #e8eeff;
-    --td-danger: #b42318; --td-danger-tint: #fdeceb; --td-ok: #087443;
-    --td-ink: #111; --td-muted: #666; --td-line: #eee;
+    --td-danger: #b42318; --td-danger-hover: #931c14; --td-danger-tint: #fdeceb; --td-ok: #087443;
+    --td-ink: #111; --td-muted: #666; --td-line: #eee; --td-surface: #f7f7f7;
   }
-  body { font: 15px system-ui, -apple-system, sans-serif; max-width: 1120px; margin: 48px auto; padding: 0 20px; color: var(--td-ink); }
+  body { font: 15px system-ui, -apple-system, sans-serif; max-width: 680px; margin: 48px auto; padding: 0 20px; color: var(--td-ink); }
   h1 { font-size: 28px; margin: 0 0 4px; color: var(--td-accent); }
-  .sub { color: var(--td-muted); margin: 0 0 32px; }
-  table { width: 100%; border-collapse: collapse; }
-  th, td { text-align: left; vertical-align: top; padding: 10px 12px; border-bottom: 1px solid var(--td-line); }
-  th { font-size: 12px; text-transform: uppercase; color: #888; letter-spacing: 0.04em; }
+  .who { color: var(--td-muted); font-size: 13px; margin: 0 0 28px; }
+  .who b { color: #444; font-weight: 600; }
   a { color: var(--td-accent); text-decoration: none; }
   a:hover { text-decoration: underline; }
-  .empty { color: #888; padding: 40px 0; text-align: center; }
-  .who { color: #888; font-size: 13px; margin: 0 0 32px; }
-  .who b { color: #444; font-weight: 600; }
-  .toolbar { display: flex; gap: 10px; align-items: end; margin: 0 0 18px; }
-  .toolbar label { max-width: 320px; }
-  .toolbar input { min-width: 280px; }
-  .access-form { display: grid; grid-template-columns: repeat(4, minmax(110px, 1fr)) auto; gap: 8px; align-items: end; min-width: 620px; }
-  label { display: grid; gap: 4px; color: var(--td-muted); font-size: 12px; }
-  select, input, button { font: inherit; border: 1px solid #d7d7d7; border-radius: 6px; background: #fff; color: var(--td-ink); padding: 7px 8px; }
-  input { min-width: 180px; }
-  button { cursor: pointer; transition: border-color .12s, background .12s, color .12s; }
-  button:hover { border-color: var(--td-accent); }
-  .delete-doc { color: var(--td-danger); border-color: #f1b8b2; }
+  .empty { color: #888; padding: 40px 0; text-align: center; border: 1px dashed var(--td-line); border-radius: 12px; }
+  .doc-list { display: flex; flex-direction: column; gap: 8px; }
+  .doc-row { display: flex; align-items: center; justify-content: space-between; gap: 16px; padding: 14px 16px; border: 1px solid var(--td-line); border-radius: 10px; background: var(--td-surface); }
+  .doc-info { min-width: 0; }
+  .doc-title { display: block; font-weight: 600; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+  .doc-meta { color: var(--td-muted); font-size: 12px; margin-top: 2px; }
+  button { font: inherit; cursor: pointer; transition: border-color .12s, background .12s, color .12s; }
+  .delete-doc { flex-shrink: 0; color: var(--td-danger); background: #fff; border: 1px solid #f1b8b2; border-radius: 6px; padding: 7px 12px; }
   .delete-doc:hover { background: var(--td-danger); color: #fff; border-color: var(--td-danger); }
   .status { min-height: 20px; margin: 0 0 16px; color: var(--td-muted); font-size: 13px; }
   .status[data-kind="error"] { color: var(--td-danger); }
@@ -1016,41 +1025,22 @@ async function indexHtml(env, session) {
   .tdoc-modal p { margin: 0 0 14px; color: #444; line-height: 1.5; }
   .tdoc-modal .status { color: #888; font-size: 13px; margin: 0 0 8px; }
   .tdoc-modal .actions { display: flex; gap: 8px; justify-content: flex-end; margin-top: 6px; }
-  .tdoc-modal button { padding: 8px 16px; border-radius: 6px; }
+  .tdoc-modal button { padding: 8px 16px; border-radius: 6px; border: 1px solid #ccc; background: #fff; }
   .tdoc-modal button.danger { background: var(--td-danger); border-color: var(--td-danger); color: #fff; }
-  .tdoc-modal button.danger:hover { background: #931c14; border-color: #931c14; }
-  @media (max-width: 900px) {
-    table, thead, tbody, tr, th, td { display: block; }
-    thead { display: none; }
-    tr { padding: 14px 0; border-bottom: 1px solid var(--td-line); }
-    td { border: 0; padding: 5px 0; }
-    .access-form { min-width: 0; grid-template-columns: 1fr; }
-  }
+  .tdoc-modal button.danger:hover { background: var(--td-danger-hover); border-color: var(--td-danger-hover); }
 </style></head><body>
 <h1>My docs</h1>
 <p class="who">Documents hosted on this worker${session && session.login ? ` · signed in as <b>${escapeHtml(session.login)}</b>` : ''}.</p>
-<div class="toolbar">
-  <label>Admin token
-    <input id="admin-token" type="password" autocomplete="off" placeholder="Required for remote changes">
-  </label>
-</div>
 <p id="status" class="status" aria-live="polite"></p>
 ${rows.length === 0 ? '<p class="empty">No published docs yet.</p>' :
-  `<table><thead><tr><th>Title</th><th>Slug</th><th>Version</th><th>Remote access</th><th>Remote delete</th></tr></thead><tbody>${rows.join('')}</tbody></table>`}
+  `<div class="doc-list">${rows.join('')}</div>`}
 <script>
 (() => {
   const status = document.getElementById('status');
-  const tokenInput = document.getElementById('admin-token');
   const say = (message, kind = '') => {
     status.textContent = message || '';
     status.dataset.kind = kind;
   };
-  const authHeaders = () => {
-    const token = tokenInput.value.trim();
-    if (!token) throw new Error('Admin token is required for remote changes.');
-    return { 'Content-Type': 'application/json', 'Authorization': 'Bearer ' + token };
-  };
-  const users = (value) => value.split(/[\\s,]+/).map((x) => x.trim()).filter(Boolean);
   // Styled confirm — replaces window.confirm(). Resolves true/false; never
   // silently proceeds (Cancel and the backdrop both resolve false).
   function showConfirm({ title, body, confirmLabel, danger }) {
@@ -1075,33 +1065,10 @@ ${rows.length === 0 ? '<p class="empty">No published docs yet.</p>' :
       document.body.appendChild(bg);
     });
   }
-  document.querySelectorAll('.access-form').forEach((form) => {
-    form.addEventListener('submit', async (event) => {
-      event.preventDefault();
-      const slug = form.dataset.slug;
-      const access = {
-        visibility: form.elements.visibility.value,
-        history_visibility: form.elements.history_visibility.value,
-        commenting: form.elements.commenting.value,
-        allowed_users: users(form.elements.allowed_users.value),
-      };
-      say('Saving access...');
-      let headers;
-      try { headers = authHeaders(); } catch (e) { say(e.message, 'error'); return; }
-      const res = await fetch('/api/doc/access', {
-        method: 'PATCH',
-        headers,
-        body: JSON.stringify({ slug, access }),
-      });
-      if (!res.ok) {
-        let body = {};
-        try { body = await res.json(); } catch {}
-        say(body.error ? 'Access save failed: ' + body.error : 'Access save failed.', 'error');
-        return;
-      }
-      say('Access saved for ' + slug + '.', 'ok');
-    });
-  });
+  // Delete: no token — the browser is already signed in as the owner (this
+  // page 302s away for anyone else), so the session cookie alone authorizes
+  // DELETE /api/doc (authorizeOwnerMutation in worker.js). Plain same-origin
+  // fetch sends the cookie automatically; no Authorization header needed.
   document.querySelectorAll('.delete-doc').forEach((button) => {
     button.addEventListener('click', async () => {
       const slug = button.dataset.slug;
@@ -1117,11 +1084,9 @@ ${rows.length === 0 ? '<p class="empty">No published docs yet.</p>' :
       });
       if (!proceed) return;
       say('Deleting ' + slug + '...');
-      let headers;
-      try { headers = authHeaders(); } catch (e) { say(e.message, 'error'); return; }
       const res = await fetch('/api/doc?slug=' + encodeURIComponent(slug), {
         method: 'DELETE',
-        headers,
+        credentials: 'same-origin',
       });
       if (!res.ok) {
         let body = {};
@@ -1129,7 +1094,7 @@ ${rows.length === 0 ? '<p class="empty">No published docs yet.</p>' :
         say(body.error ? 'Delete failed: ' + body.error : 'Delete failed.', 'error');
         return;
       }
-      button.closest('tr').remove();
+      button.closest('.doc-row').remove();
       say('Deleted ' + slug + ' from remote storage.', 'ok');
     });
   });
@@ -1622,6 +1587,32 @@ async function requireUploadAuth(req, env) {
   return null;
 }
 
+// Owner-mutation gate for browser-facing admin routes (DELETE /api/doc,
+// PATCH /api/doc/access). EITHER credential authorizes:
+//   - the caller is signed in as the configured TDOC_OWNER (session cookie
+//     set by the GitHub device-flow login) — this is the new browser path,
+//     replacing the admin-token field that used to live on /me and the
+//     doc-page manage modal;
+//   - OR the caller presents the CLI's upload bearer token (requireUploadAuth)
+//     — unchanged, still how `tdoc publish`/`tdoc-delete` authenticate.
+//
+// Trusting the session cookie here is safe ONLY because every doc-serving
+// response now carries the CSP set by cspHeader() above, which stops author
+// <script>/onclick content from running at all — so a doc can't ride the
+// owner's cookie into these routes (the confused-deputy the admin token used
+// to guard against). The two changes ship together; do not relax one without
+// the other.
+//
+// Returns { ok: true } when authorized, or { ok: false, response } (the 401
+// to return as-is) otherwise. Does not read/parse the request body.
+async function authorizeOwnerMutation(req, env) {
+  const session = await getSession(env, req);
+  if (isOwnerSession(env, session)) return { ok: true, session };
+  const unauth = await requireUploadAuth(req, env);
+  if (unauth) return { ok: false, response: unauth };
+  return { ok: true, session: null };
+}
+
 // ===========================================================================
 // #34 — Per-slug write serialization via a Durable Object.
 //
@@ -1979,7 +1970,10 @@ export default {
         } catch {}
         ownerManage = { access: gate.access, versionCount: versions.length, commentCount };
       }
-      return html(injectOverlay(raw, slug, Number(vStr), identity, versions, isOwner, ownerManage));
+      const nonce = rand(16);
+      return html(injectOverlay(raw, slug, Number(vStr), identity, versions, isOwner, ownerManage, nonce), {
+        headers: { 'Content-Security-Policy': cspHeader(nonce) },
+      });
     }
 
     // ---- doc export / fork ----
@@ -2075,12 +2069,18 @@ export default {
       // The fork route boots the overlay in read-only "fork" mode so the
       // user can SEE what they just downloaded — comments rendered as cards,
       // anchors highlighted — without any backend.
+      // Same confused-deputy surface as the doc-view route (same-origin
+      // cookie, arbitrary author HTML) even though fork/export don't expose
+      // owner-manage UI — a script here could still ride the viewer's session
+      // cookie to hit /api/doc*. Nonce the injected overlay script the same
+      // way; author content stays unnonced and inert under the CSP below.
+      const nonce = rand(16);
       let bodyHtml = html;
       if (kind === 'fork') {
         bodyHtml = injectOverlayCfg(bodyHtml, {
           slug, version: Number(vStr), identity: null,
           authConfigured: false, mode: 'fork', originalSlug: slug,
-        });
+        }, nonce);
       }
 
       const finalHtml = banner + jsonBlock + bodyHtml;
@@ -2089,7 +2089,7 @@ export default {
       // overridden with ?download=1 / ?download=0.
       const defaultAttach = kind === 'export';
       const forceDownload = dl === '1' || (defaultAttach && dl !== '0');
-      const headers = { 'Content-Type': 'text/html; charset=utf-8' };
+      const headers = { 'Content-Type': 'text/html; charset=utf-8', 'Content-Security-Policy': cspHeader(nonce) };
       if (forceDownload) headers['Content-Disposition'] = `attachment; filename="${slug}-v${vStr}-fork.html"`;
       return new Response(finalHtml, { status: 200, headers });
     }
@@ -2488,11 +2488,13 @@ export default {
 
     // ---- admin access mutation ----
     // Remote storage is the source of truth: access policy must be mutable
-    // without a local meta.json or full document re-upload. Authenticated with
-    // the same upload token as /api/upload and /api/doc DELETE.
+    // without a local meta.json or full document re-upload. Authorized by
+    // authorizeOwnerMutation: the owner's session (browser, doc-page Share
+    // panel / /me) OR the upload token (CLI) — see its doc comment for why
+    // the session path is safe (CSP blocks author scripts on every response).
     if (p === '/api/doc/access' && method === 'PATCH') {
-      const unauth = await requireUploadAuth(req, env);
-      if (unauth) return unauth;
+      const auth = await authorizeOwnerMutation(req, env);
+      if (!auth.ok) return auth.response;
       let body = {};
       try { body = await req.json(); } catch {}
       const topKeys = Object.keys(body || {});
@@ -2512,9 +2514,12 @@ export default {
     }
 
     // ---- admin delete ----
+    // Authorized by authorizeOwnerMutation: the owner's session (browser,
+    // /me or the doc-page Share panel) OR the upload token (CLI's
+    // tdoc-delete) — see its doc comment for why the session path is safe.
     if (p === '/api/doc' && method === 'DELETE') {
-      const unauth = await requireUploadAuth(req, env);
-      if (unauth) return unauth;
+      const auth = await authorizeOwnerMutation(req, env);
+      if (!auth.ok) return auth.response;
       const slug = url.searchParams.get('slug');
       if (!slug) return json({ error: 'slug required' }, { status: 400 });
       // delete all R2 versions

--- a/worker/worker.js
+++ b/worker/worker.js
@@ -987,7 +987,12 @@ async function indexHtml(env, session) {
         <a class="doc-title" href="/d/${encodeURIComponent(slug)}/v/${latest}">${escapeHtml(meta.title || slug)}</a>
         <div class="doc-meta">${escapeHtml(slug)} · v${latest}</div>
       </div>
-      <button class="delete-doc" data-slug="${escapeHtml(slug)}" data-title="${escapeHtml(meta.title || slug)}" data-versions="${versionCount}" data-comments="${commentCount}">Delete</button>
+      <div class="row-actions">
+        <button class="row-menu-btn" aria-label="More actions" aria-haspopup="true" aria-expanded="false">⋯</button>
+        <div class="row-menu" hidden>
+          <button class="row-delete" data-slug="${escapeHtml(slug)}" data-title="${escapeHtml(meta.title || slug)}" data-versions="${versionCount}" data-comments="${commentCount}">Delete…</button>
+        </div>
+      </div>
     </div>`);
   }
 
@@ -1005,14 +1010,22 @@ async function indexHtml(env, session) {
   a { color: var(--td-accent); text-decoration: none; }
   a:hover { text-decoration: underline; }
   .empty { color: #888; padding: 40px 0; text-align: center; border: 1px dashed var(--td-line); border-radius: 12px; }
-  .doc-list { display: flex; flex-direction: column; gap: 8px; }
-  .doc-row { display: flex; align-items: center; justify-content: space-between; gap: 16px; padding: 14px 16px; border: 1px solid var(--td-line); border-radius: 10px; background: var(--td-surface); }
+  .doc-list { display: flex; flex-direction: column; }
+  .doc-row { display: flex; align-items: center; justify-content: space-between; gap: 16px; padding: 13px 4px; border-bottom: 1px solid var(--td-line); }
   .doc-info { min-width: 0; }
   .doc-title { display: block; font-weight: 600; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
   .doc-meta { color: var(--td-muted); font-size: 12px; margin-top: 2px; }
   button { font: inherit; cursor: pointer; transition: border-color .12s, background .12s, color .12s; }
-  .delete-doc { flex-shrink: 0; color: var(--td-danger); background: #fff; border: 1px solid #f1b8b2; border-radius: 6px; padding: 7px 12px; }
-  .delete-doc:hover { background: var(--td-danger); color: #fff; border-color: var(--td-danger); }
+  /* Delete lives behind a quiet ⋯ overflow — the catalog reads as a clean list,
+     not a management console. Faint by default, clearer on row hover. */
+  .row-actions { position: relative; flex-shrink: 0; }
+  .row-menu-btn { border: none; background: none; color: #ccc; font-size: 20px; line-height: 1; padding: 2px 8px; border-radius: 6px; }
+  .doc-row:hover .row-menu-btn { color: var(--td-muted); }
+  .row-menu-btn:hover, .row-menu-btn[aria-expanded="true"] { background: var(--td-line); color: var(--td-ink); }
+  .row-menu { position: absolute; right: 0; top: 100%; margin-top: 4px; min-width: 128px; background: #fff; border: 1px solid var(--td-line); border-radius: 8px; box-shadow: 0 8px 24px rgba(0,0,0,0.12); padding: 4px; z-index: 10; }
+  .row-menu[hidden] { display: none; }
+  .row-delete { display: block; width: 100%; text-align: left; border: none; background: none; color: var(--td-danger); padding: 8px 12px; border-radius: 6px; white-space: nowrap; }
+  .row-delete:hover { background: var(--td-danger-tint); }
   .status { min-height: 20px; margin: 0 0 16px; color: var(--td-muted); font-size: 13px; }
   .status[data-kind="error"] { color: var(--td-danger); }
   .status[data-kind="ok"] { color: var(--td-ok); }
@@ -1065,12 +1078,34 @@ ${rows.length === 0 ? '<p class="empty">No published docs yet.</p>' :
       document.body.appendChild(bg);
     });
   }
+  // ⋯ overflow menu — one open at a time; a click anywhere else closes it.
+  function closeMenus(except) {
+    document.querySelectorAll('.row-menu').forEach((m) => {
+      if (m === except) return;
+      m.hidden = true;
+      m.previousElementSibling.setAttribute('aria-expanded', 'false');
+    });
+  }
+  document.querySelectorAll('.row-menu-btn').forEach((btn) => {
+    btn.addEventListener('click', (e) => {
+      e.stopPropagation();
+      const menu = btn.nextElementSibling;
+      const willOpen = menu.hidden;
+      closeMenus(willOpen ? menu : null);
+      menu.hidden = !willOpen;
+      btn.setAttribute('aria-expanded', String(willOpen));
+    });
+  });
+  document.addEventListener('click', () => closeMenus(null));
+  document.addEventListener('keydown', (e) => { if (e.key === 'Escape') closeMenus(null); });
+
   // Delete: no token — the browser is already signed in as the owner (this
   // page 302s away for anyone else), so the session cookie alone authorizes
   // DELETE /api/doc (authorizeOwnerMutation in worker.js). Plain same-origin
   // fetch sends the cookie automatically; no Authorization header needed.
-  document.querySelectorAll('.delete-doc').forEach((button) => {
+  document.querySelectorAll('.row-delete').forEach((button) => {
     button.addEventListener('click', async () => {
+      closeMenus(null);
       const slug = button.dataset.slug;
       const title = button.dataset.title || slug;
       const versions = button.dataset.versions || '1';

--- a/worker/worker.js
+++ b/worker/worker.js
@@ -863,11 +863,14 @@ function injectOverlayCfg(rawHtml, cfg) {
   return rawHtml + inject;
 }
 
-function injectOverlay(rawHtml, slug, version, identity, versions, isOwner) {
+function injectOverlay(rawHtml, slug, version, identity, versions, isOwner, ownerManage) {
   return injectOverlayCfg(rawHtml, {
     slug, version,
     identity: identity || null,
     isOwner: !!isOwner,
+    // Always null for non-owners (never just omitted-but-truthy-elsewhere) so
+    // the overlay's `if (!cfg.ownerManage) return;` guard is unambiguous.
+    ownerManage: isOwner ? (ownerManage || null) : null,
     authConfigured: true,
     mode: 'published',
     versions: Array.isArray(versions) && versions.length ? versions : [{ n: version }],
@@ -923,6 +926,17 @@ async function indexHtml(env, session) {
     // while KV meta updates succeeded; defense in depth.)
     const exists = await env.DOCS.head(`docs/${slug}/v${latest}/index.html`);
     if (!exists) continue;
+    // Honest delete-confirm copy needs a real comment count (JUL-36) — same
+    // fold used by the doc-view route's ownerManage data.
+    let commentCount = 0;
+    try {
+      const list = await readComments(env, slug);
+      ensureMigrated(list);
+      for (const c of historyList(list)) {
+        commentCount += 1 + (Array.isArray(c.replies) ? c.replies.length : 0);
+      }
+    } catch {}
+    const versionCount = Array.isArray(meta.versions) && meta.versions.length ? meta.versions.length : 1;
     rows.push(`<tr>
       <td><a href="/d/${encodeURIComponent(slug)}/v/${latest}">${escapeHtml(meta.title || slug)}</a></td>
       <td>${escapeHtml(slug)}</td>
@@ -957,19 +971,24 @@ async function indexHtml(env, session) {
           <button type="submit">Save</button>
         </form>
       </td>
-      <td><button class="delete-doc" data-slug="${escapeHtml(slug)}" data-title="${escapeHtml(meta.title || slug)}">Delete</button></td>
+      <td><button class="delete-doc" data-slug="${escapeHtml(slug)}" data-title="${escapeHtml(meta.title || slug)}" data-versions="${versionCount}" data-comments="${commentCount}">Delete</button></td>
     </tr>`);
   }
 
   return `<!doctype html><html><head><meta charset="utf-8"><title>tdoc</title>
 <style>
-  body { font: 15px system-ui, -apple-system, sans-serif; max-width: 1120px; margin: 48px auto; padding: 0 20px; color: #111; }
-  h1 { font-size: 28px; margin: 0 0 4px; color: #1652f0; }
-  .sub { color: #666; margin: 0 0 32px; }
+  :root {
+    --td-accent: #1652f0; --td-accent-hover: #1245d0; --td-accent-tint: #e8eeff;
+    --td-danger: #b42318; --td-danger-tint: #fdeceb; --td-ok: #087443;
+    --td-ink: #111; --td-muted: #666; --td-line: #eee;
+  }
+  body { font: 15px system-ui, -apple-system, sans-serif; max-width: 1120px; margin: 48px auto; padding: 0 20px; color: var(--td-ink); }
+  h1 { font-size: 28px; margin: 0 0 4px; color: var(--td-accent); }
+  .sub { color: var(--td-muted); margin: 0 0 32px; }
   table { width: 100%; border-collapse: collapse; }
-  th, td { text-align: left; vertical-align: top; padding: 10px 12px; border-bottom: 1px solid #eee; }
+  th, td { text-align: left; vertical-align: top; padding: 10px 12px; border-bottom: 1px solid var(--td-line); }
   th { font-size: 12px; text-transform: uppercase; color: #888; letter-spacing: 0.04em; }
-  a { color: #1652f0; text-decoration: none; }
+  a { color: var(--td-accent); text-decoration: none; }
   a:hover { text-decoration: underline; }
   .empty { color: #888; padding: 40px 0; text-align: center; }
   .who { color: #888; font-size: 13px; margin: 0 0 32px; }
@@ -978,19 +997,32 @@ async function indexHtml(env, session) {
   .toolbar label { max-width: 320px; }
   .toolbar input { min-width: 280px; }
   .access-form { display: grid; grid-template-columns: repeat(4, minmax(110px, 1fr)) auto; gap: 8px; align-items: end; min-width: 620px; }
-  label { display: grid; gap: 4px; color: #666; font-size: 12px; }
-  select, input, button { font: inherit; border: 1px solid #d7d7d7; border-radius: 6px; background: #fff; color: #111; padding: 7px 8px; }
+  label { display: grid; gap: 4px; color: var(--td-muted); font-size: 12px; }
+  select, input, button { font: inherit; border: 1px solid #d7d7d7; border-radius: 6px; background: #fff; color: var(--td-ink); padding: 7px 8px; }
   input { min-width: 180px; }
-  button { cursor: pointer; }
-  button:hover { border-color: #1652f0; }
-  .delete-doc { color: #b42318; border-color: #f1b8b2; }
-  .status { min-height: 20px; margin: 0 0 16px; color: #666; font-size: 13px; }
-  .status[data-kind="error"] { color: #b42318; }
-  .status[data-kind="ok"] { color: #087443; }
+  button { cursor: pointer; transition: border-color .12s, background .12s, color .12s; }
+  button:hover { border-color: var(--td-accent); }
+  .delete-doc { color: var(--td-danger); border-color: #f1b8b2; }
+  .delete-doc:hover { background: var(--td-danger); color: #fff; border-color: var(--td-danger); }
+  .status { min-height: 20px; margin: 0 0 16px; color: var(--td-muted); font-size: 13px; }
+  .status[data-kind="error"] { color: var(--td-danger); }
+  .status[data-kind="ok"] { color: var(--td-ok); }
+  /* Styled confirm modal — replaces window.confirm() (JUL-36). Matches the
+     doc overlay's .tdoc-modal-bg/.tdoc-modal visual language; kept as a
+     standalone copy here since /me does not load overlay.js. */
+  .tdoc-modal-bg { position: fixed; inset: 0; background: rgba(0,0,0,0.55); z-index: 1000; display: flex; align-items: center; justify-content: center; font: 14px system-ui, sans-serif; }
+  .tdoc-modal { background: #fff; color: var(--td-ink); border-radius: 12px; padding: 26px; width: 420px; max-width: calc(100vw - 32px); box-shadow: 0 20px 60px rgba(0,0,0,0.3); }
+  .tdoc-modal h3 { margin: 0 0 10px; font-size: 18px; }
+  .tdoc-modal p { margin: 0 0 14px; color: #444; line-height: 1.5; }
+  .tdoc-modal .status { color: #888; font-size: 13px; margin: 0 0 8px; }
+  .tdoc-modal .actions { display: flex; gap: 8px; justify-content: flex-end; margin-top: 6px; }
+  .tdoc-modal button { padding: 8px 16px; border-radius: 6px; }
+  .tdoc-modal button.danger { background: var(--td-danger); border-color: var(--td-danger); color: #fff; }
+  .tdoc-modal button.danger:hover { background: #931c14; border-color: #931c14; }
   @media (max-width: 900px) {
     table, thead, tbody, tr, th, td { display: block; }
     thead { display: none; }
-    tr { padding: 14px 0; border-bottom: 1px solid #eee; }
+    tr { padding: 14px 0; border-bottom: 1px solid var(--td-line); }
     td { border: 0; padding: 5px 0; }
     .access-form { min-width: 0; grid-template-columns: 1fr; }
   }
@@ -1019,6 +1051,30 @@ ${rows.length === 0 ? '<p class="empty">No published docs yet.</p>' :
     return { 'Content-Type': 'application/json', 'Authorization': 'Bearer ' + token };
   };
   const users = (value) => value.split(/[\\s,]+/).map((x) => x.trim()).filter(Boolean);
+  // Styled confirm — replaces window.confirm(). Resolves true/false; never
+  // silently proceeds (Cancel and the backdrop both resolve false).
+  function showConfirm({ title, body, confirmLabel, danger }) {
+    return new Promise((resolve) => {
+      const bg = document.createElement('div');
+      bg.className = 'tdoc-modal-bg';
+      bg.innerHTML = '<div class="tdoc-modal">' +
+        '<h3></h3><p></p>' +
+        '<div class="actions">' +
+          '<button type="button" data-act="cancel">Cancel</button>' +
+          '<button type="button" data-act="go"></button>' +
+        '</div></div>';
+      bg.querySelector('h3').textContent = title;
+      bg.querySelector('p').innerHTML = body;
+      const goBtn = bg.querySelector('[data-act="go"]');
+      goBtn.textContent = confirmLabel;
+      if (danger) goBtn.className = 'danger';
+      const done = (v) => { bg.remove(); resolve(v); };
+      bg.querySelector('[data-act="cancel"]').onclick = () => done(false);
+      bg.addEventListener('click', (e) => { if (e.target === bg) done(false); });
+      goBtn.onclick = () => done(true);
+      document.body.appendChild(bg);
+    });
+  }
   document.querySelectorAll('.access-form').forEach((form) => {
     form.addEventListener('submit', async (event) => {
       event.preventDefault();
@@ -1050,7 +1106,16 @@ ${rows.length === 0 ? '<p class="empty">No published docs yet.</p>' :
     button.addEventListener('click', async () => {
       const slug = button.dataset.slug;
       const title = button.dataset.title || slug;
-      if (!confirm('Delete "' + title + '" from remote storage? This removes all versions and comments.')) return;
+      const versions = button.dataset.versions || '1';
+      const comments = button.dataset.comments || '0';
+      const proceed = await showConfirm({
+        title: 'Delete "' + title + '"?',
+        body: 'This permanently removes <b>' + versions + ' version(s)</b> and <b>' + comments +
+          ' comment(s)</b> from remote storage. No undo.',
+        confirmLabel: 'Delete',
+        danger: true,
+      });
+      if (!proceed) return;
       say('Deleting ' + slug + '...');
       let headers;
       try { headers = authHeaders(); } catch (e) { say(e.message, 'error'); return; }
@@ -1895,7 +1960,26 @@ export default {
           versions = [{ n: Number(vStr), created: (hit && hit.created) || null }];
         }
       } catch {}
-      return html(injectOverlay(raw, slug, Number(vStr), identity, versions, isOwnerSession(env, session)));
+      const isOwner = isOwnerSession(env, session);
+      // JUL-36: owner-only manage data (Delete / Unpublish / visibility switch),
+      // computed fresh on THIS request and embedded only for the owner. A
+      // non-owner's bootCfg carries `ownerManage: null` — the overlay's manage
+      // menu never builds a single DOM node without it, so there is nothing to
+      // hide, only nothing rendered. Kept separate from `isOwner` (also still
+      // sent) so the manage UI's data dependency is explicit and single-source.
+      let ownerManage = null;
+      if (isOwner) {
+        let commentCount = 0;
+        try {
+          const list = await readComments(env, slug);
+          ensureMigrated(list);
+          for (const c of historyList(list)) {
+            commentCount += 1 + (Array.isArray(c.replies) ? c.replies.length : 0);
+          }
+        } catch {}
+        ownerManage = { access: gate.access, versionCount: versions.length, commentCount };
+      }
+      return html(injectOverlay(raw, slug, Number(vStr), identity, versions, isOwner, ownerManage));
     }
 
     // ---- doc export / fork ----


### PR DESCRIPTION
## What & why

Removes the browser **admin-token** requirement for owner management and makes the owner surfaces clean. julie's asks: "access control UI 不好看" + "不能有 admin token".

### The core move (why it's safe to drop the token)
Published docs are arbitrary same-origin HTML — a doc `<script>` could ride the owner's session cookie to silently delete docs (confused-deputy). That's the *only* reason browser writes needed an explicit token. Fix: a per-response **CSP** (`script-src 'nonce-<n>' 'strict-dynamic'`) blocks all author scripts/inline-handlers while the overlay's own nonced scripts run → no untrusted code in the browser → cookie/session auth is safe → the browser token is removed. CLI publish keeps its bearer token (CLIs have no origin/scripts).
0 of 36 published doc versions use `<script>`, so zero breakage.

### Changes
- **CSP** on every doc-serving response — doc-view **and** `/export`/`/fork` (same author-HTML surface; covering only `/d/` would be bypassable via `/export`). Nonce is fresh-random per response; author HTML never gets it. Fixed one inline `onerror` in `avatarHTML`.
- **`authorizeOwnerMutation`** (session **OR** upload token) on `DELETE /api/doc` + `PATCH /api/doc/access` — browser uses the session (no token), CLI keeps the token; ownership re-checked inside each route.
- **`/me` → clean catalog**: dropped the visibility/history/commenting/allowed dropdowns + admin-token input; response no longer carries access data (no `allowed_users`). Delete tucked behind a quiet `⋯` overflow (airy border-bottom list, pre-#104 aesthetic).
- **Doc page → "Share settings" panel**: visibility / history / commenting / allowed-users, no token field, PATCH via same-origin cookie. Styled confirm modals kept; modal width capped so it never goes edge-to-edge (narrow-mode margin fixed).

### Verification (self-run)
- **24 offline suites green** + **csp-xss browser proof 7/7**: author `<script>`/`onclick` never execute (`window.__XSS__` undefined) with a **real CSP violation logged**; overlay + commenting fully work under the policy; **negative-mutation checked** (remove the CSP header → the XSS tests go red); **nonce hardening** — two requests get different nonces, and an author script carrying a *real captured* nonce is still blocked (per-response-random, non-replayable).
- Preview screenshots (clean `/me`, Share panel, subtle `⋯` delete) shared with julie for taste sign-off.

Reviewer (@小cc) will independently reproduce the CSP block.