### PR TITLE
fix: Vercel publish hits public host, not SSO-gated deploy URL

### DIFF
--- a/bin/tdoc-agent-reply
+++ b/bin/tdoc-agent-reply
@@ -110,7 +110,11 @@ if [ -f "$CONFIG_FILE" ]; then
   PLATFORM="$(jq -r '.platform // "cloudflare"' "$CONFIG_FILE")"
   TOKEN="$(jq -r '.upload_token // empty' "$CONFIG_FILE")"
   if [ "$PLATFORM" = "vercel" ]; then
+    HOST="$(jq -r '.public_host // empty' "$CONFIG_FILE")"
     BASE="$(jq -r '.base // empty' "$CONFIG_FILE")"
+    if [ -n "$HOST" ] && [ "$HOST" != "null" ]; then
+      BASE="https://${HOST}"
+    fi
   else
     SUBDOMAIN="$(jq -r .subdomain "$CONFIG_FILE")"
     WORKER="$(jq -r .worker "$CONFIG_FILE")"

--- a/bin/tdoc-publish
+++ b/bin/tdoc-publish
@@ -573,9 +573,10 @@ first_time_setup_vercel() {
     umask 077
     jq -n \
       --arg tok "$token" \
-      --arg base "$deploy_url" \
+      --arg base "https://${public_host}" \
       --arg host "$public_host" \
-      '{platform:"vercel", upload_token:$tok, base:$base, public_host:$host, created: now | todate}' \
+      --arg deploy "$deploy_url" \
+      '{platform:"vercel", upload_token:$tok, base:$base, public_host:$host, last_deploy:$deploy, created: now | todate}' \
       > "$CONFIG_FILE"
   )
   chmod 600 "$CONFIG_FILE"
@@ -628,18 +629,20 @@ if [ "$PLATFORM" = "vercel" ]; then
       sync_vercel_app
       NEW_BASE="$(vercel_deploy_prod)" || exit 1
       if [ "$NEW_BASE" != "$BASE" ]; then
-        # Persist the fresh deployment URL as the upload base. Old deployment
-        # URLs keep serving, so previously shared links stay live either way.
-        jq --arg base "$NEW_BASE" '.base = $base' "$CONFIG_FILE" > "$CONFIG_FILE.tmp" \
+        # Keep a record of the latest deploy URL, but do not use it as the
+        # API origin. Per-deployment aliases are often behind Vercel SSO
+        # ("Protected Deployment") and 401 curl from localhost.
+        jq --arg base "$NEW_BASE" '.last_deploy = $base' "$CONFIG_FILE" > "$CONFIG_FILE.tmp" \
           && mv "$CONFIG_FILE.tmp" "$CONFIG_FILE" && chmod 600 "$CONFIG_FILE"
-        BASE="$NEW_BASE"
       fi
       jq --arg sha "$DESIRED_BUNDLE_SHA" '.vercel_bundle_sha256 = $sha' "$CONFIG_FILE" > "$CONFIG_FILE.tmp" \
         && mv "$CONFIG_FILE.tmp" "$CONFIG_FILE" && chmod 600 "$CONFIG_FILE"
     fi
   fi
-  UPLOAD_BASE="$BASE"
   PUBLIC_BASE="https://${PUBLIC_HOST}"
+  # Upload through the stable production alias. `.base` used to hold the
+  # per-deployment URL, which Vercel Deployment Protection then 401s.
+  UPLOAD_BASE="$PUBLIC_BASE"
 else
   SUBDOMAIN="$(jq -r .subdomain "$CONFIG_FILE")"
   WORKER_NAME="$(jq -r .worker "$CONFIG_FILE")"

--- a/bin/tdoc-pull
+++ b/bin/tdoc-pull
@@ -30,13 +30,18 @@ if [ ! -f "$CONFIG_FILE" ]; then
 fi
 if ! command -v jq >/dev/null 2>&1; then echo "needs jq" >&2; exit 1; fi
 
-# Resolve the API base for the configured platform: vercel configs store the
-# deployment URL directly in `.base`; cloudflare configs derive workers.dev.
+# Resolve the API base for the configured platform. Vercel: prefer the
+# stable public_host — `.base` may still be a SSO-protected deploy URL.
+# Cloudflare: derive workers.dev.
 PLATFORM="$(jq -r '.platform // "cloudflare"' "$CONFIG_FILE")"
 if [ "$PLATFORM" = "vercel" ]; then
+  HOST="$(jq -r '.public_host // empty' "$CONFIG_FILE")"
   BASE="$(jq -r '.base // empty' "$CONFIG_FILE")"
