### PR TITLE
feat: notification overlay badge and inbox panel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ file and `.claude-plugin/plugin.json`.
 
 ### Fixed
 
+- **Opening one notification no longer marks siblings in the same thread.**
+  Mark-read matches the exact comment/reply id, not the thread root.
 - **Clicking Reply no longer collapses the comment.** A hover-opened card
   used to vanish as soon as you hit Reply (the click never pinned it, then
   the pointer leaving the pin hid the card). Reply now pins the card and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,9 +27,10 @@ file and `.claude-plugin/plugin.json`.
   New top-level comments notify the doc owner; replies notify only the
   direct parent (Reddit); reactions notify the item author. Same-thread
   events collapse to one unread row. `#118`.
-- **Notification badge and panel.** The profile chip shows unread count;
-  Notifications in the menu opens the last 20 rows. Clicking a row (or the
-  comment in the doc) marks it read and opens that comment. `#118`.
+- **Notification badge and panel.** The profile chip shows a red unread
+  dot; Notifications in the existing profile menu opens the existing modal
+  with the last 20 rows (cluster rows, unread highlighted). Clicking a row
+  (or the comment in the doc) marks it read and opens that comment. `#118`.
 
 - **Nested replies.** You can reply to a reply (and to that reply), the way
   Reddit and Hacker News do. Each node in the thread has its own Reply.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,11 @@ file and `.claude-plugin/plugin.json`.
 
 ### Added
 
+- **In-app inbox (API).** Signed-in users have a per-host notification inbox.
+  New top-level comments notify the doc owner; replies notify only the
+  direct parent (Reddit); reactions notify the item author. Same-thread
+  events collapse to one unread row. `#118`.
+
 - **Nested replies.** You can reply to a reply (and to that reply), the way
   Reddit and Hacker News do. Each node in the thread has its own Reply.
 - **Host-runtime logos on agent replies.** Claude / Codex / Grok / Cursor /

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,9 @@ file and `.claude-plugin/plugin.json`.
   New top-level comments notify the doc owner; replies notify only the
   direct parent (Reddit); reactions notify the item author. Same-thread
   events collapse to one unread row. `#118`.
+- **Notification badge and panel.** The profile chip shows unread count;
+  Notifications in the menu opens the last 20 rows. Clicking a row (or the
+  comment in the doc) marks it read and opens that comment. `#118`.
 
 - **Nested replies.** You can reply to a reply (and to that reply), the way
   Reddit and Hacker News do. Each node in the thread has its own Reply.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,8 +29,9 @@ file and `.claude-plugin/plugin.json`.
   events collapse to one unread row. `#118`.
 - **Notification badge and panel.** The profile chip shows a red unread
   dot; Notifications in the existing profile menu opens the existing modal
-  with the last 20 rows (cluster rows, unread highlighted, each with a
-  timestamp). The page polls every 8s so a new comment/reply/reaction
+  with the last 20 rows (cluster rows, unread highlighted; action on
+  the first line, preview under it, relative time on the right). The
+  page polls every 8s so a new comment/reply/reaction
   updates the dot and the doc without a manual refresh. Clicking a row
   (or the comment in the doc) marks it read and opens that comment. `#118`.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,8 +29,8 @@ file and `.claude-plugin/plugin.json`.
   events collapse to one unread row. `#118`.
 - **Notification badge and panel.** The profile chip shows a red unread
   dot; Notifications in the existing profile menu opens the existing modal
-  with the last 20 rows (cluster rows, unread highlighted; action on
-  the first line, preview under it, relative time on the right). The
+  with the last 20 rows (cluster rows, unread highlighted; one-line
+  action plus relative time). The
   page polls every 8s so a new comment/reply/reaction
   updates the dot and the doc without a manual refresh. Clicking a row
   (or the comment in the doc) marks it read and opens that comment. `#118`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,9 @@ file and `.claude-plugin/plugin.json`.
   events collapse to one unread row. `#118`.
 - **Notification badge and panel.** The profile chip shows a red unread
   dot; Notifications in the existing profile menu opens the existing modal
-  with the last 20 rows (cluster rows, unread highlighted). Clicking a row
+  with the last 20 rows (cluster rows, unread highlighted, each with a
+  timestamp). The page polls every 8s so a new comment/reply/reaction
+  updates the dot and the doc without a manual refresh. Clicking a row
   (or the comment in the doc) marks it read and opens that comment. `#118`.
 
 - **Nested replies.** You can reply to a reply (and to that reply), the way

