### PR TITLE
Speed up /me catalog (KV titles only)

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -278,14 +278,11 @@ function indexPage() {
     const meta = readJson(path.join(ROOT, slug, 'meta.json'), { title: slug, versions: [] });
     const latest = meta.versions?.[meta.versions.length - 1]?.n || 1;
     const versionCount = Array.isArray(meta.versions) && meta.versions.length ? meta.versions.length : 1;
-    const comments = readCommentFile(path.join(ROOT, slug, 'comments.json'));
-    const open = comments.filter(c => c.status === 'open').length;
     return `<tr>
       <td><a href="/d/${encodeURIComponent(slug)}/v/${latest}">${escHtml(meta.title || slug)}</a></td>
       <td>${escHtml(slug)}</td>
       <td>v${latest}</td>
-      <td>${open ? `<b>${open} open</b>` : '—'}</td>
-      <td><button class="del" data-slug="${escHtml(slug)}" data-versions="${versionCount}" data-comments="${comments.length}">Delete</button></td>
+      <td><button class="del" data-slug="${escHtml(slug)}" data-versions="${versionCount}">Delete</button></td>
     </tr>`;
   }).join('');
   return `<!doctype html><html><head><meta charset="utf-8"><title>tdoc</title>
@@ -320,7 +317,7 @@ function indexPage() {
 </style></head><body>
 <h1>tdoc</h1><p class="sub">Prompt-native documents.</p>
 ${slugs.length === 0 ? '<p class="empty">No docs yet. Try <code>/tdoc new &lt;prompt&gt;</code>.</p>' :
-  `<table><thead><tr><th>Title</th><th>Slug</th><th>Version</th><th>Comments</th><th></th></tr></thead><tbody>${rows}</tbody></table>`}
+  `<table><thead><tr><th>Title</th><th>Slug</th><th>Version</th><th></th></tr></thead><tbody>${rows}</tbody></table>`}
 <script>
 function showConfirm({ title, body, confirmLabel, danger }) {
   return new Promise((resolve) => {
@@ -348,10 +345,20 @@ document.addEventListener('click', async (e) => {
   const b = e.target.closest('.del');
   if (!b) return;
   const slug = b.dataset.slug;
+  let comments = 0;
+  try {
+    const r = await fetch('/api/comments?slug=' + encodeURIComponent(slug));
+    if (r.ok) {
+      const list = await r.json();
+      if (Array.isArray(list)) {
+        for (const c of list) comments += 1 + (Array.isArray(c.replies) ? c.replies.length : 0);
+      }
+    }
+  } catch {}
   // Irreversible: name exactly what disappears before acting.
   const proceed = await showConfirm({
     title: 'Delete "' + slug + '"?',
-    body: 'This permanently removes <b>' + b.dataset.versions + ' version(s)</b> and <b>' + b.dataset.comments +
+    body: 'This permanently removes <b>' + b.dataset.versions + ' version(s)</b> and <b>' + comments +
       ' comment(s)</b> — the local copy AND the published copy (if any). No undo.',
     confirmLabel: 'Delete',
     danger: true,

--- a/test/jul36-owner-manage.test.js
+++ b/test/jul36-owner-manage.test.js
@@ -287,6 +287,7 @@ async function main() {
     const indexPageSrc = serverJs.slice(idxStart, serverJs.indexOf('const server = http.createServer'));
     assert(!nativeConfirmCall.test(stripLineComments(indexPageSrc)), 'local index page must not call the native confirm()');
     assert(indexPageSrc.includes('showConfirm('), 'local index page must use the styled showConfirm() modal');
+    assert(!indexPageSrc.includes('readCommentFile('), 'local catalog must not read comments.json for every row');
   });
 
   t('overlay.js manage flow never uses window.confirm() either', () => {

--- a/test/me-management.test.js
+++ b/test/me-management.test.js
@@ -79,7 +79,17 @@ t('/me still uses the styled confirm modal, never native confirm()', () => {
   const stripped = index.split('\n').filter(l => !l.trim().startsWith('//') && !l.trim().startsWith('*')).join('\n');
   assert(!nativeConfirmCall.test(stripped), '/me must not call the native confirm()');
   assert(index.includes('showConfirm('), '/me must use the styled showConfirm() modal');
-  assert(index.includes('dataset.versions'), 'delete confirm copy should be built from data-versions/data-comments (honest N/M copy)');
+  assert(index.includes('dataset.versions'), 'delete confirm copy should include version count from meta');
+  assert(index.includes("'/api/comments?slug='"), 'comment count for delete confirm must load lazily, not at catalog render');
+});
+
+t('/me catalog does not fold comment logs or HEAD R2 per row', () => {
+  // The slow /me load: N serial readComments (full event-log fold) + N R2 HEADs
+  // just to paint titles. Catalog reads KV meta only; comment counts wait until
+  // Delete is clicked.
+  assert(!index.includes('readComments('), '/me must not call readComments while rendering the catalog');
+  assert(!index.includes('DOCS.head'), '/me must not HEAD R2 objects while rendering the catalog');
+  assert(index.includes('Promise.all'), '/me should fetch meta rows in parallel');
 });
 
 t('/me does not introduce a bespoke cookie-only admin-auth path', () => {

--- a/worker/worker.js
+++ b/worker/worker.js
@@ -1012,7 +1012,11 @@ function landingHtml() {
 // computed or emitted here (gate: response HTML must not contain
 // `allowed_users` — there is nothing here that could).
 async function indexHtml(env, session) {
-  // List all `meta:` keys.
+  // Catalog is title/slug/version from KV meta only. Do NOT HEAD R2 or fold
+  // comment logs here — that was N serial Durable-Object + R2 round trips
+  // per page load (the HTML bodies were never downloaded, but the comment
+  // event log for every slug was). Comment counts for the delete confirm
+  // load lazily on click via GET /api/comments.
   let list = [];
   let cursor;
   do {
@@ -1022,42 +1026,28 @@ async function indexHtml(env, session) {
     if (r.list_complete) break;
   } while (cursor);
 
-  const rows = [];
-  for (const k of list) {
+  const docs = await Promise.all(list.map(async (k) => {
     const slug = k.name.slice('meta:'.length);
     const metaRaw = await env.META.get(k.name);
     let meta = {};
     try { meta = JSON.parse(metaRaw || '{}'); } catch {}
     const latest = meta.versions?.[meta.versions.length - 1]?.n || 1;
-    // Only list docs whose latest version actually exists in R2 — otherwise
-    // the index advertises 404s. (We hit this when R2 writes silently failed
-    // while KV meta updates succeeded; defense in depth.)
-    const exists = await env.DOCS.head(`docs/${slug}/v${latest}/index.html`);
-    if (!exists) continue;
-    // Honest delete-confirm copy needs a real comment count (JUL-36) — same
-    // fold used by the doc-view route's ownerManage data.
-    let commentCount = 0;
-    try {
-      const list = await readComments(env, slug);
-      ensureMigrated(list);
-      for (const c of historyList(list)) {
-        commentCount += 1 + (Array.isArray(c.replies) ? c.replies.length : 0);
-      }
-    } catch {}
     const versionCount = Array.isArray(meta.versions) && meta.versions.length ? meta.versions.length : 1;
-    rows.push(`<div class="doc-row">
+    return { slug, title: meta.title || slug, latest, versionCount };
+  }));
+
+  const rows = docs.map(({ slug, title, latest, versionCount }) => `<div class="doc-row">
       <div class="doc-info">
-        <a class="doc-title" href="/d/${encodeURIComponent(slug)}/v/${latest}">${escapeHtml(meta.title || slug)}</a>
+        <a class="doc-title" href="/d/${encodeURIComponent(slug)}/v/${latest}">${escapeHtml(title)}</a>
         <div class="doc-meta">${escapeHtml(slug)} · v${latest}</div>
       </div>
       <div class="row-actions">
         <button class="row-menu-btn" aria-label="More actions" aria-haspopup="true" aria-expanded="false">⋯</button>
         <div class="row-menu" hidden>
-          <button class="row-delete" data-slug="${escapeHtml(slug)}" data-title="${escapeHtml(meta.title || slug)}" data-versions="${versionCount}" data-comments="${commentCount}">Delete…</button>
+          <button class="row-delete" data-slug="${escapeHtml(slug)}" data-title="${escapeHtml(title)}" data-versions="${versionCount}">Delete…</button>
         </div>
       </div>
     </div>`);
