### PR TITLE
Add a dark mode switch to the top bar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,7 +34,7 @@ file and `.claude-plugin/plugin.json`.
   page polls every 8s so a new comment/reply/reaction
   updates the dot and the doc without a manual refresh. Clicking a row
   (or the comment in the doc) marks it read and opens that comment. `#118`.
-- **Dark mode switch in the top bar.** One icon in the menu bar flips light/dark. After you switch, the choice is stored in `localStorage` on that host and restored on later visits. Default stays light until you switch. `#120`.
+- **Dark mode switch in the top bar.** One icon in the menu bar flips light/dark via a page invert (so author colors, artifacts, and replies flip together). After you switch, the choice is stored in `localStorage` on that host and restored on later visits. Default stays light until you switch. `#120`.
 - **Nested replies.** You can reply to a reply (and to that reply), the way
   Reddit and Hacker News do. Each node in the thread has its own Reply.
 - **Host-runtime logos on agent replies.** Claude / Codex / Grok / Cursor /

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,7 +34,7 @@ file and `.claude-plugin/plugin.json`.
   page polls every 8s so a new comment/reply/reaction
   updates the dot and the doc without a manual refresh. Clicking a row
   (or the comment in the doc) marks it read and opens that comment. `#118`.
-
+- **Dark mode switch in the top bar.** One icon in the menu bar flips light/dark. After you switch, the choice is stored in `localStorage` on that host and restored on later visits. Default stays light until you switch. `#120`.
 - **Nested replies.** You can reply to a reply (and to that reply), the way
   Reddit and Hacker News do. Each node in the thread has its own Reply.
 - **Host-runtime logos on agent replies.** Claude / Codex / Grok / Cursor /

--- a/server/overlay.js
+++ b/server/overlay.js
@@ -674,73 +674,21 @@
   html[data-tdoc-theme="dark"] .tdoc-theme-icon-moon { display: none; }
   html[data-tdoc-theme="dark"] .tdoc-theme-icon-sun { display: block; }
 
-  /* Dark mode. Tokens flip the default doc template; chrome surfaces that
-     still use literals get explicit overrides. Author CSS on widgets is
-     left alone except body bg/color so agent-authored body { background:#fff }
-     does not pin the page to white. */
+  /* Dark mode: invert the painted page (Dark Reader / "filter" style).
+     One transform hits author CSS, artifacts, replies, and chrome — no
+     per-color list. hue-rotate keeps blues roughly blue. Photos / video /
+     canvas / iframes are inverted back so they don't look like negatives. */
   html[data-tdoc-theme="dark"] {
     color-scheme: dark;
-    --td-ground: #111111;
-    --td-ink: #e8e8e6;
-    --td-heading: #f4f4f2;
-    --td-muted: #a3a29c;
-    --td-line: #2c2c2a;
-    --td-surface: #1c1c1b;
-    --td-surface-2: #181817;
-    --td-pre-ink: #e8e8e6;
-    --td-th-bg: #242422;
-    --td-th-ink: #f4f4f2;
-    --td-check: #e8e8e6;
-    --td-selection: #2a3f6e;
-    --td-quote: #3a3a36;
-    --td-accent-tint: #1a2744;
-    --td-accent-wash: rgba(22,82,240,0.18);
-    --td-danger-tint: #3a1816;
+    background: #fff;
+    filter: invert(1) hue-rotate(180deg);
   }
