### PR TITLE
chore: auto-review every human PR (including updates)

### DIFF
--- a/greptile.json
+++ b/greptile.json
@@ -1,3 +1,11 @@
 {
-  "shouldUpdateDescription": false
+  "shouldUpdateDescription": false,
+  "triggerOnUpdates": true,
+  "triggerOnDrafts": true,
+  "statusCheck": true,
+  "statusCommentsEnabled": true,
+  "commentTypes": ["logic", "syntax"],
+  "strictness": 2,
+  "excludeAuthors": ["dependabot[bot]", "*-bot"],
+  "instructions": "Audit every PR as a security-and-correctness review. Highest-risk surfaces: server/overlay.js (runs in every reader's browser), worker/ (untrusted request bodies + auth), bin/ (Cloudflare tokens on the user's machine). Flag XSS, authz holes, token leakage, broken comment anchors, and regressions to local/publish/comment flows. Skip style nits and description rewrites. Post the summary as a review comment."
 }


### PR DESCRIPTION
## Why

`tornado-doc/tdoc` already has `greptile.json`, but Greptile stopped posting after the repo moved to the org — no GitHub App is installed on `tornado-doc` (last review was PR #83 on 2026-07-17). Collaborator PRs from @yayashuxue have been landing without an automatic audit comment.

This PR only updates the repo config so that **once Greptile Apps is reinstalled on `tornado-doc` → `tdoc`**, every human PR (open + each new push, including drafts) gets a review comment. Dependabot/bots are excluded.

## Config

- `triggerOnUpdates: true` — re-review on every push
- `triggerOnDrafts: true` — do not wait for ready-for-review
- `shouldUpdateDescription: false` — keep the existing “comment, don’t rewrite the PR body” behavior
- `commentTypes: logic + syntax` — audit, not style nits
- `excludeAuthors: dependabot / *-bot`

## Follow-up (needs a one-click org admin install)

Install Greptile on the org (only this repo):
https://github.com/apps/greptile-apps/installations/new/permissions?target_id=309246106

Then Greptile dashboard → enable `tornado-doc/tdoc`. After that I will retrigger review on the currently open PRs (#109, #99).