-  }
 
   return `<!doctype html><html><head><meta charset="utf-8"><title>tdoc</title>
 <style>
@@ -1166,13 +1156,26 @@ ${rows.length === 0 ? '<p class="empty">No published docs yet.</p>' :
   // page 302s away for anyone else), so the session cookie alone authorizes
   // DELETE /api/doc (authorizeOwnerMutation in worker.js). Plain same-origin
   // fetch sends the cookie automatically; no Authorization header needed.
+  async function countComments(slug) {
+    try {
+      const r = await fetch('/api/comments?slug=' + encodeURIComponent(slug) + '&version=all', { credentials: 'same-origin' });
+      if (!r.ok) return 0;
+      const list = await r.json();
+      if (!Array.isArray(list)) return 0;
+      let n = 0;
+      for (const c of list) n += 1 + (Array.isArray(c.replies) ? c.replies.length : 0);
+      return n;
+    } catch { return 0; }
+  }
   document.querySelectorAll('.row-delete').forEach((button) => {
     button.addEventListener('click', async () => {
       closeMenus(null);
       const slug = button.dataset.slug;
       const title = button.dataset.title || slug;
       const versions = button.dataset.versions || '1';
-      const comments = button.dataset.comments || '0';
+      say('Checking ' + slug + '…');
+      const comments = await countComments(slug);
+      say('');
       const proceed = await showConfirm({
         title: 'Delete "' + title + '"?',
         body: 'This permanently removes <b>' + versions + ' version(s)</b> and <b>' + comments +


### PR DESCRIPTION
## Summary
- `/me` was slow because it folded every comment event log and HEADed R2 per slug, sequentially, just to paint titles.
- Catalog now reads KV `meta:` keys in parallel and skips comments/R2. Delete still shows the honest “N versions, M comments” confirm — it fetches `/api/comments` on click.
- Same for local `/`: no more `comments.json` read per row.

## Test plan
- [ ] Offline: `node --test test/me-management.test.js test/jul36-owner-manage.test.js` (already green locally)
- [ ] After Worker deploy: load `/me` with many docs — should be title/slug/version only, fast
- [ ] Click Delete on a doc with comments — confirm copy still names version count and comment count
- [ ] Local `tdoc serve` index: no Comments column; delete confirm still accurate


Made with [Cursor](https://cursor.com)