-  html[data-tdoc-theme="dark"] body { background: var(--td-ground); color: var(--td-ink); }
-  html[data-tdoc-theme="dark"] .tdoc-bar { background: #161616; color: #e8e8e6; border-bottom-color: #2c2c2a; box-shadow: none; }
-  html[data-tdoc-theme="dark"] .tdoc-bar .crumb { color: #b0b0aa; }
-  html[data-tdoc-theme="dark"] .tdoc-bar .crumb-sep { color: #555; }
-  html[data-tdoc-theme="dark"] .tdoc-bar .doc-title { color: #f4f4f2; }
-  html[data-tdoc-theme="dark"] .tdoc-bar button { color: #b0b0aa; }
-  html[data-tdoc-theme="dark"] .tdoc-bar button:hover { background: #2a2a28; color: #f4f4f2; }
-  html[data-tdoc-theme="dark"] .tdoc-version-toggle { background: #2a2a28 !important; color: #f4f4f2 !important; }
-  html[data-tdoc-theme="dark"] .tdoc-version-toggle:hover { background: #333331 !important; }
-  html[data-tdoc-theme="dark"] .tdoc-menu,
-  html[data-tdoc-theme="dark"] .tdoc-secondary-menu,
-  html[data-tdoc-theme="dark"] .tdoc-version-menu { background: #1c1c1b; border-color: #2c2c2a; box-shadow: 0 8px 24px rgba(0,0,0,0.4); }
-  html[data-tdoc-theme="dark"] .tdoc-menu button,
-  html[data-tdoc-theme="dark"] .tdoc-secondary-menu button,
-  html[data-tdoc-theme="dark"] .tdoc-version-menu button { color: #e8e8e6; }
-  html[data-tdoc-theme="dark"] .tdoc-menu button:hover,
-  html[data-tdoc-theme="dark"] .tdoc-secondary-menu button:hover,
-  html[data-tdoc-theme="dark"] .tdoc-version-menu button:hover { background: #2a2a28; }
-  html[data-tdoc-theme="dark"] .tdoc-chip { background: #2a2a28; color: #f4f4f2; }
-  html[data-tdoc-theme="dark"] .tdoc-chip:hover { background: #333331; }
-  html[data-tdoc-theme="dark"] .tdoc-margin-comment,
-  html[data-tdoc-theme="dark"] .tdoc-cluster-pop,
-  html[data-tdoc-theme="dark"] .tdoc-emoji-picker { background: #1c1c1b; border-color: #2c2c2a; color: #e8e8e6; }
-  html[data-tdoc-theme="dark"] .tdoc-margin-comment .author .login,
-  html[data-tdoc-theme="dark"] .tdoc-margin-comment .text,
-  html[data-tdoc-theme="dark"] .tdoc-reply .author .login { color: #f4f4f2; }
-  html[data-tdoc-theme="dark"] .tdoc-agent-author img { background: #1c1c1b; }
-  html[data-tdoc-theme="dark"] .tdoc-pin { background: #1c1c1b; border-color: #3a3a38; }
-  html[data-tdoc-theme="dark"] .tdoc-modal { background: #1c1c1b; color: #e8e8e6; }
-  html[data-tdoc-theme="dark"] .tdoc-modal p,
-  html[data-tdoc-theme="dark"] .tdoc-modal .step { color: #b0b0aa; }
-  html[data-tdoc-theme="dark"] .tdoc-modal button { background: #1c1c1b; color: #e8e8e6; border-color: #3a3a38; }
-  html[data-tdoc-theme="dark"] .tdoc-modal button.primary { background: var(--td-accent); border-color: var(--td-accent); color: #fff; }
-  html[data-tdoc-theme="dark"] .tdoc-modal input[type="password"],
-  html[data-tdoc-theme="dark"] .tdoc-modal input[type="text"] { background: #161616; color: #e8e8e6; border-color: #3a3a38; }
-  html[data-tdoc-theme="dark"] .tdoc-modal code { background: #2a2a28; }
-  html[data-tdoc-theme="dark"] .tdoc-modal .divider { border-top-color: #2c2c2a; }
-  html[data-tdoc-theme="dark"] .tdoc-seg button { background: #1c1c1b; color: #b0b0aa; }
-  html[data-tdoc-theme="dark"] body.tdoc-narrow #tdoc-comment-layer { background: #161616; border-top-color: #2c2c2a; }
-  html[data-tdoc-theme="dark"] .tdoc-footer { color: #888; border-top-color: #2c2c2a; }
-  html[data-tdoc-theme="dark"] .tdoc-footer a { color: #a3a29c; }
-  html[data-tdoc-theme="dark"] .tdoc-comment-pill { background: rgba(28,28,27,0.96) !important; border-color: #3a3a38 !important; }
-  html[data-tdoc-theme="dark"] .tdoc-oldver-strip { background: #2a2414; color: #e6d7a8; border-bottom-color: #3d3520; }
-  html[data-tdoc-theme="dark"] .tdoc-oldver-strip a { color: #f0d78c; }
+  html[data-tdoc-theme="dark"] img,
+  html[data-tdoc-theme="dark"] video,
+  html[data-tdoc-theme="dark"] canvas,
+  html[data-tdoc-theme="dark"] iframe {
+    filter: invert(1) hue-rotate(180deg);
+  }
 
   /* Footer */
   .tdoc-footer { margin-top: 80px; padding: 20px 16px 28px; font: 12px system-ui, sans-serif; color: #888; text-align: center; border-top: 1px solid #eee; box-sizing: border-box; max-width: 100%; }

--- a/server/overlay.js
+++ b/server/overlay.js
@@ -59,6 +59,34 @@
     document.head.appendChild(m);
   }
 
+  // Theme: light until the user flips the bar switch. After a switch, persist
+  // on this origin via localStorage and restore on later visits. No OS follow.
+  const THEME_KEY = 'tdoc-theme';
+  function readStoredTheme() {
+    try {
+      return localStorage.getItem(THEME_KEY) === 'dark' ? 'dark' : 'light';
+    } catch (e) {
+      return 'light';
+    }
+  }
+  function currentTheme() {
+    return document.documentElement.getAttribute('data-tdoc-theme') === 'dark' ? 'dark' : 'light';
+  }
+  function persistTheme(theme) {
+    try { localStorage.setItem(THEME_KEY, theme); } catch (e) { /* private mode */ }
+  }
+  function paintTheme(theme) {
+    document.documentElement.setAttribute('data-tdoc-theme', theme);
+    document.documentElement.style.colorScheme = theme;
+    const btn = document.getElementById('tdoc-theme-btn');
+    if (!btn) return;
+    const dark = theme === 'dark';
+    btn.setAttribute('aria-pressed', dark ? 'true' : 'false');
+    btn.setAttribute('aria-label', dark ? 'Switch to light mode' : 'Switch to dark mode');
+    btn.title = dark ? 'Light mode' : 'Dark mode';
+  }
+  paintTheme(readStoredTheme());
+
   // ========== UI selector registry ==========
   // One source of truth for "is this part of the tdoc overlay UI?".
   //   UI_CONTAINERS — top-level overlay regions: bar, popups, comment column,
@@ -640,6 +668,80 @@
     .tdoc-emoji-picker button.tdoc-emoji-text { grid-column: span 5; }
   }
 
+  /* Theme toggle — icon-only, lives in the bar's right cluster. */
+  .tdoc-theme-btn { flex-shrink: 0; }
+  .tdoc-theme-icon-sun { display: none; }
+  html[data-tdoc-theme="dark"] .tdoc-theme-icon-moon { display: none; }
+  html[data-tdoc-theme="dark"] .tdoc-theme-icon-sun { display: block; }
+
+  /* Dark mode. Tokens flip the default doc template; chrome surfaces that
+     still use literals get explicit overrides. Author CSS on widgets is
+     left alone except body bg/color so agent-authored body { background:#fff }
+     does not pin the page to white. */
+  html[data-tdoc-theme="dark"] {
+    color-scheme: dark;
+    --td-ground: #111111;
+    --td-ink: #e8e8e6;
+    --td-heading: #f4f4f2;
+    --td-muted: #a3a29c;
+    --td-line: #2c2c2a;
+    --td-surface: #1c1c1b;
+    --td-surface-2: #181817;
+    --td-pre-ink: #e8e8e6;
+    --td-th-bg: #242422;
+    --td-th-ink: #f4f4f2;
+    --td-check: #e8e8e6;
+    --td-selection: #2a3f6e;
+    --td-quote: #3a3a36;
+    --td-accent-tint: #1a2744;
+    --td-accent-wash: rgba(22,82,240,0.18);
+    --td-danger-tint: #3a1816;
+  }
+  html[data-tdoc-theme="dark"] body { background: var(--td-ground); color: var(--td-ink); }
+  html[data-tdoc-theme="dark"] .tdoc-bar { background: #161616; color: #e8e8e6; border-bottom-color: #2c2c2a; box-shadow: none; }
+  html[data-tdoc-theme="dark"] .tdoc-bar .crumb { color: #b0b0aa; }
+  html[data-tdoc-theme="dark"] .tdoc-bar .crumb-sep { color: #555; }
+  html[data-tdoc-theme="dark"] .tdoc-bar .doc-title { color: #f4f4f2; }
+  html[data-tdoc-theme="dark"] .tdoc-bar button { color: #b0b0aa; }
+  html[data-tdoc-theme="dark"] .tdoc-bar button:hover { background: #2a2a28; color: #f4f4f2; }
+  html[data-tdoc-theme="dark"] .tdoc-version-toggle { background: #2a2a28 !important; color: #f4f4f2 !important; }
+  html[data-tdoc-theme="dark"] .tdoc-version-toggle:hover { background: #333331 !important; }
+  html[data-tdoc-theme="dark"] .tdoc-menu,
+  html[data-tdoc-theme="dark"] .tdoc-secondary-menu,
+  html[data-tdoc-theme="dark"] .tdoc-version-menu { background: #1c1c1b; border-color: #2c2c2a; box-shadow: 0 8px 24px rgba(0,0,0,0.4); }
+  html[data-tdoc-theme="dark"] .tdoc-menu button,
+  html[data-tdoc-theme="dark"] .tdoc-secondary-menu button,
+  html[data-tdoc-theme="dark"] .tdoc-version-menu button { color: #e8e8e6; }
+  html[data-tdoc-theme="dark"] .tdoc-menu button:hover,
+  html[data-tdoc-theme="dark"] .tdoc-secondary-menu button:hover,
+  html[data-tdoc-theme="dark"] .tdoc-version-menu button:hover { background: #2a2a28; }
+  html[data-tdoc-theme="dark"] .tdoc-chip { background: #2a2a28; color: #f4f4f2; }
+  html[data-tdoc-theme="dark"] .tdoc-chip:hover { background: #333331; }
+  html[data-tdoc-theme="dark"] .tdoc-margin-comment,
+  html[data-tdoc-theme="dark"] .tdoc-cluster-pop,
+  html[data-tdoc-theme="dark"] .tdoc-emoji-picker { background: #1c1c1b; border-color: #2c2c2a; color: #e8e8e6; }
+  html[data-tdoc-theme="dark"] .tdoc-margin-comment .author .login,
+  html[data-tdoc-theme="dark"] .tdoc-margin-comment .text,
+  html[data-tdoc-theme="dark"] .tdoc-reply .author .login { color: #f4f4f2; }
+  html[data-tdoc-theme="dark"] .tdoc-agent-author img { background: #1c1c1b; }
+  html[data-tdoc-theme="dark"] .tdoc-pin { background: #1c1c1b; border-color: #3a3a38; }
+  html[data-tdoc-theme="dark"] .tdoc-modal { background: #1c1c1b; color: #e8e8e6; }
+  html[data-tdoc-theme="dark"] .tdoc-modal p,
+  html[data-tdoc-theme="dark"] .tdoc-modal .step { color: #b0b0aa; }
+  html[data-tdoc-theme="dark"] .tdoc-modal button { background: #1c1c1b; color: #e8e8e6; border-color: #3a3a38; }
+  html[data-tdoc-theme="dark"] .tdoc-modal button.primary { background: var(--td-accent); border-color: var(--td-accent); color: #fff; }
+  html[data-tdoc-theme="dark"] .tdoc-modal input[type="password"],
+  html[data-tdoc-theme="dark"] .tdoc-modal input[type="text"] { background: #161616; color: #e8e8e6; border-color: #3a3a38; }
+  html[data-tdoc-theme="dark"] .tdoc-modal code { background: #2a2a28; }
+  html[data-tdoc-theme="dark"] .tdoc-modal .divider { border-top-color: #2c2c2a; }
+  html[data-tdoc-theme="dark"] .tdoc-seg button { background: #1c1c1b; color: #b0b0aa; }
+  html[data-tdoc-theme="dark"] body.tdoc-narrow #tdoc-comment-layer { background: #161616; border-top-color: #2c2c2a; }
+  html[data-tdoc-theme="dark"] .tdoc-footer { color: #888; border-top-color: #2c2c2a; }
+  html[data-tdoc-theme="dark"] .tdoc-footer a { color: #a3a29c; }
+  html[data-tdoc-theme="dark"] .tdoc-comment-pill { background: rgba(28,28,27,0.96) !important; border-color: #3a3a38 !important; }
+  html[data-tdoc-theme="dark"] .tdoc-oldver-strip { background: #2a2414; color: #e6d7a8; border-bottom-color: #3d3520; }
+  html[data-tdoc-theme="dark"] .tdoc-oldver-strip a { color: #f0d78c; }
+
   /* Footer */
   .tdoc-footer { margin-top: 80px; padding: 20px 16px 28px; font: 12px system-ui, sans-serif; color: #888; text-align: center; border-top: 1px solid #eee; box-sizing: border-box; max-width: 100%; }
   .tdoc-footer .tdoc-footer-row { display: inline-flex; flex-wrap: wrap; gap: 8px; align-items: center; justify-content: center; row-gap: 4px; }
@@ -746,7 +848,14 @@
     ? '<button id="tdoc-fork-btn">Fork</button>'
     : (isFork ? '<button id="tdoc-saveas-btn">Save As New Local Doc</button>' : '');
 
+  const themeBtnHtml = `
+    <button type="button" id="tdoc-theme-btn" class="tdoc-theme-btn" aria-pressed="false" title="Dark mode" aria-label="Switch to dark mode">
+      <svg class="tdoc-theme-icon-moon" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 14.5A8.5 8.5 0 1 1 9.5 3 7 7 0 0 0 21 14.5z"/></svg>
+      <svg class="tdoc-theme-icon-sun" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="4"/><path d="M12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M4.93 19.07l1.41-1.41M17.66 6.34l1.41-1.41"/></svg>
+    </button>`;
+
   const rightHtml = `
+    ${themeBtnHtml}
     ${copyMenuHtml}
     <div class="tdoc-menu-wrap">
     </div>
@@ -806,6 +915,13 @@
   // chip menu instead.
   document.getElementById('tdoc-bar-mark').onclick = () =>
     window.open('https://github.com/tornado-doc/tdoc', '_blank', 'noopener');
+
+  paintTheme(currentTheme());
+  document.getElementById('tdoc-theme-btn').onclick = () => {
+    const next = currentTheme() === 'dark' ? 'light' : 'dark';
+    persistTheme(next);
+    paintTheme(next);
+  };
 
   // Fork: opens the renderable /fork view in a new tab AND triggers a download
   // (one click, both happen). We use a hidden iframe to fire the download so

--- a/test/dark-mode.test.js
+++ b/test/dark-mode.test.js
@@ -33,6 +33,11 @@ t('applies html[data-tdoc-theme]', () => {
   assert(src.includes('html[data-tdoc-theme="dark"]'), 'no dark CSS');
 });
 
+t('dark mode is a page invert, not a per-color palette', () => {
+  assert(src.includes('invert(1) hue-rotate(180deg)'), 'missing invert transform');
+  assert(!src.includes('--td-ground: #111111'), 'old per-token dark palette came back');
+});
+
 t('default is light — only dark if storage says dark', () => {
   assert(
     /getItem\(THEME_KEY\) === 'dark' \? 'dark' : 'light'/.test(src),

--- a/test/dark-mode.test.js
+++ b/test/dark-mode.test.js
@@ -1,0 +1,55 @@
+// Dark-mode switch contract (overlay.js). #120
+//
+// One bar button. Preference lives in localStorage after the user switches.
+// Default is light. No prefers-color-scheme auto-follow.
+//
+// Run with: node test/dark-mode.test.js
+
+const fs = require('fs');
+const path = require('path');
+
+let pass = 0, fail = 0;
+function ok(n) { console.log(`  ✓ ${n}`); pass++; }
+function bad(n, e) { console.log(`  ✗ ${n}\n    ${e}`); fail++; }
+function t(n, fn) { try { fn(); ok(n); } catch (e) { bad(n, e.message); } }
+function assert(c, m) { if (!c) throw new Error(m || 'assertion failed'); }
+
+const src = fs.readFileSync(path.join(__dirname, '..', 'server', 'overlay.js'), 'utf8');
+
+console.log('dark-mode (#120 bar switch + localStorage)');
+
+t('bar has #tdoc-theme-btn', () => {
+  assert(src.includes('id="tdoc-theme-btn"'), 'theme button missing from bar HTML');
+});
+
+t('theme is stored under tdoc-theme', () => {
+  assert(src.includes("const THEME_KEY = 'tdoc-theme'"), 'THEME_KEY missing');
+  assert(src.includes('localStorage.setItem(THEME_KEY, theme)'), 'does not persist on switch');
+  assert(src.includes('localStorage.getItem(THEME_KEY)'), 'does not restore stored theme');
+});
+
+t('applies html[data-tdoc-theme]', () => {
+  assert(src.includes("setAttribute('data-tdoc-theme', theme)"), 'does not set data-tdoc-theme');
+  assert(src.includes('html[data-tdoc-theme="dark"]'), 'no dark CSS');
+});
+
+t('default is light — only dark if storage says dark', () => {
+  assert(
+    /getItem\(THEME_KEY\) === 'dark' \? 'dark' : 'light'/.test(src),
+    'readStoredTheme no longer defaults to light'
+  );
+});
+
+t('does not auto-follow the OS theme', () => {
+  assert(!src.includes('prefers-color-scheme'), 'must not follow prefers-color-scheme');
+});
+
+t('toggle writes storage then paints', () => {
+  assert(src.includes('tdoc-theme-btn').valueOf());
+  assert(/tdoc-theme-btn'\)\.onclick/.test(src), 'no click handler on #tdoc-theme-btn');
+  assert(src.includes('persistTheme(next)'), 'click does not persist');
+  assert(src.includes('paintTheme(next)'), 'click does not paint');
+});
+
+console.log(`\n${pass} passed, ${fail} failed.`);
+process.exit(fail ? 1 : 0);

--- a/test/run.js
+++ b/test/run.js
@@ -27,6 +27,7 @@ const OFFLINE = [
   'jul36-owner-manage.test.js', // JUL-36 owner manage UX: server-gated data, token-only mutations, no native confirm()
   'runtime-provenance.test.js', // release provenance + content-hash redeploy
   'oldver-strip.test.js',     // old-version banner predicate
+  'dark-mode.test.js',        // #120 top-bar dark mode switch + localStorage
   'cli.test.js',              // CLI resilience (drives bash hermetically)
   'no-drift.test.js',         // duplicated-helper drift guard
   'coverage.test.js',         // migration, bundle inlining, pull-merge, rich fold

--- a/test/ui.test.js
+++ b/test/ui.test.js
@@ -55,6 +55,47 @@ async function tPub(name, fn) {
     await page.waitForSelector('.tdoc-bar', { timeout: 5000 });
   });
 
+  await t('Dark mode switch is in the top bar', async () => {
+    const btn = await page.$('#tdoc-theme-btn');
+    if (!btn) throw new Error('no #tdoc-theme-btn');
+    const inBar = await page.$('.tdoc-bar #tdoc-theme-btn');
+    if (!inBar) throw new Error('theme button is not inside .tdoc-bar');
+  });
+
+  await t('Default theme is light and storage is empty until switch', async () => {
+    const theme = await page.getAttribute('html', 'data-tdoc-theme');
+    if (theme && theme !== 'light') throw new Error(`expected light, got "${theme}"`);
+    const stored = await page.evaluate(() => localStorage.getItem('tdoc-theme'));
+    if (stored !== null) throw new Error(`storage should be empty before switch, got "${stored}"`);
+  });
+
+  await t('Clicking the switch turns dark and remembers', async () => {
+    await page.click('#tdoc-theme-btn');
+    const theme = await page.getAttribute('html', 'data-tdoc-theme');
+    if (theme !== 'dark') throw new Error(`expected dark after click, got "${theme}"`);
+    const stored = await page.evaluate(() => localStorage.getItem('tdoc-theme'));
+    if (stored !== 'dark') throw new Error(`storage should be dark, got "${stored}"`);
+    const pressed = await page.getAttribute('#tdoc-theme-btn', 'aria-pressed');
+    if (pressed !== 'true') throw new Error(`aria-pressed should be true, got "${pressed}"`);
+  });
+
+  await t('Reload restores the remembered dark theme', async () => {
+    await page.reload({ waitUntil: 'networkidle' });
+    await page.waitForSelector('#tdoc-theme-btn', { timeout: 5000 });
+    const theme = await page.getAttribute('html', 'data-tdoc-theme');
+    if (theme !== 'dark') throw new Error(`expected dark after reload, got "${theme}"`);
+    const stored = await page.evaluate(() => localStorage.getItem('tdoc-theme'));
+    if (stored !== 'dark') throw new Error(`storage lost on reload: "${stored}"`);
+  });
+
+  await t('Clicking again returns to light and remembers', async () => {
+    await page.click('#tdoc-theme-btn');
+    const theme = await page.getAttribute('html', 'data-tdoc-theme');
+    if (theme !== 'light') throw new Error(`expected light after second click, got "${theme}"`);
+    const stored = await page.evaluate(() => localStorage.getItem('tdoc-theme'));
+    if (stored !== 'light') throw new Error(`storage should be light, got "${stored}"`);
+  });
+
   await t('Copy button exists with icon + label', async () => {
     const btn = await page.$('#tdoc-copy-md-btn');
     if (!btn) throw new Error('no #tdoc-copy-md-btn');


### PR DESCRIPTION
## What & why

Fixes #120. Design: #123.

One Dark / Light icon in the overlay menu bar. Dark mode is a page invert (`invert(1) hue-rotate(180deg)`), so author colors, artifacts, and replies flip together. Photos / video / canvas / iframes are inverted back. After the user switches, the choice is stored in `localStorage` on that host. Default stays light.

No per-color palette, no OS-theme follow, no account sync, no `/me` restyle.

## Checklist

- [x] `npm test` passes locally (offline suite).
- [x] Touched `server/overlay.js` — ran `node test/ui.test.js`.
- [x] Did not edit `SKILL.md`.
- [x] Did not change the version.

## Security note

n/a. The switch only reads/writes `localStorage['tdoc-theme']` (`light` / `dark`).