### PR TITLE
fix: tdoc.dev CD needs Node 22

### DIFF
--- a/.github/workflows/deploy-tdoc-dev.yml
+++ b/.github/workflows/deploy-tdoc-dev.yml
@@ -33,7 +33,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
-          node-version: '20'
+          node-version: '22'
 
       - name: Require tdoc.dev deploy secrets
         env:

--- a/.github/workflows/deploy-tdoc-dev.yml
+++ b/.github/workflows/deploy-tdoc-dev.yml
@@ -33,6 +33,8 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
+          # wrangler@4.90.1 engines.node is >=22. Node 20 fails EBADENGINE
+          # and never reaches wrangler deploy (first CD run after #114).
           node-version: '22'
 
       - name: Require tdoc.dev deploy secrets

--- a/test/deploy-tdoc-dev.test.js
+++ b/test/deploy-tdoc-dev.test.js
@@ -62,6 +62,15 @@ t('tdoc-publish reuses tdoc-bundle (no second copy of the inliner)', () => {
     'the overlay inliner must not remain copy-pasted inside tdoc-publish');
 });
 
+t('CD Node matches the pinned wrangler engine (>=22)', () => {
+  const node = wf.match(/node-version:\s*'(\d+)'/);
+  assert(node, 'workflow must pin a Node major');
+  assert(Number(node[1]) >= 22,
+    `wrangler 4.90.1 requires Node >= 22; first CD run died on Node ${node[1]}`);
+  assert(/wranglerVersion:\s*'4\.90\.1'/.test(wf),
+    'keep wranglerVersion and the Node pin in lockstep');
+});
+
 t('placeholder guard matches active declarations, not leftover comments', () => {
   assert(wf.includes('const OVERLAY_JS = `__TDOC_OVERLAY_JS__`;'),
     'overlay guard must match the live declaration, not any comment mention');


### PR DESCRIPTION
## What & why

The first #114 CD run failed: `wrangler@4.90.1` requires Node `>=22`, and `deploy-tdoc-dev.yml` was still on Node 20 (`EBADENGINE`, then `Wrangler requires at least Node.js v22.0.0`). tdoc.dev never got the merge.

- Bump the CD workflow to Node 22.
- Lock the Node major against the pinned `wranglerVersion` in the offline suite so this cannot regress to a comment-only YAML check.

Failed run: https://github.com/tornado-doc/tdoc/actions/runs/31905036981

## Checklist

- [x] `npm test` passes locally (offline suite).
- [x] Browser overlay/worker UI tests n/a.
- [x] SKILL.md unchanged.
- [x] VERSION unchanged.