--- a/server/overlay.js
+++ b/server/overlay.js
@@ -927,10 +927,11 @@
   }
   function inboxRowLabel(row) {
     const n = row.count || 1;
+    const who = (row.actor && (row.actor.login || row.actor.name)) || 'someone';
     const title = row.title || row.slug || 'a doc';
-    if (row.kind === 'comment') return n > 1 ? `${n} new comments on ${title}` : `New comment on ${title}`;
-    if (row.kind === 'reply') return n > 1 ? `${n} new replies to your comment` : `New reply to your comment`;
-    if (row.kind === 'reaction') return n > 1 ? `${n} people reacted to your comment` : `Someone reacted to your comment`;
+    if (row.kind === 'comment') return n > 1 ? `${n} new comments on ${title}` : `${who} commented on ${title}`;
+    if (row.kind === 'reply') return n > 1 ? `${n} new replies to your comment` : `${who} replied to your comment`;
+    if (row.kind === 'reaction') return n > 1 ? `${n} people reacted to your comment` : `${who} reacted to your comment`;
     return 'Notification';
   }
   function paintInboxChrome() {
@@ -1004,9 +1005,8 @@
           listEl.innerHTML = '<p class="muted">No notifications yet.</p>';
         } else {
           const html = items.map(row => {
-            const who = (row.actor && row.actor.login) || '';
-            const extra = row.preview ? `${who ? who + ' · ' : ''}${String(row.preview).slice(0, 60)}` : who;
-            const snip = extra ? `${inboxRowLabel(row)} · ${extra}` : inboxRowLabel(row);
+            const preview = row.preview ? String(row.preview).slice(0, 60) : '';
+            const snip = preview ? `${inboxRowLabel(row)} · ${preview}` : inboxRowLabel(row);
             const cur = row.read ? '' : ' tdoc-cluster-current';
             return `<div class="tdoc-cluster-row${cur}" role="button" tabindex="0" data-id="${escapeHtml(row.id)}">
               ${avatarHTML(row.actor, 'tdoc-cluster-anon')}

--- a/server/overlay.js
+++ b/server/overlay.js
@@ -299,14 +299,8 @@
   .tdoc-chip .name { font-size: 13px; font-weight: 500; }
   .tdoc-chip.signin { padding: 7px 14px; background: var(--td-accent); color: #fff; font-weight: 600; }
   .tdoc-chip.signin:hover { background: var(--td-accent-hover); }
-  .tdoc-unread-badge { position: absolute; top: -4px; right: -2px; min-width: 16px; height: 16px; padding: 0 4px; border-radius: 999px; background: #e11d48; color: #fff; font: 700 10px/16px system-ui, sans-serif; text-align: center; }
-  .tdoc-inbox-count { color: #888; font-size: 12px; }
-  .tdoc-inbox-row { display: block; width: 100%; text-align: left; padding: 10px 8px; border: none; border-bottom: 1px solid #f0f1f4; background: #fff; cursor: pointer; font: 13px/1.4 system-ui, sans-serif; }
-  .tdoc-inbox-row.unread { background: #f4f7ff; }
-  .tdoc-inbox-row:hover { background: #f0f1f4; }
-  .tdoc-inbox-row .who { font-weight: 600; color: #111; }
-  .tdoc-inbox-row .meta { font-size: 12px; color: #888; margin-top: 2px; }
-  .tdoc-inbox-empty { padding: 20px 8px; color: #888; font-size: 13px; text-align: center; }
+  /* Only new inbox chrome: a red dot on the existing identity chip. */
+  .tdoc-unread-dot { position: absolute; top: 1px; right: 1px; width: 8px; height: 8px; border-radius: 50%; background: #e11d48; border: 1.5px solid #fff; pointer-events: none; }
 
   /* Comment cards */
   #tdoc-comment-layer { position: absolute; top: 0; left: 0; width: 100%; pointer-events: none; z-index: 999996; }
@@ -927,6 +921,10 @@
     if (!n) return '';
     return n > 99 ? '99+' : String(n);
   }
+  function inboxMenuLabel(n) {
+    const txt = inboxBadgeText(n);
+    return txt ? `Notifications (${txt})` : 'Notifications';
+  }
   function inboxRowLabel(row) {
     const n = row.count || 1;
     const title = row.title || row.slug || 'a doc';
@@ -934,6 +932,12 @@
     if (row.kind === 'reply') return n > 1 ? `${n} new replies to your comment` : `New reply to your comment`;
     if (row.kind === 'reaction') return n > 1 ? `${n} people reacted to your comment` : `Someone reacted to your comment`;
     return 'Notification';
+  }
+  function paintInboxChrome() {
+    const dot = document.getElementById('tdoc-inbox-dot');
+    if (dot) dot.hidden = !inboxUnreadN;
+    const menu = document.getElementById('tdoc-inbox-open');
+    if (menu) menu.textContent = inboxMenuLabel(inboxUnreadN);
   }
   async function refreshInboxBadge() {
     if (!identity) return;
@@ -943,14 +947,7 @@
       const body = await r.json();
       inboxUnreadN = Number(body.unread) || 0;
     } catch { return; }
-    const badge = document.getElementById('tdoc-inbox-badge');
-    const menuN = document.getElementById('tdoc-inbox-menu-count');
-    const txt = inboxBadgeText(inboxUnreadN);
-    if (badge) {
-      badge.textContent = txt;
-      badge.hidden = !txt;
-    }
-    if (menuN) menuN.textContent = txt ? `(${txt})` : '';
+    paintInboxChrome();
   }
   async function markInboxSeen(commentId) {
     if (!identity || !commentId) return;
@@ -987,10 +984,10 @@
     bg.className = 'tdoc-modal-bg';
     bg.id = 'tdoc-aux-modal';
     bg.innerHTML = `
-      <div class="tdoc-modal" style="max-width:420px">
+      <div class="tdoc-modal">
         <h3>Notifications</h3>
-        <div id="tdoc-inbox-list"><p class="tdoc-inbox-empty">Loading…</p></div>
-        <div class="actions"><button id="tdoc-inbox-more" hidden>Load more</button><button id="tdoc-inbox-close">Close</button></div>
+        <div id="tdoc-inbox-list"><p class="muted">Loading…</p></div>
+        <div class="actions"><button type="button" id="tdoc-inbox-more" hidden>Load more</button><button type="button" id="tdoc-inbox-close">Close</button></div>
       </div>`;
     document.body.appendChild(bg);
     document.getElementById('tdoc-inbox-close').onclick = closeAuxModal;
@@ -1000,21 +997,26 @@
       const more = document.getElementById('tdoc-inbox-more');
       try {
         const r = await fetch(`/api/notifications?offset=${offset}`, { credentials: 'same-origin' });
-        if (!r.ok) { listEl.innerHTML = '<p class="tdoc-inbox-empty">Could not load notifications.</p>'; return; }
+        if (!r.ok) { listEl.innerHTML = '<p class="muted">Could not load notifications.</p>'; return; }
         const body = await r.json();
         const items = Array.isArray(body.items) ? body.items : [];
         if (offset === 0 && !items.length) {
-          listEl.innerHTML = '<p class="tdoc-inbox-empty">No notifications yet.</p>';
+          listEl.innerHTML = '<p class="muted">No notifications yet.</p>';
         } else {
-          const html = items.map(row => `
-            <button type="button" class="tdoc-inbox-row${row.read ? '' : ' unread'}" data-id="${escapeHtml(row.id)}">
-              <div class="who">${escapeHtml(inboxRowLabel(row))}</div>
-              <div class="meta">${escapeHtml((row.actor && row.actor.login) || '')}${row.preview ? ' · ' + escapeHtml(String(row.preview).slice(0, 80)) : ''}</div>
-            </button>`).join('');
+          const html = items.map(row => {
+            const who = (row.actor && row.actor.login) || '';
+            const extra = row.preview ? `${who ? who + ' · ' : ''}${String(row.preview).slice(0, 60)}` : who;
+            const snip = extra ? `${inboxRowLabel(row)} · ${extra}` : inboxRowLabel(row);
+            const cur = row.read ? '' : ' tdoc-cluster-current';
+            return `<div class="tdoc-cluster-row${cur}" role="button" tabindex="0" data-id="${escapeHtml(row.id)}">
+              ${avatarHTML(row.actor, 'tdoc-cluster-anon')}
+              <span class="tdoc-cluster-snip">${escapeHtml(snip)}</span>
+            </div>`;
+          }).join('');
           if (offset === 0) listEl.innerHTML = html;
           else listEl.insertAdjacentHTML('beforeend', html);
           items.forEach(row => {
-            const btn = listEl.querySelector(`.tdoc-inbox-row[data-id="${CSS.escape(row.id)}"]`);
+            const btn = listEl.querySelector(`.tdoc-cluster-row[data-id="${CSS.escape(row.id)}"]`);
             if (!btn) return;
             btn.dataset.slug = row.slug || '';
             btn.dataset.version = String(row.version || 1);
@@ -1022,27 +1024,25 @@
             btn.dataset.thread = row.thread_id || '';
             if (btn._bound) return;
             btn._bound = true;
-            btn.onclick = () => {
+            const go = () => {
               openInboxTarget({
                 slug: btn.dataset.slug, version: btn.dataset.version,
                 comment_id: btn.dataset.comment, thread_id: btn.dataset.thread,
               });
               closeAuxModal();
             };
+            btn.onclick = go;
+            btn.onkeydown = (e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); go(); } };
           });
         }
         more.hidden = !body.has_more;
         more.onclick = () => { offset += items.length; paint(); };
         if (typeof body.unread === 'number') {
           inboxUnreadN = body.unread;
-          const badge = document.getElementById('tdoc-inbox-badge');
-          const menuN = document.getElementById('tdoc-inbox-menu-count');
-          const txt = inboxBadgeText(inboxUnreadN);
-          if (badge) { badge.textContent = txt; badge.hidden = !txt; }
-          if (menuN) menuN.textContent = txt ? `(${txt})` : '';
+          paintInboxChrome();
         }
       } catch {
-        listEl.innerHTML = '<p class="tdoc-inbox-empty">Could not load notifications.</p>';
+        listEl.innerHTML = '<p class="muted">Could not load notifications.</p>';
       }
     };
     paint();
@@ -1052,15 +1052,14 @@
     if (!slot) return;
     if (!isPublished && !identity) { slot.innerHTML = ''; return; }
     if (identity) {
-      const txt = inboxBadgeText(inboxUnreadN);
       slot.innerHTML =
         `<div class="tdoc-menu-wrap">
           <button class="tdoc-chip" id="tdoc-me" aria-haspopup="menu" aria-expanded="false">
             <img src="${escapeHtml(identity.avatar_url || '')}" alt=""><span class="name">${escapeHtml(identity.login)}</span>
-            <span class="tdoc-unread-badge" id="tdoc-inbox-badge" ${txt ? '' : 'hidden'}>${escapeHtml(txt)}</span>
+            <span class="tdoc-unread-dot" id="tdoc-inbox-dot" ${inboxUnreadN ? '' : 'hidden'}></span>
           </button>
           <div class="tdoc-menu" id="tdoc-me-menu" role="menu">
-            <button id="tdoc-inbox-open" role="menuitem">Notifications <span class="tdoc-inbox-count" id="tdoc-inbox-menu-count">${txt ? '(' + escapeHtml(txt) + ')' : ''}</span></button>
+            <button id="tdoc-inbox-open" role="menuitem">${escapeHtml(inboxMenuLabel(inboxUnreadN))}</button>
             ${isOwner ? `<button id="tdoc-my-docs" role="menuitem">My docs</button>` : ''}
             <button id="tdoc-signout" role="menuitem">Sign out</button>
           </div>

--- a/server/overlay.js
+++ b/server/overlay.js
@@ -5,7 +5,9 @@
 //
 // External contract preserved verbatim:
 //   - Endpoints: /api/comments, /api/reactions, /api/auth/device/start,
-//     /api/auth/device/poll, /api/auth/logout, /d/<slug>/v/<n>/export
+//     /api/auth/device/poll, /api/auth/logout, /api/notifications,
+//     /api/notifications/unread, /api/notifications/read,
+//     /d/<slug>/v/<n>/export
 //   - Globals: window.__tdocCopyDocMd(includeComments), window.__tdocCopyCommentMd(id, btn)
 //   - Body classes: tdoc-has-comments, tdoc-narrow
 //   - Keyboard: ⌘/Ctrl-Enter submits, Esc cancels.
@@ -291,12 +293,20 @@
   /* Overflow ⋯ button shows on narrow viewports. */
   .tdoc-bar .tdoc-secondary-toggle { display: none; padding: 6px 10px; }
   /* Identity chip — avatar + name (name hides on narrow). */
-  .tdoc-chip { display: inline-flex; align-items: center; gap: 8px; padding: 3px 12px 3px 3px; background: #f0f1f4; border-radius: 999px; cursor: pointer; color: #1a1a1a; font: inherit; border: none; }
+  .tdoc-chip { display: inline-flex; align-items: center; gap: 8px; padding: 3px 12px 3px 3px; background: #f0f1f4; border-radius: 999px; cursor: pointer; color: #1a1a1a; font: inherit; border: none; position: relative; }
   .tdoc-chip:hover { background: #e5e6ea; }
   .tdoc-chip img { width: 26px; height: 26px; border-radius: 50%; }
   .tdoc-chip .name { font-size: 13px; font-weight: 500; }
   .tdoc-chip.signin { padding: 7px 14px; background: var(--td-accent); color: #fff; font-weight: 600; }
   .tdoc-chip.signin:hover { background: var(--td-accent-hover); }
+  .tdoc-unread-badge { position: absolute; top: -4px; right: -2px; min-width: 16px; height: 16px; padding: 0 4px; border-radius: 999px; background: #e11d48; color: #fff; font: 700 10px/16px system-ui, sans-serif; text-align: center; }
+  .tdoc-inbox-count { color: #888; font-size: 12px; }
+  .tdoc-inbox-row { display: block; width: 100%; text-align: left; padding: 10px 8px; border: none; border-bottom: 1px solid #f0f1f4; background: #fff; cursor: pointer; font: 13px/1.4 system-ui, sans-serif; }
+  .tdoc-inbox-row.unread { background: #f4f7ff; }
+  .tdoc-inbox-row:hover { background: #f0f1f4; }
+  .tdoc-inbox-row .who { font-weight: 600; color: #111; }
+  .tdoc-inbox-row .meta { font-size: 12px; color: #888; margin-top: 2px; }
+  .tdoc-inbox-empty { padding: 20px 8px; color: #888; font-size: 13px; text-align: center; }
 
   /* Comment cards */
   #tdoc-comment-layer { position: absolute; top: 0; left: 0; width: 100%; pointer-events: none; z-index: 999996; }
@@ -912,18 +922,145 @@
   });
 
 
+  let inboxUnreadN = 0;
+  function inboxBadgeText(n) {
+    if (!n) return '';
+    return n > 99 ? '99+' : String(n);
+  }
+  function inboxRowLabel(row) {
+    const n = row.count || 1;
+    const title = row.title || row.slug || 'a doc';
+    if (row.kind === 'comment') return n > 1 ? `${n} new comments on ${title}` : `New comment on ${title}`;
+    if (row.kind === 'reply') return n > 1 ? `${n} new replies to your comment` : `New reply to your comment`;
+    if (row.kind === 'reaction') return n > 1 ? `${n} people reacted to your comment` : `Someone reacted to your comment`;
+    return 'Notification';
+  }
+  async function refreshInboxBadge() {
+    if (!identity) return;
+    try {
+      const r = await fetch('/api/notifications/unread', { credentials: 'same-origin' });
+      if (!r.ok) return;
+      const body = await r.json();
+      inboxUnreadN = Number(body.unread) || 0;
+    } catch { return; }
+    const badge = document.getElementById('tdoc-inbox-badge');
+    const menuN = document.getElementById('tdoc-inbox-menu-count');
+    const txt = inboxBadgeText(inboxUnreadN);
+    if (badge) {
+      badge.textContent = txt;
+      badge.hidden = !txt;
+    }
+    if (menuN) menuN.textContent = txt ? `(${txt})` : '';
+  }
+  async function markInboxSeen(commentId) {
+    if (!identity || !commentId) return;
+    try {
+      await fetch('/api/notifications/read', {
+        method: 'POST', credentials: 'same-origin',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ comment_id: commentId }),
+      });
+    } catch {}
+    refreshInboxBadge();
+  }
+  function openInboxTarget(row) {
+    const target = row.comment_id || row.thread_id;
+    const root = row.thread_id || row.comment_id;
+    const destSlug = row.slug || slug;
+    const destVer = row.version || version;
+    if (destSlug === slug && Number(destVer) === Number(version)) {
+      if (root) {
+        state.openReplyThreads.add(root);
+        pinOpenCard(root);
+        setActiveComment(root);
+      }
+      const el = document.querySelector(`[data-comment-id="${CSS.escape(target || '')}"]`);
+      if (el && el.scrollIntoView) el.scrollIntoView({ block: 'center' });
+      markInboxSeen(target);
+      return;
+    }
+    location.href = `/d/${encodeURIComponent(destSlug)}/v/${destVer}?comment=${encodeURIComponent(target || root || '')}`;
+  }
+  async function showInboxPanel() {
+    closeAuxModal();
+    const bg = document.createElement('div');
+    bg.className = 'tdoc-modal-bg';
+    bg.id = 'tdoc-aux-modal';
+    bg.innerHTML = `
+      <div class="tdoc-modal" style="max-width:420px">
+        <h3>Notifications</h3>
+        <div id="tdoc-inbox-list"><p class="tdoc-inbox-empty">Loading…</p></div>
+        <div class="actions"><button id="tdoc-inbox-more" hidden>Load more</button><button id="tdoc-inbox-close">Close</button></div>
+      </div>`;
+    document.body.appendChild(bg);
+    document.getElementById('tdoc-inbox-close').onclick = closeAuxModal;
+    let offset = 0;
+    const paint = async () => {
+      const listEl = document.getElementById('tdoc-inbox-list');
+      const more = document.getElementById('tdoc-inbox-more');
+      try {
+        const r = await fetch(`/api/notifications?offset=${offset}`, { credentials: 'same-origin' });
+        if (!r.ok) { listEl.innerHTML = '<p class="tdoc-inbox-empty">Could not load notifications.</p>'; return; }
+        const body = await r.json();
+        const items = Array.isArray(body.items) ? body.items : [];
+        if (offset === 0 && !items.length) {
+          listEl.innerHTML = '<p class="tdoc-inbox-empty">No notifications yet.</p>';
+        } else {
+          const html = items.map(row => `
+            <button type="button" class="tdoc-inbox-row${row.read ? '' : ' unread'}" data-id="${escapeHtml(row.id)}">
+              <div class="who">${escapeHtml(inboxRowLabel(row))}</div>
+              <div class="meta">${escapeHtml((row.actor && row.actor.login) || '')}${row.preview ? ' · ' + escapeHtml(String(row.preview).slice(0, 80)) : ''}</div>
+            </button>`).join('');
+          if (offset === 0) listEl.innerHTML = html;
+          else listEl.insertAdjacentHTML('beforeend', html);
+          items.forEach(row => {
+            const btn = listEl.querySelector(`.tdoc-inbox-row[data-id="${CSS.escape(row.id)}"]`);
+            if (!btn) return;
+            btn.dataset.slug = row.slug || '';
+            btn.dataset.version = String(row.version || 1);
+            btn.dataset.comment = row.comment_id || '';
+            btn.dataset.thread = row.thread_id || '';
+            if (btn._bound) return;
+            btn._bound = true;
+            btn.onclick = () => {
+              openInboxTarget({
+                slug: btn.dataset.slug, version: btn.dataset.version,
+                comment_id: btn.dataset.comment, thread_id: btn.dataset.thread,
+              });
+              closeAuxModal();
+            };
+          });
+        }
+        more.hidden = !body.has_more;
+        more.onclick = () => { offset += items.length; paint(); };
+        if (typeof body.unread === 'number') {
+          inboxUnreadN = body.unread;
+          const badge = document.getElementById('tdoc-inbox-badge');
+          const menuN = document.getElementById('tdoc-inbox-menu-count');
+          const txt = inboxBadgeText(inboxUnreadN);
+          if (badge) { badge.textContent = txt; badge.hidden = !txt; }
+          if (menuN) menuN.textContent = txt ? `(${txt})` : '';
+        }
+      } catch {
+        listEl.innerHTML = '<p class="tdoc-inbox-empty">Could not load notifications.</p>';
+      }
+    };
+    paint();
+  }
   function renderIdentity() {
     const slot = document.getElementById('tdoc-identity-slot');
-    if (!isPublished) { slot.innerHTML = ''; return; }
+    if (!slot) return;
+    if (!isPublished && !identity) { slot.innerHTML = ''; return; }
     if (identity) {
-      // Profile chip → dropdown. "My docs" is owner-only (the configured
-      // TDOC_OWNER); everyone signed in still gets Sign out.
+      const txt = inboxBadgeText(inboxUnreadN);
       slot.innerHTML =
         `<div class="tdoc-menu-wrap">
           <button class="tdoc-chip" id="tdoc-me" aria-haspopup="menu" aria-expanded="false">
             <img src="${escapeHtml(identity.avatar_url || '')}" alt=""><span class="name">${escapeHtml(identity.login)}</span>
+            <span class="tdoc-unread-badge" id="tdoc-inbox-badge" ${txt ? '' : 'hidden'}>${escapeHtml(txt)}</span>
           </button>
           <div class="tdoc-menu" id="tdoc-me-menu" role="menu">
+            <button id="tdoc-inbox-open" role="menuitem">Notifications <span class="tdoc-inbox-count" id="tdoc-inbox-menu-count">${txt ? '(' + escapeHtml(txt) + ')' : ''}</span></button>
             ${isOwner ? `<button id="tdoc-my-docs" role="menuitem">My docs</button>` : ''}
             <button id="tdoc-signout" role="menuitem">Sign out</button>
           </div>
@@ -935,6 +1072,7 @@
         const open = meMenu.classList.toggle('open');
         meBtn.setAttribute('aria-expanded', open ? 'true' : 'false');
       };
+      document.getElementById('tdoc-inbox-open').onclick = () => { meMenu.classList.remove('open'); showInboxPanel(); };
       if (isOwner) {
         document.getElementById('tdoc-my-docs').onclick = () => {
           window.open('/me', '_blank', 'noopener');
@@ -944,12 +1082,16 @@
         await fetch('/api/auth/logout', { method: 'POST' });
         identity = null;
         isOwner = false;
+        inboxUnreadN = 0;
         renderIdentity();
         refreshComments();
       };
-    } else {
+      refreshInboxBadge();
+    } else if (isPublished) {
       slot.innerHTML = `<button class="tdoc-chip signin" id="tdoc-signin">Sign in with GitHub</button>`;
       document.getElementById('tdoc-signin').onclick = startDeviceFlow;
+    } else {
+      slot.innerHTML = '';
     }
   }
   renderIdentity();
@@ -2092,6 +2234,7 @@
     // stable positions and just the visual cue swap. Cards keep whatever
     // layout repositionCards() established at refresh/resize time.
     scrollAnchorIntoView(id);
+    markInboxSeen(id);
   }
 
   function scrollAnchorIntoView(id) {
@@ -2256,6 +2399,17 @@
         // are all re-established together. The manual version desynced activeId
         // and lost the card's .active state (+ the "move anchor" affordance).
         setActiveComment(keepPinnedId);
+      }
+      const want = (() => { try { return new URLSearchParams(location.search).get('comment'); } catch { return null; } })();
+      if (want) {
+        const hit = state.activeComments.find(c => c.id === want)
+          || state.activeComments.find(c => (c.replies || []).some(r => r.id === want));
+        const root = hit ? hit.id : want;
+        state.openReplyThreads.add(root);
+        if (state.cardEls.has(root)) setActiveComment(root);
+        const el = document.querySelector(`[data-comment-id="${CSS.escape(want)}"]`);
+        if (el && el.scrollIntoView) el.scrollIntoView({ block: 'center' });
+        markInboxSeen(want);
       }
     });
   }

--- a/server/overlay.js
+++ b/server/overlay.js
@@ -972,7 +972,7 @@
       if (root) {
         state.openReplyThreads.add(root);
         pinOpenCard(root);
-        setActiveComment(root);
+        if (target === root) setActiveComment(root);
       }
       const el = document.querySelector(`[data-comment-id="${CSS.escape(target || '')}"]`);
       if (el && el.scrollIntoView) el.scrollIntoView({ block: 'center' });
@@ -2406,7 +2406,10 @@
           || state.activeComments.find(c => (c.replies || []).some(r => r.id === want));
         const root = hit ? hit.id : want;
         state.openReplyThreads.add(root);
-        if (state.cardEls.has(root)) setActiveComment(root);
+        // Opening a reply must not activate the root — that would mark the
+        // root's own notifications (e.g. a reaction) as read.
+        if (want === root && state.cardEls.has(root)) setActiveComment(root);
+        else if (state.cardEls.has(root)) pinOpenCard(root);
         const el = document.querySelector(`[data-comment-id="${CSS.escape(want)}"]`);
         if (el && el.scrollIntoView) el.scrollIntoView({ block: 'center' });
         markInboxSeen(want);

--- a/server/overlay.js
+++ b/server/overlay.js
@@ -301,6 +301,11 @@
   .tdoc-chip.signin:hover { background: var(--td-accent-hover); }
   /* Only new inbox chrome: a red dot on the existing identity chip. */
   .tdoc-unread-dot { position: absolute; top: 1px; right: 1px; width: 8px; height: 8px; border-radius: 50%; background: #e11d48; border: 1.5px solid #fff; pointer-events: none; }
+  /* Inbox rows reuse cluster-row: action + preview stacked, relative time on the right. */
+  #tdoc-inbox-list .tdoc-cluster-row { align-items: flex-start; }
+  #tdoc-inbox-list .tdoc-cluster-snip { white-space: normal; display: block; }
+  #tdoc-inbox-list .tdoc-cluster-snip .muted { display: block; margin-top: 2px; }
+  #tdoc-inbox-list .tdoc-cluster-row > .muted { flex-shrink: 0; white-space: nowrap; font-size: 12px; }
 
   /* Comment cards */
   #tdoc-comment-layer { position: absolute; top: 0; left: 0; width: 100%; pointer-events: none; z-index: 999996; }
@@ -928,11 +933,16 @@
     const txt = inboxBadgeText(n);
     return txt ? `Notifications (${txt})` : 'Notifications';
   }
-  function formatCommentTime(iso) {
+  function formatRelativeTime(iso) {
     if (!iso) return '';
     const d = new Date(iso);
     if (Number.isNaN(d.getTime())) return '';
-    return d.toLocaleString([], { month: 'short', day: 'numeric', hour: 'numeric', minute: '2-digit' });
+    const sec = Math.max(0, Math.round((Date.now() - d.getTime()) / 1000));
+    if (sec < 60) return 'now';
+    if (sec < 3600) return Math.floor(sec / 60) + 'm';
+    if (sec < 86400) return Math.floor(sec / 3600) + 'h';
+    if (sec < 86400 * 7) return Math.floor(sec / 86400) + 'd';
+    return d.toLocaleString([], { month: 'short', day: 'numeric' });
   }
   function inboxRowLabel(row) {
     const n = row.count || 1;
@@ -960,13 +970,14 @@
       return;
     }
     const html = items.map(row => {
-      const preview = row.preview ? String(row.preview).slice(0, 60) : '';
-      const when = formatCommentTime(row.at);
-      const snip = [inboxRowLabel(row), preview, when].filter(Boolean).join(' · ');
+      const preview = row.preview ? String(row.preview).slice(0, 80) : (row.emoji || '');
+      const when = formatRelativeTime(row.at);
+      const whenFull = row.at ? new Date(row.at).toLocaleString() : '';
       const cur = row.read ? '' : ' tdoc-cluster-current';
       return `<div class="tdoc-cluster-row${cur}" role="button" tabindex="0" data-id="${escapeHtml(row.id)}">
         ${avatarHTML(row.actor, 'tdoc-cluster-anon')}
-        <span class="tdoc-cluster-snip">${escapeHtml(snip)}</span>
+        <span class="tdoc-cluster-snip">${escapeHtml(inboxRowLabel(row))}${preview ? `<span class="muted">${escapeHtml(preview)}</span>` : ''}</span>
+        ${when ? `<span class="muted" title="${escapeHtml(whenFull)}">${escapeHtml(when)}</span>` : ''}
       </div>`;
     }).join('');
     if (!append) listEl.innerHTML = html;

--- a/server/overlay.js
+++ b/server/overlay.js
@@ -302,9 +302,6 @@
   /* Only new inbox chrome: a red dot on the existing identity chip. */
   .tdoc-unread-dot { position: absolute; top: 1px; right: 1px; width: 8px; height: 8px; border-radius: 50%; background: #e11d48; border: 1.5px solid #fff; pointer-events: none; }
   /* Inbox rows reuse cluster-row: action + preview stacked, relative time on the right. */
-  #tdoc-inbox-list .tdoc-cluster-row { align-items: flex-start; }
-  #tdoc-inbox-list .tdoc-cluster-snip { white-space: normal; display: block; }
-  #tdoc-inbox-list .tdoc-cluster-snip .muted { display: block; margin-top: 2px; }
   #tdoc-inbox-list .tdoc-cluster-row > .muted { flex-shrink: 0; white-space: nowrap; font-size: 12px; }
 
   /* Comment cards */
@@ -970,13 +967,12 @@
       return;
     }
     const html = items.map(row => {
-      const preview = row.preview ? String(row.preview).slice(0, 80) : (row.emoji || '');
       const when = formatRelativeTime(row.at);
       const whenFull = row.at ? new Date(row.at).toLocaleString() : '';
       const cur = row.read ? '' : ' tdoc-cluster-current';
       return `<div class="tdoc-cluster-row${cur}" role="button" tabindex="0" data-id="${escapeHtml(row.id)}">
         ${avatarHTML(row.actor, 'tdoc-cluster-anon')}
-        <span class="tdoc-cluster-snip">${escapeHtml(inboxRowLabel(row))}${preview ? `<span class="muted">${escapeHtml(preview)}</span>` : ''}</span>
+        <span class="tdoc-cluster-snip">${escapeHtml(inboxRowLabel(row))}</span>
         ${when ? `<span class="muted" title="${escapeHtml(whenFull)}">${escapeHtml(when)}</span>` : ''}
       </div>`;
     }).join('');

--- a/server/overlay.js
+++ b/server/overlay.js
@@ -917,6 +917,9 @@
 
 
   let inboxUnreadN = 0;
+  let inboxSig = '';
+  let inboxPollTimer = null;
+  const INBOX_POLL_MS = 8000;
   function inboxBadgeText(n) {
     if (!n) return '';
     return n > 99 ? '99+' : String(n);
@@ -924,6 +927,12 @@
   function inboxMenuLabel(n) {
     const txt = inboxBadgeText(n);
     return txt ? `Notifications (${txt})` : 'Notifications';
+  }
+  function formatCommentTime(iso) {
+    if (!iso) return '';
+    const d = new Date(iso);
+    if (Number.isNaN(d.getTime())) return '';
+    return d.toLocaleString([], { month: 'short', day: 'numeric', hour: 'numeric', minute: '2-digit' });
   }
   function inboxRowLabel(row) {
     const n = row.count || 1;
@@ -934,11 +943,53 @@
     if (row.kind === 'reaction') return n > 1 ? `${n} people reacted to your comment` : `${who} reacted to your comment`;
     return 'Notification';
   }
+  function inboxFingerprint(body) {
+    const items = (body && Array.isArray(body.items)) ? body.items : [];
+    return `${body && body.unread}|${items.map(i => [i.id, i.count, i.at, i.read].join(':')).join(',')}`;
+  }
   function paintInboxChrome() {
     const dot = document.getElementById('tdoc-inbox-dot');
     if (dot) dot.hidden = !inboxUnreadN;
     const menu = document.getElementById('tdoc-inbox-open');
     if (menu) menu.textContent = inboxMenuLabel(inboxUnreadN);
+  }
+  function writeInboxRows(listEl, items, append) {
+    if (!listEl) return;
+    if (!items.length && !append) {
+      listEl.innerHTML = '<p class="muted">No notifications yet.</p>';
+      return;
+    }
+    const html = items.map(row => {
+      const preview = row.preview ? String(row.preview).slice(0, 60) : '';
+      const when = formatCommentTime(row.at);
+      const snip = [inboxRowLabel(row), preview, when].filter(Boolean).join(' · ');
+      const cur = row.read ? '' : ' tdoc-cluster-current';
+      return `<div class="tdoc-cluster-row${cur}" role="button" tabindex="0" data-id="${escapeHtml(row.id)}">
+        ${avatarHTML(row.actor, 'tdoc-cluster-anon')}
+        <span class="tdoc-cluster-snip">${escapeHtml(snip)}</span>
+      </div>`;
+    }).join('');
+    if (!append) listEl.innerHTML = html;
+    else listEl.insertAdjacentHTML('beforeend', html);
+    items.forEach(row => {
+      const btn = listEl.querySelector(`.tdoc-cluster-row[data-id="${CSS.escape(row.id)}"]`);
+      if (!btn) return;
+      btn.dataset.slug = row.slug || '';
+      btn.dataset.version = String(row.version || 1);
+      btn.dataset.comment = row.comment_id || '';
+      btn.dataset.thread = row.thread_id || '';
+      if (btn._bound) return;
+      btn._bound = true;
+      const go = () => {
+        openInboxTarget({
+          slug: btn.dataset.slug, version: btn.dataset.version,
+          comment_id: btn.dataset.comment, thread_id: btn.dataset.thread,
+        });
+        closeAuxModal();
+      };
+      btn.onclick = go;
+      btn.onkeydown = (e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); go(); } };
+    });
   }
   async function refreshInboxBadge() {
     if (!identity) return;
@@ -950,6 +1001,36 @@
     } catch { return; }
     paintInboxChrome();
   }
+  async function tickInbox() {
+    if (!identity || document.hidden) return;
+    if (document.querySelector('.tdoc-reply-form.open, .tdoc-popup, textarea:focus')) return;
+    try {
+      const r = await fetch('/api/notifications?offset=0', { credentials: 'same-origin' });
+      if (!r.ok) return;
+      const body = await r.json();
+      const sig = inboxFingerprint(body);
+      const first = !inboxSig;
+      const changed = sig !== inboxSig;
+      if (typeof body.unread === 'number') inboxUnreadN = body.unread;
+      inboxSig = sig;
+      paintInboxChrome();
+      if (!first && changed) refreshComments({ deepLink: false });
+      const listEl = document.getElementById('tdoc-inbox-list');
+      if (listEl && changed) {
+        const more = document.getElementById('tdoc-inbox-more');
+        if (more) { more.dataset.offset = '0'; more.hidden = !body.has_more; }
+        writeInboxRows(listEl, Array.isArray(body.items) ? body.items : [], false);
+      }
+    } catch {}
+  }
+  function startInboxPoll() {
+    if (inboxPollTimer) return;
+    inboxPollTimer = setInterval(tickInbox, INBOX_POLL_MS);
+  }
+  function stopInboxPoll() {
+    if (inboxPollTimer) { clearInterval(inboxPollTimer); inboxPollTimer = null; }
+  }
+  document.addEventListener('visibilitychange', () => { if (!document.hidden) tickInbox(); });
   async function markInboxSeen(commentId) {
     if (!identity || !commentId) return;
     try {
@@ -992,53 +1073,22 @@
       </div>`;
     document.body.appendChild(bg);
     document.getElementById('tdoc-inbox-close').onclick = closeAuxModal;
-    let offset = 0;
+    const more = document.getElementById('tdoc-inbox-more');
+    more.dataset.offset = '0';
     const paint = async () => {
       const listEl = document.getElementById('tdoc-inbox-list');
-      const more = document.getElementById('tdoc-inbox-more');
+      const offset = Number(more.dataset.offset) || 0;
       try {
         const r = await fetch(`/api/notifications?offset=${offset}`, { credentials: 'same-origin' });
         if (!r.ok) { listEl.innerHTML = '<p class="muted">Could not load notifications.</p>'; return; }
         const body = await r.json();
         const items = Array.isArray(body.items) ? body.items : [];
-        if (offset === 0 && !items.length) {
-          listEl.innerHTML = '<p class="muted">No notifications yet.</p>';
-        } else {
-          const html = items.map(row => {
-            const preview = row.preview ? String(row.preview).slice(0, 60) : '';
-            const snip = preview ? `${inboxRowLabel(row)} · ${preview}` : inboxRowLabel(row);
-            const cur = row.read ? '' : ' tdoc-cluster-current';
-            return `<div class="tdoc-cluster-row${cur}" role="button" tabindex="0" data-id="${escapeHtml(row.id)}">
-              ${avatarHTML(row.actor, 'tdoc-cluster-anon')}
-              <span class="tdoc-cluster-snip">${escapeHtml(snip)}</span>
-            </div>`;
-          }).join('');
-          if (offset === 0) listEl.innerHTML = html;
-          else listEl.insertAdjacentHTML('beforeend', html);
-          items.forEach(row => {
-            const btn = listEl.querySelector(`.tdoc-cluster-row[data-id="${CSS.escape(row.id)}"]`);
-            if (!btn) return;
-            btn.dataset.slug = row.slug || '';
-            btn.dataset.version = String(row.version || 1);
-            btn.dataset.comment = row.comment_id || '';
-            btn.dataset.thread = row.thread_id || '';
-            if (btn._bound) return;
-            btn._bound = true;
-            const go = () => {
-              openInboxTarget({
-                slug: btn.dataset.slug, version: btn.dataset.version,
-                comment_id: btn.dataset.comment, thread_id: btn.dataset.thread,
-              });
-              closeAuxModal();
-            };
-            btn.onclick = go;
-            btn.onkeydown = (e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); go(); } };
-          });
-        }
+        writeInboxRows(listEl, items, offset > 0);
         more.hidden = !body.has_more;
-        more.onclick = () => { offset += items.length; paint(); };
+        more.onclick = () => { more.dataset.offset = String(offset + items.length); paint(); };
         if (typeof body.unread === 'number') {
           inboxUnreadN = body.unread;
+          inboxSig = inboxFingerprint(body);
           paintInboxChrome();
         }
       } catch {
@@ -1082,10 +1132,13 @@
         identity = null;
         isOwner = false;
         inboxUnreadN = 0;
+        inboxSig = '';
+        stopInboxPoll();
         renderIdentity();
         refreshComments();
       };
-      refreshInboxBadge();
+      tickInbox();
+      startInboxPoll();
     } else if (isPublished) {
       slot.innerHTML = `<button class="tdoc-chip signin" id="tdoc-signin">Sign in with GitHub</button>`;
       document.getElementById('tdoc-signin').onclick = startDeviceFlow;
@@ -2295,7 +2348,8 @@
   }
 
   // ========== refreshComments ==========
-  async function refreshComments() {
+  async function refreshComments(opts) {
+    const allowDeepLink = !opts || opts.deepLink !== false;
     // Preserve which comment had its floating card pinned open (wide mode) so a
     // reply/react/re-anchor that triggers a refresh doesn't make the card the
     // user is interacting with vanish. resetAnchors() nulls state.pinnedId, so
@@ -2399,7 +2453,9 @@
         // and lost the card's .active state (+ the "move anchor" affordance).
         setActiveComment(keepPinnedId);
       }
-      const want = (() => { try { return new URLSearchParams(location.search).get('comment'); } catch { return null; } })();
+      const want = allowDeepLink
+        ? (() => { try { return new URLSearchParams(location.search).get('comment'); } catch { return null; } })()
+        : null;
       if (want) {
         const hit = state.activeComments.find(c => c.id === want)
           || state.activeComments.find(c => (c.replies || []).some(r => r.id === want));

--- a/server/server.js
+++ b/server/server.js
@@ -13,6 +13,9 @@ const { spawn } = require('child_process');
 const PORT = process.env.TDOC_PORT ? Number(process.env.TDOC_PORT) : 7878;
 const ROOT = process.env.TDOC_DIR || path.join(os.homedir(), 'tdocs');
 const OVERLAY_PATH = path.join(__dirname, 'overlay.js');
+// Optional two-person local inbox (browser e2e). Off unless TDOC_E2E_USER is set.
+const E2E_USER = String(process.env.TDOC_E2E_USER || '').trim();
+const E2E_OWNER = String(process.env.TDOC_E2E_OWNER || E2E_USER || '').trim();
 
 fs.mkdirSync(ROOT, { recursive: true });
 
@@ -27,6 +30,53 @@ function readJson(p, fallback) {
   try { return JSON.parse(fs.readFileSync(p, 'utf8')); } catch { return fallback; }
 }
 function writeJson(p, obj) { fs.writeFileSync(p, JSON.stringify(obj, null, 2)); }
+function e2eIdentity() {
+  if (!E2E_USER) return null;
+  return { login: E2E_USER, name: E2E_USER, avatar_url: '' };
+}
+function inboxFile(login) {
+  return path.join(ROOT, `.inbox-${String(login).toLowerCase()}.json`);
+}
+function localRecordAuthor(comments, id) {
+  for (const c of comments) {
+    if (c.id === id) return c.author || null;
+    for (const r of (c.replies || [])) if (r.id === id) return r.author || null;
+  }
+  return null;
+}
+function localDeliver(recipient, ev) {
+  const who = recipient && String(recipient).trim().toLowerCase();
+  const actor = ev.actor && ev.actor.login && String(ev.actor.login).trim().toLowerCase();
+  if (!who || who === actor) return;
+  const file = inboxFile(who);
+  const inbox = readJson(file, { items: [] });
+  const items = Array.isArray(inbox.items) ? inbox.items : [];
+  const gk = ev.kind === 'comment' ? `comment:${ev.slug}`
+    : ev.kind === 'reply' ? `reply:${ev.target_id}`
+    : ev.kind === 'reaction' ? `reaction:${ev.target_id}`
+    : `other:${ev.slug}`;
+  const existing = items.find(i => i && !i.read && i.group_key === gk);
+  if (existing) {
+    existing.count = (Number(existing.count) || 1) + 1;
+    existing.at = ev.at;
+    existing.actor = ev.actor;
+    existing.comment_id = ev.comment_id || existing.comment_id;
+    existing.thread_id = ev.thread_id || existing.thread_id;
+    existing.preview = ev.preview != null ? ev.preview : existing.preview;
+    existing.version = ev.version || existing.version;
+    const rest = items.filter(i => i !== existing);
+    writeJson(file, { items: [existing, ...rest].slice(0, 200) });
+    return;
+  }
+  items.unshift({
+    id: ev.id || `n_${Date.now()}`,
+    kind: ev.kind, group_key: gk, slug: ev.slug, version: ev.version || 1,
+    comment_id: ev.comment_id, thread_id: ev.thread_id || ev.comment_id,
+    actor: ev.actor || null, preview: ev.preview || '', title: ev.title || ev.slug,
+    at: ev.at || new Date().toISOString(), read: false, count: 1, emoji: ev.emoji || null,
+  });
+  writeJson(file, { items: items.slice(0, 200) });
+}
 // Cap request bodies so a hostile/buggy client can't OOM the local server.
 const MAX_BODY_BYTES = 1 << 20; // 1 MiB — comments are small
 function readBody(req) {
@@ -202,8 +252,12 @@ function injectOverlay(html, slug, version, nonce) {
   // the CSP set by cspHeader() above — author content in `html` has no nonce
   // and is inert.
   const nonceAttr = nonce ? ` nonce="${nonce}"` : '';
+  const ident = e2eIdentity();
   const cfg = `<script${nonceAttr}>window.__TDOC__ = ${safeJsonForScript({
-    slug, version, identity: null, authConfigured: false, mode: 'local', versions,
+    slug, version,
+    identity: ident,
+    isOwner: !!(ident && E2E_OWNER && ident.login.toLowerCase() === E2E_OWNER.toLowerCase()),
+    authConfigured: !!ident, mode: 'local', versions,
   })};</script>`;
   const inject = `${cfg}\n<script${nonceAttr}>${overlay}</script>`;
   if (html.includes('</body>')) return html.replace('</body>', `${inject}\n</body>`);
@@ -383,6 +437,43 @@ const server = http.createServer(async (req, res) => {
   // wild: a daemon from another product bound 7878).
   if (p === '/api/ping') return json(res, 200, { ok: true, service: 'tdoc' });
 
+  if (p === '/api/notifications' && req.method === 'GET') {
+    const ident = e2eIdentity();
+    if (!ident) return json(res, 401, { error: 'sign_in_required' });
+    const inbox = readJson(inboxFile(ident.login), { items: [] });
+    const items = Array.isArray(inbox.items) ? inbox.items.filter(Boolean) : [];
+    const unread = items.filter(i => !i.read);
+    const ordered = unread.concat(items.filter(i => i.read));
+    const offset = Math.max(0, Number(url.searchParams.get('offset') || 0));
+    return json(res, 200, {
+      items: ordered.slice(offset, offset + 20),
+      unread: unread.length,
+      has_more: offset + 20 < ordered.length,
+    });
+  }
+  if (p === '/api/notifications/unread' && req.method === 'GET') {
+    const ident = e2eIdentity();
+    if (!ident) return json(res, 401, { error: 'sign_in_required' });
+    const inbox = readJson(inboxFile(ident.login), { items: [] });
+    const items = Array.isArray(inbox.items) ? inbox.items : [];
+    return json(res, 200, { unread: items.filter(i => i && !i.read).length });
+  }
+  if (p === '/api/notifications/read' && req.method === 'POST') {
+    const ident = e2eIdentity();
+    if (!ident) return json(res, 401, { error: 'sign_in_required' });
+    const body = await readBody(req);
+    const file = inboxFile(ident.login);
+    const inbox = readJson(file, { items: [] });
+    const items = (Array.isArray(inbox.items) ? inbox.items : []).map((i) => {
+      if (!i) return i;
+      if (Array.isArray(body.ids) && body.ids.includes(i.id)) return { ...i, read: true };
+      if (body.comment_id && (i.comment_id === body.comment_id || i.thread_id === body.comment_id)) return { ...i, read: true };
+      return i;
+    });
+    writeJson(file, { items });
+    return json(res, 200, { ok: true, unread: items.filter(i => i && !i.read).length });
+  }
+
   if (p === '/tdoc_logo.png') {
     const logoPath = path.join(__dirname, '..', 'assets', 'tdoc_logo.png');
     if (!fs.existsSync(logoPath)) return send(res, 404, 'not found');
@@ -439,9 +530,18 @@ const server = http.createServer(async (req, res) => {
       // `r.version` check falls back to the parent's created_in, so replies were
       // never hidden on older versions (diverging from the worker).
       // parent_id is the immediate parent (top-level or another reply).
-      const reply = { id: `r_${Date.now()}`, parent_id, text, version: Number(version) || 1, author: null, created, reactions: {} };
+      const reply = { id: `r_${Date.now()}`, parent_id, text, version: Number(version) || 1, author: e2eIdentity(), created, reactions: {} };
       thread.replies.push(reply);
       writeJson(file, comments);
+      if (E2E_USER) {
+        const parentA = localRecordAuthor(comments, parent_id);
+        let title = slug;
+        try { title = JSON.parse(fs.readFileSync(path.join(ROOT, slug, 'meta.json'), 'utf8')).title || slug; } catch {}
+        localDeliver(parentA && parentA.login, {
+          kind: 'reply', slug, version: Number(version) || 1, comment_id: reply.id,
+          thread_id: thread.id, target_id: parent_id, actor: reply.author, preview: text, title, at: created,
+        });
+      }
       return json(res, 200, reply);
     }
     const entry = {
@@ -449,7 +549,7 @@ const server = http.createServer(async (req, res) => {
       version: version || 1,
       anchor: anchor || null,
       text,
-      author: null,
+      author: e2eIdentity(),
       status: 'open',
       created,
       replies: [],
@@ -457,6 +557,14 @@ const server = http.createServer(async (req, res) => {
     };
     comments.push(entry);
     writeJson(file, comments);
+    if (E2E_USER && E2E_OWNER) {
+      let title = slug;
+      try { title = JSON.parse(fs.readFileSync(path.join(ROOT, slug, 'meta.json'), 'utf8')).title || slug; } catch {}
+      localDeliver(E2E_OWNER, {
+        kind: 'comment', slug, version: Number(version) || 1, comment_id: entry.id,
+        thread_id: entry.id, actor: entry.author, preview: text, title, at: created,
+      });
+    }
     return json(res, 200, entry);
   }
 
@@ -584,13 +692,23 @@ const server = http.createServer(async (req, res) => {
     if (!target) return json(res, 404, { error: 'not_found' });
     if (!target.reactions) target.reactions = {};
     const users = target.reactions[emoji] || [];
-    const me = 'anon';
+    const me = E2E_USER || 'anon';
     const idx = users.indexOf(me);
+    const added = idx < 0;
     if (idx >= 0) users.splice(idx, 1);
     else users.push(me);
     if (users.length === 0) delete target.reactions[emoji];
     else target.reactions[emoji] = users;
     writeJson(file, all);
+    if (added && E2E_USER && target.author && target.author.login) {
+      let title = slug;
+      try { title = JSON.parse(fs.readFileSync(path.join(ROOT, slug, 'meta.json'), 'utf8')).title || slug; } catch {}
+      const thread = all.find(c => c.id === comment_id || (c.replies || []).some(r => r.id === comment_id));
+      localDeliver(target.author.login, {
+        kind: 'reaction', slug, version: 1, comment_id, thread_id: thread && thread.id,
+        target_id: comment_id, actor: e2eIdentity(), title, emoji,
+      });
+    }
     return json(res, 200, { ok: true, reactions: target.reactions });
   }
 

--- a/server/server.js
+++ b/server/server.js
@@ -467,7 +467,7 @@ const server = http.createServer(async (req, res) => {
     const items = (Array.isArray(inbox.items) ? inbox.items : []).map((i) => {
       if (!i) return i;
       if (Array.isArray(body.ids) && body.ids.includes(i.id)) return { ...i, read: true };
-      if (body.comment_id && (i.comment_id === body.comment_id || i.thread_id === body.comment_id)) return { ...i, read: true };
+      if (body.comment_id && i.comment_id === body.comment_id) return { ...i, read: true };
       return i;
     });
     writeJson(file, { items });

--- a/server/server.js
+++ b/server/server.js
@@ -704,8 +704,9 @@ const server = http.createServer(async (req, res) => {
       let title = slug;
       try { title = JSON.parse(fs.readFileSync(path.join(ROOT, slug, 'meta.json'), 'utf8')).title || slug; } catch {}
       const thread = all.find(c => c.id === comment_id || (c.replies || []).some(r => r.id === comment_id));
+      const V = Number(body.version) || Number(target.version) || Number(thread && thread.version) || 1;
       localDeliver(target.author.login, {
-        kind: 'reaction', slug, version: 1, comment_id, thread_id: thread && thread.id,
+        kind: 'reaction', slug, version: V, comment_id, thread_id: thread && thread.id,
         target_id: comment_id, actor: e2eIdentity(), title, emoji,
       });
     }

--- a/test/notifications.test.js
+++ b/test/notifications.test.js
@@ -135,6 +135,24 @@ t('mark read by comment_id; page unread first', () => {
   assert(page.unread === 1 && page.has_more === false);
 });
 
+t('mark read by comment_id does not clear other rows on the same thread', () => {
+  let inbox = box.emptyInbox();
+  inbox = box.applyInboxEvent(inbox, {
+    id: 'n-react', kind: 'reaction', slug: 'd', comment_id: 'c1',
+    thread_id: 'c1', target_id: 'c1', actor: { login: 'bob' }, at: 't1',
+  });
+  inbox = box.applyInboxEvent(inbox, {
+    id: 'n-reply', kind: 'reply', slug: 'd', comment_id: 'r1',
+    thread_id: 'c1', target_id: 'c1', actor: { login: 'bob' }, at: 't2',
+  });
+  inbox = box.markInboxRead(inbox, { comment_id: 'r1' });
+  const reply = inbox.items.find(i => i.id === 'n-reply');
+  const react = inbox.items.find(i => i.id === 'n-react');
+  assert(reply && reply.read === true, 'reply row should be read');
+  assert(react && !react.read, 'reaction on the thread root must stay unread');
+  assert(box.inboxUnread(inbox) === 1);
+});
+
 t('recordAuthor finds nested reply authors', () => {
   const list = [{
     id: 'c1', author: { login: 'alice' },

--- a/test/notifications.test.js
+++ b/test/notifications.test.js
@@ -1,0 +1,151 @@
+// Inbox helpers — Reddit-style recipients + aggregation + read/paging.
+// Extracted from worker.js (same pattern as comment-ops.test.js).
+
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+
+let pass = 0, fail = 0;
+function ok(n) { console.log(`  ✓ ${n}`); pass++; }
+function bad(n, e) { console.log(`  ✗ ${n}\n    ${e}`); fail++; }
+function t(n, fn) { try { fn(); ok(n); } catch (e) { bad(n, e.message); } }
+function assert(c, m) { if (!c) throw new Error(m || 'assertion failed'); }
+
+const src = fs.readFileSync(path.join(__dirname, '..', 'worker', 'worker.js'), 'utf8');
+function fn(name) {
+  const s = src.indexOf(`function ${name}(`);
+  if (s === -1) throw new Error(`fn ${name} not found`);
+  let i = src.indexOf('(', s), d = 0;
+  for (; i < src.length; i++) {
+    if (src[i] === '(') d++;
+    else if (src[i] === ')') { d--; if (d === 0) { i++; break; } }
+  }
+  while (i < src.length && src[i] !== '{') i++;
+  d = 0;
+  for (; i < src.length; i++) {
+    if (src[i] === '{') d++;
+    else if (src[i] === '}') { d--; if (d === 0) { i++; break; } }
+  }
+  return src.slice(s, i);
+}
+
+function consts() {
+  const a = src.indexOf('const INBOX_MAX');
+  const b = src.indexOf('function emptyInbox');
+  if (a === -1 || b === -1) throw new Error('INBOX_MAX block not found');
+  return src.slice(a, b);
+}
+
+const box = {};
+vm.createContext(box);
+vm.runInContext([
+  consts(),
+  fn('sessionLogin'),
+  fn('normalizeGithubLogin'),
+  fn('emptyInbox'),
+  fn('inboxUnread'),
+  fn('applyInboxEvent'),
+  fn('markInboxRead'),
+  fn('pageInbox'),
+  fn('inboxRecipients'),
+  fn('recordAuthor'),
+  fn('findCommentThread'),
+].join('\n\n'), box);
+
+console.log('notifications inbox');
+
+t('inboxKey lowercases github login', () => {
+  assert(box.inboxKey('SerenaKeyitan') === 'inbox:serenakeyitan');
+  assert(box.inboxKey('') === null);
+});
+
+t('Reddit: reply notifies only the direct parent, not owner or ancestors', () => {
+  const r = box.inboxRecipients({
+    kind: 'reply',
+    actorLogin: 'carol',
+    ownerLogin: 'owner',
+    parentAuthorLogin: 'bob',
+    targetAuthorLogin: 'alice',
+  });
+  assert(r.length === 1 && r[0] === 'bob', `got ${JSON.stringify(r)}`);
+});
+
+t('top-level comment notifies owner, not the commenter', () => {
+  const r = box.inboxRecipients({
+    kind: 'comment', actorLogin: 'bob', ownerLogin: 'alice',
+  });
+  assert(r.length === 1 && r[0] === 'alice');
+  const self = box.inboxRecipients({
+    kind: 'comment', actorLogin: 'alice', ownerLogin: 'alice',
+  });
+  assert(self.length === 0, 'owner commenting on own doc should not notify self');
+});
+
+t('reaction notifies the item author only', () => {
+  const r = box.inboxRecipients({
+    kind: 'reaction', actorLogin: 'bob', targetAuthorLogin: 'alice', ownerLogin: 'owner',
+  });
+  assert(r.length === 1 && r[0] === 'alice');
+});
+
+t('same-thread events aggregate into one unread row', () => {
+  let inbox = box.emptyInbox();
+  inbox = box.applyInboxEvent(inbox, {
+    id: 'n1', kind: 'comment', slug: 'conway-life', comment_id: 'c1',
+    actor: { login: 'bob' }, preview: 'first', title: 'Conway', at: 't1',
+  });
+  inbox = box.applyInboxEvent(inbox, {
+    id: 'n2', kind: 'comment', slug: 'conway-life', comment_id: 'c2',
+    actor: { login: 'carol' }, preview: 'second', title: 'Conway', at: 't2',
+  });
+  assert(inbox.items.length === 1, `expected 1 row, got ${inbox.items.length}`);
+  assert(inbox.items[0].count === 2, `count ${inbox.items[0].count}`);
+  assert(inbox.items[0].comment_id === 'c2', 'should jump to latest');
+  assert(box.inboxUnread(inbox) === 1);
+});
+
+t('replies to different parents do not merge', () => {
+  let inbox = box.emptyInbox();
+  inbox = box.applyInboxEvent(inbox, {
+    id: 'n1', kind: 'reply', slug: 'd', comment_id: 'r1', target_id: 'c1',
+    actor: { login: 'a' }, at: 't1',
+  });
+  inbox = box.applyInboxEvent(inbox, {
+    id: 'n2', kind: 'reply', slug: 'd', comment_id: 'r2', target_id: 'c2',
+    actor: { login: 'b' }, at: 't2',
+  });
+  assert(inbox.items.length === 2);
+});
+
+t('mark read by comment_id; page unread first', () => {
+  let inbox = box.emptyInbox();
+  inbox = box.applyInboxEvent(inbox, {
+    id: 'n1', kind: 'reply', slug: 'd', comment_id: 'r1', target_id: 'c1',
+    actor: { login: 'a' }, at: 't1',
+  });
+  inbox = box.markInboxRead(inbox, { comment_id: 'r1' });
+  assert(inbox.items[0].read === true);
+  assert(box.inboxUnread(inbox) === 0);
+  inbox = box.applyInboxEvent(inbox, {
+    id: 'n3', kind: 'comment', slug: 'other', comment_id: 'c9',
+    actor: { login: 'z' }, at: 't3',
+  });
+  const page = box.pageInbox(inbox, { offset: 0, limit: 20 });
+  assert(page.items[0].id === 'n3', 'unread should sort first');
+  assert(page.unread === 1 && page.has_more === false);
+});
+
+t('recordAuthor finds nested reply authors', () => {
+  const list = [{
+    id: 'c1', author: { login: 'alice' },
+    events: [
+      { kind: 'reply_added', reply: { id: 'r1', author: { login: 'bob' } } },
+    ],
+  }];
+  assert(box.recordAuthor(list, 'c1').login === 'alice');
+  assert(box.recordAuthor(list, 'r1').login === 'bob');
+  assert(box.recordAuthor(list, 'missing') === null);
+});
+
+console.log(`\n${pass} passed, ${fail} failed`);
+process.exit(fail ? 1 : 0);

--- a/test/run.js
+++ b/test/run.js
@@ -35,6 +35,7 @@ const OFFLINE = [
   'pins-layout.test.js',      // v0.8.0 pins clustering/spread/overflow-fold core
   'comment-upload.test.js',   // local→worker comment merge (non-destructive)
   'comment-ops.test.js',      // #34 DO-serialized mutation ops
+  'notifications.test.js',    // inbox aggregation + Reddit recipients
   'p3-hardening.test.js',     // #33 safeParseList + escapeHtml
   'csp-headers.test.js',      // CSP header + nonce plumbing (hermetic, no browser)
   'stampaids.test.js',        // aid-stamp regex hardening (equivalence + edges)

--- a/worker/worker.js
+++ b/worker/worker.js
@@ -1822,7 +1822,7 @@ function markInboxRead(inbox, { ids, comment_id } = {}) {
   const items = (inbox && Array.isArray(inbox.items) ? inbox.items : []).map((i) => {
     if (!i) return i;
     if (Array.isArray(ids) && ids.includes(i.id)) return { ...i, read: true };
-    if (comment_id && (i.comment_id === comment_id || i.thread_id === comment_id)) return { ...i, read: true };
+    if (comment_id && i.comment_id === comment_id) return { ...i, read: true };
     return i;
   });
   return { items };

--- a/worker/worker.js
+++ b/worker/worker.js
@@ -1748,6 +1748,116 @@ function findCommentThread(list, id) {
   return null;
 }
 
+function recordAuthor(list, id) {
+  if (!id || !Array.isArray(list)) return null;
+  const top = list.find(c => c && c.id === id);
+  if (top) return top.author || null;
+  for (const c of list) {
+    const ev = (c.events || []).find(e => e.kind === 'reply_added' && e.reply && e.reply.id === id);
+    if (ev) return ev.reply.author || null;
+  }
+  return null;
+}
+
+// Per-user inbox (same host, cross-doc). KV key inbox:<github-login>.
+// Rows are aggregated by group_key so a viral doc does not write 40 lines.
+const INBOX_MAX = 200;
+const INBOX_PAGE = 20;
+
+function inboxKey(login) {
+  const n = normalizeGithubLogin(login);
+  return n ? `inbox:${n}` : null;
+}
+
+function inboxGroupKey(kind, slug, targetId) {
+  if (kind === 'comment') return `comment:${slug}`;
+  if (kind === 'reply') return `reply:${targetId}`;
+  if (kind === 'reaction') return `reaction:${targetId}`;
+  return `other:${slug || 'x'}`;
+}
+
+function emptyInbox() { return { items: [] }; }
+
+function inboxUnread(inbox) {
+  const items = inbox && Array.isArray(inbox.items) ? inbox.items : [];
+  return items.filter(i => i && !i.read).length;
+}
+
+function applyInboxEvent(inbox, ev) {
+  const items = inbox && Array.isArray(inbox.items) ? inbox.items.slice() : [];
+  const gk = inboxGroupKey(ev.kind, ev.slug, ev.target_id || ev.comment_id);
+  const existing = items.find(i => i && !i.read && i.group_key === gk);
+  if (existing) {
+    existing.count = (Number(existing.count) || 1) + 1;
+    existing.at = ev.at;
+    existing.actor = ev.actor || existing.actor;
+    existing.comment_id = ev.comment_id || existing.comment_id;
+    existing.thread_id = ev.thread_id || existing.thread_id;
+    existing.preview = ev.preview != null ? ev.preview : existing.preview;
+    if (ev.emoji) existing.emoji = ev.emoji;
+    existing.version = ev.version || existing.version;
+    const rest = items.filter(i => i !== existing);
+    return { items: [existing, ...rest].slice(0, INBOX_MAX) };
+  }
+  const row = {
+    id: ev.id,
+    kind: ev.kind,
+    group_key: gk,
+    slug: ev.slug,
+    version: ev.version || 1,
+    comment_id: ev.comment_id,
+    thread_id: ev.thread_id || ev.comment_id,
+    actor: ev.actor || null,
+    preview: ev.preview || '',
+    title: ev.title || ev.slug,
+    at: ev.at,
+    read: false,
+    count: 1,
+    emoji: ev.emoji || null,
+  };
+  return { items: [row, ...items].slice(0, INBOX_MAX) };
+}
+
+function markInboxRead(inbox, { ids, comment_id } = {}) {
+  const items = (inbox && Array.isArray(inbox.items) ? inbox.items : []).map((i) => {
+    if (!i) return i;
+    if (Array.isArray(ids) && ids.includes(i.id)) return { ...i, read: true };
+    if (comment_id && (i.comment_id === comment_id || i.thread_id === comment_id)) return { ...i, read: true };
+    return i;
+  });
+  return { items };
+}
+
+function pageInbox(inbox, { offset = 0, limit = INBOX_PAGE } = {}) {
+  const items = inbox && Array.isArray(inbox.items) ? inbox.items.filter(Boolean) : [];
+  const unread = items.filter(i => !i.read);
+  const read = items.filter(i => i.read);
+  const ordered = unread.concat(read);
+  const off = Math.max(0, Number(offset) || 0);
+  const lim = Math.min(50, Math.max(1, Number(limit) || INBOX_PAGE));
+  return {
+    items: ordered.slice(off, off + lim),
+    unread: unread.length,
+    has_more: off + lim < ordered.length,
+  };
+}
+
+// Reddit-style: top-level comment → doc owner; reply → direct parent author
+// only; reaction → author of that item. Never notify the actor.
+function inboxRecipients({ kind, actorLogin, ownerLogin, parentAuthorLogin, targetAuthorLogin }) {
+  const actor = sessionLogin({ login: actorLogin });
+  const out = [];
+  const push = (login) => {
+    const n = sessionLogin({ login });
+    if (!n || n === actor) return;
+    if (!out.includes(n)) out.push(n);
+  };
+  if (kind === 'comment') push(ownerLogin);
+  else if (kind === 'reply') push(parentAuthorLogin);
+  else if (kind === 'reaction') push(targetAuthorLogin);
+  return out;
+}
+
 // Apply one comment operation to the in-memory list. PURE w.r.t. I/O: it only
 // mutates `list` and returns { status, body }. Both the DO path and the KV
 // fallback call this, so mutation logic is defined exactly once.
@@ -1804,7 +1914,7 @@ function applyCommentOp(list, op) {
       appendEvent(host, evt);
       const fresh = snapshotAt(host, op.version);
       const reactions = isReply ? (fresh.replies.find(r => r.id === replyId)?.reactions || {}) : fresh.reactions;
-      return { status: 200, body: { ok: true, reactions } };
+      return { status: 200, body: { ok: true, reactions, added: !had } };
     }
     case 'delete': {
       // Authorization enforced upstream (worker resolves target + canMutate
@@ -1890,6 +2000,40 @@ function safeParseList(raw) {
 // requests, which silently loses updates (the bug a KV-based DO had). With
 // state.storage the get→mutate→put is gated and concurrent same-slug writes
 // serialize correctly.
+async function loadInbox(env, login) {
+  const key = inboxKey(login);
+  if (!key) return { key: null, inbox: emptyInbox() };
+  try {
+    const raw = await env.META.get(key);
+    if (!raw) return { key, inbox: emptyInbox() };
+    const parsed = JSON.parse(raw);
+    return { key, inbox: parsed && Array.isArray(parsed.items) ? parsed : emptyInbox() };
+  } catch {
+    return { key, inbox: emptyInbox() };
+  }
+}
+
+async function deliverInbox(env, recipientLogin, ev) {
+  const recips = inboxRecipients({
+    kind: ev.kind,
+    actorLogin: ev.actor && ev.actor.login,
+    ownerLogin: ev.kind === 'comment' ? recipientLogin : '',
+    parentAuthorLogin: ev.kind === 'reply' ? recipientLogin : '',
+    targetAuthorLogin: ev.kind === 'reaction' ? recipientLogin : '',
+  });
+  const at = ev.at || new Date().toISOString();
+  for (const who of recips) {
+    const { key, inbox } = await loadInbox(env, who);
+    if (!key) continue;
+    const next = applyInboxEvent(inbox, {
+      ...ev,
+      id: ev.id || `n_${Date.now()}_${rand(4)}`,
+      at,
+    });
+    await env.META.put(key, JSON.stringify(next));
+  }
+}
+
 async function mutateComments(env, slug, op) {
   if (env.COMMENTS) {
     const stub = env.COMMENTS.get(env.COMMENTS.idFromName(slug));
@@ -2300,6 +2444,49 @@ export default {
       return json({ ok: true }, { headers: { 'Set-Cookie': 'tdoc_sid=; Path=/; Max-Age=0' } });
     }
 
+    // ---- inbox (signed-in, this host, all docs) ----
+    if (p === '/api/notifications' && method === 'GET') {
+      const s = await getSession(env, req);
+      if (!s) return json({ error: 'sign_in_required' }, { status: 401 });
+      const key = inboxKey(s.login);
+      if (!key) return json({ error: 'sign_in_required' }, { status: 401 });
+      let inbox = emptyInbox();
+      try {
+        const raw = await env.META.get(key);
+        if (raw) inbox = JSON.parse(raw);
+      } catch { inbox = emptyInbox(); }
+      const offset = Number(url.searchParams.get('offset') || 0);
+      return json(pageInbox(inbox, { offset }));
+    }
+    if (p === '/api/notifications/unread' && method === 'GET') {
+      const s = await getSession(env, req);
+      if (!s) return json({ error: 'sign_in_required' }, { status: 401 });
+      const key = inboxKey(s.login);
+      if (!key) return json({ unread: 0 });
+      let inbox = emptyInbox();
+      try {
+        const raw = await env.META.get(key);
+        if (raw) inbox = JSON.parse(raw);
+      } catch { inbox = emptyInbox(); }
+      return json({ unread: inboxUnread(inbox) });
+    }
+    if (p === '/api/notifications/read' && method === 'POST') {
+      const s = await getSession(env, req);
+      if (!s) return json({ error: 'sign_in_required' }, { status: 401 });
+      const key = inboxKey(s.login);
+      if (!key) return json({ error: 'sign_in_required' }, { status: 401 });
+      let body = {};
+      try { body = await req.json(); } catch {}
+      let inbox = emptyInbox();
+      try {
+        const raw = await env.META.get(key);
+        if (raw) inbox = JSON.parse(raw);
+      } catch { inbox = emptyInbox(); }
+      inbox = markInboxRead(inbox, { ids: body.ids, comment_id: body.comment_id });
+      await env.META.put(key, JSON.stringify(inbox));
+      return json({ ok: true, unread: inboxUnread(inbox) });
+    }
+
     // ---- comments ----
     if (p === '/api/comments' && method === 'GET') {
       const slug = url.searchParams.get('slug');
@@ -2343,6 +2530,24 @@ export default {
         ? { kind: 'reply', slug, parent_id, reply_id: `r_${Date.now()}_${rand(4)}`, author, text: commentText, version: V, at: created }
         : { kind: 'create', slug, id: `c_${Date.now()}_${rand(4)}`, author, text: commentText, anchor: anchor || null, version: V, at: created };
       const res = await mutateComments(env, slug, op);
+      if (res.status === 200) {
+        const meta = await loadDocMeta(env, slug);
+        const title = (meta && meta.title) || slug;
+        if (!parent_id) {
+          await deliverInbox(env, env.TDOC_OWNER, {
+            kind: 'comment', slug, version: V, comment_id: op.id, thread_id: op.id,
+            actor: author, preview: commentText, title, at: created,
+          });
+        } else {
+          const list = await readComments(env, slug);
+          const parentA = recordAuthor(list, parent_id);
+          await deliverInbox(env, parentA && parentA.login, {
+            kind: 'reply', slug, version: V, comment_id: op.reply_id,
+            thread_id: res.body && res.body.thread_id, target_id: parent_id,
+            actor: author, preview: commentText, title, at: created,
+          });
+        }
+      }
       return json(res.body, { status: res.status });
     }
 
@@ -2451,6 +2656,18 @@ export default {
       const res = await mutateComments(env, slug, {
         kind: 'react', slug, comment_id, emoji, by: s.login, version: V,
       });
+      if (res.status === 200 && res.body && res.body.added) {
+        const list = await readComments(env, slug);
+        const target = recordAuthor(list, comment_id);
+        const thread = findCommentThread(list, comment_id);
+        const meta = await loadDocMeta(env, slug);
+        await deliverInbox(env, target && target.login, {
+          kind: 'reaction', slug, version: V, comment_id,
+          thread_id: thread && thread.root && thread.root.id, target_id: comment_id,
+          actor: { login: s.login, avatar_url: s.avatar_url, name: s.name },
+          title: (meta && meta.title) || slug, emoji,
+        });
+      }
       return json(res.body, { status: res.status });
     }
 


### PR DESCRIPTION
Part of #118. Depends on #119.

**What:** Overlay unread badge, Notifications menu item, 20-row panel, `?comment=` deep link, mark-read when the comment opens. Local `TDOC_E2E_USER` / `TDOC_E2E_OWNER` for real-browser e2e.

**Do not merge** until the user-journey browser pass is done. Leave both PRs open.