+  if [ -n "$HOST" ] && [ "$HOST" != "null" ]; then
+    BASE="https://${HOST}"
+  fi
   if [ -z "$BASE" ] || [ "$BASE" = "null" ]; then
-    echo "[tdoc] $CONFIG_FILE has no '.base' — delete it and re-run /tdoc publish to re-setup." >&2
+    echo "[tdoc] $CONFIG_FILE has no public_host/base — delete it and re-run /tdoc publish to re-setup." >&2
     exit 1
   fi
 else

--- a/bin/tdoc-unpublish
+++ b/bin/tdoc-unpublish
@@ -21,13 +21,16 @@ fi
 if ! command -v jq >/dev/null 2>&1; then echo "needs jq" >&2; exit 1; fi
 
 TOKEN="$(jq -r .upload_token "$CONFIG_FILE")"
-# Resolve the API base for the configured platform: vercel configs store the
-# deployment URL directly in `.base`; cloudflare configs derive workers.dev.
+# Resolve the API base. Vercel: prefer public_host (`.base` may be SSO-gated).
 PLATFORM="$(jq -r '.platform // "cloudflare"' "$CONFIG_FILE")"
 if [ "$PLATFORM" = "vercel" ]; then
+  HOST="$(jq -r '.public_host // empty' "$CONFIG_FILE")"
   BASE="$(jq -r '.base // empty' "$CONFIG_FILE")"
+  if [ -n "$HOST" ] && [ "$HOST" != "null" ]; then
+    BASE="https://${HOST}"
+  fi
   if [ -z "$BASE" ] || [ "$BASE" = "null" ]; then
-    echo "[tdoc] $CONFIG_FILE has no '.base' — delete it and re-run /tdoc publish to re-setup." >&2
+    echo "[tdoc] $CONFIG_FILE has no public_host/base — delete it and re-run /tdoc publish to re-setup." >&2
     exit 1
   fi
 else

--- a/server/overlay.js
+++ b/server/overlay.js
@@ -2714,7 +2714,11 @@
         });
         const data = await r.json();
         if (!r.ok || data.error) {
-          status.textContent = 'Failed: ' + (data.error || data.message || 'unknown');
+          const raw = String(data.stderr || data.stdout || '').trim();
+          const last = raw.split('\n').filter(Boolean).pop() || '';
+          const detail = last.length > 180 ? last.slice(0, 180) + '…' : last;
+          status.textContent = 'Failed: ' + (data.error || data.message || 'unknown')
+            + (detail ? ' — ' + detail : '');
           go.disabled = false;
           return;
         }

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -49,6 +49,18 @@ t('tdoc-publish validates published.json fields (no null host/token)', () => {
     'published.json null-field validation missing');
 });
 
+t('vercel upload uses the stable public_host, not a per-deploy URL', () => {
+  const src = readBin('tdoc-publish');
+  assert(/UPLOAD_BASE="\$PUBLIC_BASE"/.test(src),
+    'tdoc-publish must upload to PUBLIC_BASE (tdoc-phi style alias)');
+  assert(!/UPLOAD_BASE="\$BASE"/.test(src),
+    'tdoc-publish must not upload to .base (SSO-protected deploy URL)');
+  for (const f of ['tdoc-pull', 'tdoc-unpublish', 'tdoc-agent-reply']) {
+    const s = readBin(f);
+    assert(/public_host/.test(s), `${f} must prefer public_host on vercel`);
+  }
+});
+
 t('tdoc-publish does not let an older-version failure abort the latest', () => {
   const src = readBin('tdoc-publish');
   assert(/OLDER_FAILED/.test(src), 'older-version best-effort handling missing');


### PR DESCRIPTION
## Why

Clicking Publish on localhost showed `Failed: publish_failed`.

`tdoc-publish` uploaded to `published.json` `.base`, which was a per-deployment URL (`tdoc-….vercel.app`). That URL is behind Vercel Deployment Protection, so curl gets `401 Protected Deployment`. The production alias (`tdoc-phi.vercel.app`) is fine. The modal only printed `data.error`, so the real reason was hidden.

## What

- Vercel upload / pull / unpublish / agent-reply go through `public_host`
- First-time setup stores `base` as the public alias
- Publish modal appends the last stderr line

## Verify

- `node test/cli.test.js` — 10 passed
- Reproduced the 401 against the old `.base`, then published `tdoc-me` to https://tdoc-phi.vercel.app/d/tdoc-me/v/1

Not tdoc.dev / hosted (#131). This is the self-host Vercel path on this machine.