### PR TITLE
feat: search and batch delete on My docs (/me)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,12 @@ file and `.claude-plugin/plugin.json`.
 
 ### Added
 
+- **Search and batch delete on My docs (`/me`).** Filter the owner catalog by
+  title or slug, multi-select rows, and delete the selection in one confirm.
+  Still client-side over the KV title list (no extra R2/comment work at render);
+  access policy stays on the doc Share panel. Feedback is a tiny inline
+  top-right toast (`Deleted`) — no third-party toast library on the owner
+  session surface.
 - **BYOK update nag.** User-facing CLIs and the skill preamble compare this
   checkout to `origin/main` and point at `/tdoc update --yes` when main is
   ahead. Ahead-only feature branches stay silent; a true diverge does not

--- a/test/jul36-owner-manage.test.js
+++ b/test/jul36-owner-manage.test.js
@@ -282,8 +282,9 @@ async function main() {
     const indexHtmlSrc = worker.slice(idxStart, idxEnd);
     assert(!nativeConfirmCall.test(stripLineComments(indexHtmlSrc)), '/me must not call the native confirm()');
     assert(indexHtmlSrc.includes('showConfirm('), '/me must use the styled showConfirm() modal');
-    assert(indexHtmlSrc.includes('dataset.versions'),
-      'delete confirm copy should be built from data-versions/data-comments (honest N/M copy)');
+    // Quiet confirm — title + "This can't be undone.", no version/comment inventory.
+    assert(indexHtmlSrc.includes("This can't be undone."), 'delete confirm copy should stay short and plain');
+    assert(!/remote storage/i.test(stripLineComments(indexHtmlSrc)), '/me must not say "remote storage" to the user');
   });
 
   t('local server index page no longer uses window.confirm() for delete', () => {

--- a/test/me-management.test.js
+++ b/test/me-management.test.js
@@ -76,6 +76,10 @@ t('/me search is client-side over title/slug (no extra catalog round-trips)', ()
   assert(index.includes('dataset.title'), 'search must read title from the rendered row');
   assert(index.includes('dataset.slug'), 'search must read slug from the rendered row');
   assert(index.includes('No docs match that search'), 'missing empty search state');
+  // `.doc-row { display:flex }` would otherwise override the UA [hidden] rule
+  // and leave "filtered" rows visible — pin the !important hide.
+  assert(/\.doc-row\[hidden\][^}]*display:\s*none\s*!important/.test(index),
+    'filtered rows must force display:none !important so search actually hides them');
 });
 
 t('/me batch delete reuses session DELETE /api/doc (no token, no access forms)', () => {

--- a/test/me-management.test.js
+++ b/test/me-management.test.js
@@ -102,18 +102,21 @@ t('/me still uses the styled confirm modal, never native confirm()', () => {
   const stripped = index.split('\n').filter(l => !l.trim().startsWith('//') && !l.trim().startsWith('*')).join('\n');
   assert(!nativeConfirmCall.test(stripped), '/me must not call the native confirm()');
   assert(index.includes('showConfirm('), '/me must use the styled showConfirm() modal');
-  // Quiet Toastify feedback — no inline status row, no "remote storage" jargon.
+  // Quiet Toastify feedback — vendored (no CDN), no inline status row.
   assert(index.includes("This can't be undone."), 'confirm body should be short and plain');
   const userFacing = index.split('\n').filter(l => !l.trim().startsWith('//') && !l.trim().startsWith('*')).join('\n');
   assert(!/remote storage/i.test(userFacing), '/me copy must not say "remote storage"');
   assert(!index.includes("'/api/comments?slug='"), 'delete confirm must not pre-flight comment counts');
-  assert(index.includes('toastify-js@1.12.0'), '/me must load toastify-js from the pinned CDN');
+  assert(index.includes('${TOASTIFY_JS}'), '/me must inline vendored toastify-js (not a third-party CDN)');
+  assert(index.includes('${TOASTIFY_CSS}'), '/me must inline vendored toastify CSS');
+  assert(!index.includes('cdn.jsdelivr.net'), '/me must not load toastify from a CDN');
   assert(index.includes('Toastify('), '/me must call Toastify() for feedback');
   assert(!index.includes('id="status"'), 'inline status row should be gone — toast replaces it');
   assert(index.includes("toast('Deleted')"), 'success feedback should be a quiet toast("Deleted")');
   assert(index.includes("position: 'right'"), 'use Toastify top-right placement (library default feel)');
   assert(index.includes('linear-gradient'), 'toast should use a gradient skin, not a flat DIY pill');
-  assert(!/5477f5|73a5ff/.test(index), 'must not keep Toastify stock purple stops');
+  assert(!index.includes('data-versions'), 'unused data-versions should be gone from /me rows');
+  assert(index.includes('applySearch();'), 'single-row delete must re-run applySearch so empty/filter state stays consistent');
 });
 
 t('/me catalog does not fold comment logs or HEAD R2 per row', () => {

--- a/test/me-management.test.js
+++ b/test/me-management.test.js
@@ -1,15 +1,15 @@
 // Owner catalog (/me) guard.
 //
 // 2026-08-13 rework (julie: "删改实在是太丑了 uiux 请improve。而且不能只在/me page"):
-// /me is now a clean delete-only catalog — title/slug/version + Delete. The
-// per-row visibility/history/commenting/allowed_users dropdowns and the
-// admin-token input are GONE: access controls moved to the doc-page Share
-// panel (overlay.js showManageModal, see jul36-owner-manage.test.js), and
-// Delete now authorizes off the owner's session cookie instead of a pasted
-// token (safe only because of the CSP on every doc response — see
-// csp.test.js). /me is reachable only by the signed-in owner (route-level
-// isOwnerSession redirect), so its own same-origin fetches are already
-// cookied.
+// /me is a clean catalog — title/slug/version + search + multi-select batch
+// delete + quiet ⋯ Delete. The per-row visibility/history/commenting/
+// allowed_users dropdowns and the admin-token input are GONE: access
+// controls moved to the doc-page Share panel (overlay.js showManageModal,
+// see jul36-owner-manage.test.js), and Delete now authorizes off the owner's
+// session cookie instead of a pasted token (safe only because of the CSP on
+// every doc response — see csp.test.js). /me is reachable only by the
+// signed-in owner (route-level isOwnerSession redirect), so its own
+// same-origin fetches are already cookied.
 //
 // Gate (小cc review #2): the /me HTML response must not contain access data
 // of any kind — especially `allowed_users` — since none of that is rendered
@@ -57,13 +57,32 @@ t('/me never computes or emits allowed_users (gate: no access data leaks into th
   assert(!index.includes('accessFromMeta'), '/me must not compute an access policy per row anymore');
 });
 
-t('/me keeps only title, slug, version, and a quiet ⋯ delete per row', () => {
+t('/me keeps title, slug, version, search, batch select, and a quiet ⋯ delete per row', () => {
   assert(index.includes('doc-title'), 'missing doc title link');
   assert(index.includes('doc-meta'), 'missing slug/version meta line');
   // Delete is tucked behind a ⋯ overflow menu, not a prominent per-row button.
   assert(index.includes('class="row-menu-btn"'), 'missing ⋯ overflow trigger');
   assert(index.includes('class="row-delete"'), 'missing delete item inside the menu');
   assert(!index.includes('class="delete-doc"'), 'the loud standalone delete button should be gone');
+  // Search + multi-select batch delete (still no access forms).
+  assert(index.includes('id="doc-search"'), 'missing catalog search input');
+  assert(index.includes('class="doc-check"'), 'missing per-row select checkbox');
+  assert(index.includes('id="batch-delete"'), 'missing batch delete control');
+  assert(index.includes('id="select-all"'), 'missing select-all control');
+});
+
+t('/me search is client-side over title/slug (no extra catalog round-trips)', () => {
+  assert(index.includes('applySearch'), 'missing search apply helper');
+  assert(index.includes('dataset.title'), 'search must read title from the rendered row');
+  assert(index.includes('dataset.slug'), 'search must read slug from the rendered row');
+  assert(index.includes('No docs match that search'), 'missing empty search state');
+});
+
+t('/me batch delete reuses session DELETE /api/doc (no token, no access forms)', () => {
+  assert(index.includes('batchDelete.addEventListener'), 'batch delete must be wired');
+  assert(index.includes('selectedRows'), 'batch delete must operate on the selected set');
+  // Still no access-policy batching — JUL-36 keeps policy on the doc Share panel.
+  assert(!index.includes('/api/doc/access'), '/me must not batch-patch access policy');
 });
 
 t('/me deletes remote docs through DELETE /api/doc using the session (no token)', () => {

--- a/test/me-management.test.js
+++ b/test/me-management.test.js
@@ -111,9 +111,9 @@ t('/me still uses the styled confirm modal, never native confirm()', () => {
   assert(index.includes('Toastify('), '/me must call Toastify() for feedback');
   assert(!index.includes('id="status"'), 'inline status row should be gone — toast replaces it');
   assert(index.includes("toast('Deleted')"), 'success feedback should be a quiet toast("Deleted")');
-  // Don't ship Toastify's stock purple gradient as the default skin.
-  assert(index.includes("background: kind === 'error' ? '#b42318' : '#1652f0'"),
-    'toast skin must use tdoc accent/danger, not the library purple gradient');
+  assert(index.includes("position: 'right'"), 'use Toastify top-right placement (library default feel)');
+  assert(index.includes('linear-gradient'), 'toast should use a gradient skin, not a flat DIY pill');
+  assert(!/5477f5|73a5ff/.test(index), 'must not keep Toastify stock purple stops');
 });
 
 t('/me catalog does not fold comment logs or HEAD R2 per row', () => {

--- a/test/me-management.test.js
+++ b/test/me-management.test.js
@@ -102,21 +102,18 @@ t('/me still uses the styled confirm modal, never native confirm()', () => {
   const stripped = index.split('\n').filter(l => !l.trim().startsWith('//') && !l.trim().startsWith('*')).join('\n');
   assert(!nativeConfirmCall.test(stripped), '/me must not call the native confirm()');
   assert(index.includes('showConfirm('), '/me must use the styled showConfirm() modal');
-  // Quiet Toastify feedback — vendored (no CDN), no inline status row.
+  // Quiet inline toast feedback — no third-party script, no inline status row.
   assert(index.includes("This can't be undone."), 'confirm body should be short and plain');
   const userFacing = index.split('\n').filter(l => !l.trim().startsWith('//') && !l.trim().startsWith('*')).join('\n');
   assert(!/remote storage/i.test(userFacing), '/me copy must not say "remote storage"');
   assert(!index.includes("'/api/comments?slug='"), 'delete confirm must not pre-flight comment counts');
-  assert(index.includes('${TOASTIFY_JS}'), '/me must inline vendored toastify-js (not a third-party CDN)');
-  assert(index.includes('${TOASTIFY_CSS}'), '/me must inline vendored toastify CSS');
-  assert(!index.includes('cdn.jsdelivr.net'), '/me must not load toastify from a CDN');
-  assert(index.includes('Toastify('), '/me must call Toastify() for feedback');
+  assert(!/<script\s+src=/i.test(index), '/me must not load third-party <script src=>');
+  assert(index.includes("function toast("), '/me must use a tiny inline toast for feedback');
   assert(!index.includes('id="status"'), 'inline status row should be gone — toast replaces it');
   assert(index.includes("toast('Deleted')"), 'success feedback should be a quiet toast("Deleted")');
-  assert(index.includes("position: 'right'"), 'use Toastify top-right placement (library default feel)');
-  assert(index.includes('linear-gradient'), 'toast should use a gradient skin, not a flat DIY pill');
   assert(!index.includes('data-versions'), 'unused data-versions should be gone from /me rows');
   assert(index.includes('applySearch();'), 'single-row delete must re-run applySearch so empty/filter state stays consistent');
+  assert(index.includes('name="viewport"'), '/me must send a mobile viewport meta');
 });
 
 t('/me catalog does not fold comment logs or HEAD R2 per row', () => {

--- a/test/me-management.test.js
+++ b/test/me-management.test.js
@@ -102,15 +102,18 @@ t('/me still uses the styled confirm modal, never native confirm()', () => {
   const stripped = index.split('\n').filter(l => !l.trim().startsWith('//') && !l.trim().startsWith('*')).join('\n');
   assert(!nativeConfirmCall.test(stripped), '/me must not call the native confirm()');
   assert(index.includes('showConfirm('), '/me must use the styled showConfirm() modal');
-  // Quiet floating toast — no inline status row, no "remote storage" jargon.
+  // Quiet Toastify feedback — no inline status row, no "remote storage" jargon.
   assert(index.includes("This can't be undone."), 'confirm body should be short and plain');
   const userFacing = index.split('\n').filter(l => !l.trim().startsWith('//') && !l.trim().startsWith('*')).join('\n');
   assert(!/remote storage/i.test(userFacing), '/me copy must not say "remote storage"');
   assert(!index.includes("'/api/comments?slug='"), 'delete confirm must not pre-flight comment counts');
-  assert(index.includes("function toast("), '/me must use a floating toast for feedback');
-  assert(index.includes('tdoc-toast'), 'missing toast styles/markup class');
+  assert(index.includes('toastify-js@1.12.0'), '/me must load toastify-js from the pinned CDN');
+  assert(index.includes('Toastify('), '/me must call Toastify() for feedback');
   assert(!index.includes('id="status"'), 'inline status row should be gone — toast replaces it');
   assert(index.includes("toast('Deleted')"), 'success feedback should be a quiet toast("Deleted")');
+  // Don't ship Toastify's stock purple gradient as the default skin.
+  assert(index.includes("background: kind === 'error' ? '#b42318' : '#1652f0'"),
+    'toast skin must use tdoc accent/danger, not the library purple gradient');
 });
 
 t('/me catalog does not fold comment logs or HEAD R2 per row', () => {

--- a/test/me-management.test.js
+++ b/test/me-management.test.js
@@ -102,12 +102,15 @@ t('/me still uses the styled confirm modal, never native confirm()', () => {
   const stripped = index.split('\n').filter(l => !l.trim().startsWith('//') && !l.trim().startsWith('*')).join('\n');
   assert(!nativeConfirmCall.test(stripped), '/me must not call the native confirm()');
   assert(index.includes('showConfirm('), '/me must use the styled showConfirm() modal');
-  // Quiet copy — no infra jargon / version-comment inventory / status chatter.
+  // Quiet floating toast — no inline status row, no "remote storage" jargon.
   assert(index.includes("This can't be undone."), 'confirm body should be short and plain');
   const userFacing = index.split('\n').filter(l => !l.trim().startsWith('//') && !l.trim().startsWith('*')).join('\n');
   assert(!/remote storage/i.test(userFacing), '/me copy must not say "remote storage"');
   assert(!index.includes("'/api/comments?slug='"), 'delete confirm must not pre-flight comment counts');
-  assert(index.includes("'Deleted.'"), 'success status should be a quiet "Deleted."');
+  assert(index.includes("function toast("), '/me must use a floating toast for feedback');
+  assert(index.includes('tdoc-toast'), 'missing toast styles/markup class');
+  assert(!index.includes('id="status"'), 'inline status row should be gone — toast replaces it');
+  assert(index.includes("toast('Deleted')"), 'success feedback should be a quiet toast("Deleted")');
 });
 
 t('/me catalog does not fold comment logs or HEAD R2 per row', () => {

--- a/test/me-management.test.js
+++ b/test/me-management.test.js
@@ -75,7 +75,7 @@ t('/me search is client-side over title/slug (no extra catalog round-trips)', ()
   assert(index.includes('applySearch'), 'missing search apply helper');
   assert(index.includes('dataset.title'), 'search must read title from the rendered row');
   assert(index.includes('dataset.slug'), 'search must read slug from the rendered row');
-  assert(index.includes('No docs match that search'), 'missing empty search state');
+  assert(index.includes('No matches.'), 'missing empty search state');
   // `.doc-row { display:flex }` would otherwise override the UA [hidden] rule
   // and leave "filtered" rows visible — pin the !important hide.
   assert(/\.doc-row\[hidden\][^}]*display:\s*none\s*!important/.test(index),
@@ -102,14 +102,17 @@ t('/me still uses the styled confirm modal, never native confirm()', () => {
   const stripped = index.split('\n').filter(l => !l.trim().startsWith('//') && !l.trim().startsWith('*')).join('\n');
   assert(!nativeConfirmCall.test(stripped), '/me must not call the native confirm()');
   assert(index.includes('showConfirm('), '/me must use the styled showConfirm() modal');
-  assert(index.includes('dataset.versions'), 'delete confirm copy should include version count from meta');
-  assert(index.includes("'/api/comments?slug='"), 'comment count for delete confirm must load lazily, not at catalog render');
+  // Quiet copy — no infra jargon / version-comment inventory / status chatter.
+  assert(index.includes("This can't be undone."), 'confirm body should be short and plain');
+  const userFacing = index.split('\n').filter(l => !l.trim().startsWith('//') && !l.trim().startsWith('*')).join('\n');
+  assert(!/remote storage/i.test(userFacing), '/me copy must not say "remote storage"');
+  assert(!index.includes("'/api/comments?slug='"), 'delete confirm must not pre-flight comment counts');
+  assert(index.includes("'Deleted.'"), 'success status should be a quiet "Deleted."');
 });
 
 t('/me catalog does not fold comment logs or HEAD R2 per row', () => {
   // The slow /me load: N serial readComments (full event-log fold) + N R2 HEADs
-  // just to paint titles. Catalog reads KV meta only; comment counts wait until
-  // Delete is clicked.
+  // just to paint titles. Catalog reads KV meta only.
   assert(!index.includes('readComments('), '/me must not call readComments while rendering the catalog');
   assert(!index.includes('DOCS.head'), '/me must not HEAD R2 objects while rendering the catalog');
   assert(index.includes('Promise.all'), '/me should fetch meta rows in parallel');

--- a/worker/worker.js
+++ b/worker/worker.js
@@ -1008,15 +1008,17 @@ function landingHtml() {
 //     CSP set on every doc response (see cspHeader()). /me is only reachable
 //     by the signed-in owner in the first place (isOwnerSession gate in the
 //     route above), so its own fetches are already same-origin + cookied.
-// What's left: title, slug, version, Delete. No access data of any kind is
-// computed or emitted here (gate: response HTML must not contain
-// `allowed_users` — there is nothing here that could).
+// What's left: title, slug, version, search, multi-select batch delete, and
+// a quiet ⋯ Delete. No access data of any kind is computed or emitted here
+// (gate: response HTML must not contain `allowed_users` — there is nothing
+// here that could).
 async function indexHtml(env, session) {
   // Catalog is title/slug/version from KV meta only. Do NOT HEAD R2 or fold
   // comment logs here — that was N serial Durable-Object + R2 round trips
   // per page load (the HTML bodies were never downloaded, but the comment
   // event log for every slug was). Comment counts for the delete confirm
-  // load lazily on click via GET /api/comments.
+  // load lazily on click via GET /api/comments. Search + batch select are
+  // client-side over the rendered rows (no extra KV/R2 work).
   let list = [];
   let cursor;
   do {
@@ -1036,7 +1038,10 @@ async function indexHtml(env, session) {
     return { slug, title: meta.title || slug, latest, versionCount };
   }));
 
-  const rows = docs.map(({ slug, title, latest, versionCount }) => `<div class="doc-row">
+  const rows = docs.map(({ slug, title, latest, versionCount }) => `<div class="doc-row" data-slug="${escapeHtml(slug)}" data-title="${escapeHtml(title)}" data-versions="${versionCount}">
+      <label class="row-check">
+        <input type="checkbox" class="doc-check" aria-label="Select ${escapeHtml(title)}">
+      </label>
       <div class="doc-info">
         <a class="doc-title" href="/d/${encodeURIComponent(slug)}/v/${latest}">${escapeHtml(title)}</a>
         <div class="doc-meta">${escapeHtml(slug)} · v${latest}</div>
@@ -1058,20 +1063,32 @@ async function indexHtml(env, session) {
   }
   body { font: 15px system-ui, -apple-system, sans-serif; max-width: 680px; margin: 48px auto; padding: 0 20px; color: var(--td-ink); }
   h1 { font-size: 28px; margin: 0 0 4px; color: var(--td-accent); }
-  .who { color: var(--td-muted); font-size: 13px; margin: 0 0 28px; }
+  .who { color: var(--td-muted); font-size: 13px; margin: 0 0 20px; }
   .who b { color: #444; font-weight: 600; }
   a { color: var(--td-accent); text-decoration: none; }
   a:hover { text-decoration: underline; }
   .empty { color: #888; padding: 40px 0; text-align: center; border: 1px dashed var(--td-line); border-radius: 12px; }
+  .toolbar { display: flex; flex-wrap: wrap; gap: 10px; align-items: center; margin: 0 0 12px; }
+  .toolbar input[type="search"] { flex: 1 1 220px; min-width: 0; font: inherit; padding: 8px 12px; border: 1px solid var(--td-line); border-radius: 8px; background: #fff; color: var(--td-ink); }
+  .toolbar input[type="search"]:focus { outline: 2px solid var(--td-accent-tint); border-color: var(--td-accent); }
+  .batch-bar { display: flex; flex-wrap: wrap; gap: 10px; align-items: center; justify-content: space-between; margin: 0 0 8px; min-height: 32px; }
+  .select-all { display: inline-flex; align-items: center; gap: 8px; color: var(--td-muted); font-size: 13px; cursor: pointer; user-select: none; }
+  .batch-delete { display: none; font: inherit; padding: 6px 12px; border-radius: 6px; border: 1px solid var(--td-danger); background: #fff; color: var(--td-danger); }
+  .batch-delete.is-visible { display: inline-block; }
+  .batch-delete:hover { background: var(--td-danger); color: #fff; }
+  .batch-delete:disabled { opacity: 0.5; cursor: default; }
   .doc-list { display: flex; flex-direction: column; }
-  .doc-row { display: flex; align-items: center; justify-content: space-between; gap: 16px; padding: 13px 4px; border-bottom: 1px solid var(--td-line); }
-  .doc-info { min-width: 0; }
+  .doc-row { display: flex; align-items: center; gap: 12px; padding: 13px 4px; border-bottom: 1px solid var(--td-line); }
+  .doc-row.is-selected { background: var(--td-accent-tint); border-radius: 8px; }
+  .row-check { display: flex; align-items: center; flex-shrink: 0; cursor: pointer; }
+  .row-check input, .select-all input { width: 15px; height: 15px; accent-color: var(--td-accent); cursor: pointer; }
+  .doc-info { min-width: 0; flex: 1 1 auto; }
   .doc-title { display: block; font-weight: 600; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
   .doc-meta { color: var(--td-muted); font-size: 12px; margin-top: 2px; }
   button { font: inherit; cursor: pointer; transition: border-color .12s, background .12s, color .12s; }
   /* Delete lives behind a quiet ⋯ overflow — the catalog reads as a clean list,
      not a management console. Faint by default, clearer on row hover. */
-  .row-actions { position: relative; flex-shrink: 0; }
+  .row-actions { position: relative; flex-shrink: 0; margin-left: auto; }
   .row-menu-btn { border: none; background: none; color: #ccc; font-size: 20px; line-height: 1; padding: 2px 8px; border-radius: 6px; }
   .doc-row:hover .row-menu-btn { color: var(--td-muted); }
   .row-menu-btn:hover, .row-menu-btn[aria-expanded="true"] { background: var(--td-line); color: var(--td-ink); }
@@ -1099,7 +1116,15 @@ async function indexHtml(env, session) {
 <p class="who">Documents hosted on this worker${session && session.login ? ` · signed in as <b>${escapeHtml(session.login)}</b>` : ''}.</p>
 <p id="status" class="status" aria-live="polite"></p>
 ${rows.length === 0 ? '<p class="empty">No published docs yet.</p>' :
-  `<div class="doc-list">${rows.join('')}</div>`}
+  `<div class="toolbar">
+    <input type="search" id="doc-search" placeholder="Search title or slug…" autocomplete="off" aria-label="Search docs">
+  </div>
+  <div class="batch-bar">
+    <label class="select-all"><input type="checkbox" id="select-all"> <span id="select-all-label">Select all</span></label>
+    <button type="button" id="batch-delete" class="batch-delete">Delete selected</button>
+  </div>
+  <div class="doc-list">${rows.join('')}</div>
+  <p id="no-match" class="empty" hidden>No docs match that search.</p>`}
 <script>
 (() => {
   const status = document.getElementById('status');
@@ -1167,6 +1192,17 @@ ${rows.length === 0 ? '<p class="empty">No published docs yet.</p>' :
       return n;
     } catch { return 0; }
   }
+  async function deleteDoc(slug) {
+    const res = await fetch('/api/doc?slug=' + encodeURIComponent(slug), {
+      method: 'DELETE',
+      credentials: 'same-origin',
+    });
+    if (!res.ok) {
+      let body = {};
+      try { body = await res.json(); } catch {}
+      throw new Error(body.error || ('HTTP ' + res.status));
+    }
+  }
   document.querySelectorAll('.row-delete').forEach((button) => {
     button.addEventListener('click', async () => {
       closeMenus(null);
@@ -1185,20 +1221,133 @@ ${rows.length === 0 ? '<p class="empty">No published docs yet.</p>' :
       });
       if (!proceed) return;
       say('Deleting ' + slug + '...');
-      const res = await fetch('/api/doc?slug=' + encodeURIComponent(slug), {
-        method: 'DELETE',
-        credentials: 'same-origin',
-      });
-      if (!res.ok) {
-        let body = {};
-        try { body = await res.json(); } catch {}
-        say(body.error ? 'Delete failed: ' + body.error : 'Delete failed.', 'error');
+      try {
+        await deleteDoc(slug);
+      } catch (err) {
+        say('Delete failed: ' + (err && err.message ? err.message : 'unknown'), 'error');
         return;
       }
       button.closest('.doc-row').remove();
+      syncBatchUi();
       say('Deleted ' + slug + ' from remote storage.', 'ok');
     });
   });
+
+  // Search + batch select — client-side only over the already-rendered rows.
+  // No access data, no extra KV/R2; keep the catalog fast (#115).
+  const listEl = document.querySelector('.doc-list');
+  if (!listEl) return;
+  const search = document.getElementById('doc-search');
+  const selectAll = document.getElementById('select-all');
+  const selectAllLabel = document.getElementById('select-all-label');
+  const batchDelete = document.getElementById('batch-delete');
+  const noMatch = document.getElementById('no-match');
+
+  function visibleRows() {
+    return Array.from(listEl.querySelectorAll('.doc-row')).filter((row) => !row.hidden);
+  }
+  function selectedRows() {
+    return Array.from(listEl.querySelectorAll('.doc-row')).filter((row) => {
+      const box = row.querySelector('.doc-check');
+      return box && box.checked;
+    });
+  }
+  function syncBatchUi() {
+    const visible = visibleRows();
+    const selected = selectedRows();
+    const n = selected.length;
+    selected.forEach((row) => row.classList.add('is-selected'));
+    listEl.querySelectorAll('.doc-row').forEach((row) => {
+      const box = row.querySelector('.doc-check');
+      if (!(box && box.checked)) row.classList.remove('is-selected');
+    });
+    batchDelete.classList.toggle('is-visible', n > 0);
+    batchDelete.textContent = n === 1 ? 'Delete 1 selected' : ('Delete ' + n + ' selected');
+    const allVisibleChecked = visible.length > 0 && visible.every((row) => {
+      const box = row.querySelector('.doc-check');
+      return box && box.checked;
+    });
+    const someVisibleChecked = visible.some((row) => {
+      const box = row.querySelector('.doc-check');
+      return box && box.checked;
+    });
+    selectAll.checked = allVisibleChecked;
+    selectAll.indeterminate = someVisibleChecked && !allVisibleChecked;
+    selectAllLabel.textContent = allVisibleChecked ? 'Deselect all' : 'Select all';
+    selectAll.disabled = visible.length === 0;
+    if (!listEl.querySelector('.doc-row')) {
+      search.closest('.toolbar').hidden = true;
+      selectAll.closest('.batch-bar').hidden = true;
+      listEl.insertAdjacentHTML('afterend', '<p class="empty">No published docs yet.</p>');
+      listEl.remove();
+      if (noMatch) noMatch.hidden = true;
+    }
+  }
+  function applySearch() {
+    const q = (search.value || '').trim().toLowerCase();
+    let shown = 0;
+    listEl.querySelectorAll('.doc-row').forEach((row) => {
+      const hay = ((row.dataset.title || '') + ' ' + (row.dataset.slug || '')).toLowerCase();
+      const match = !q || hay.includes(q);
+      row.hidden = !match;
+      if (match) shown += 1;
+      else {
+        const box = row.querySelector('.doc-check');
+        if (box) box.checked = false;
+      }
+    });
+    if (noMatch) noMatch.hidden = shown > 0;
+    listEl.hidden = shown === 0;
+    syncBatchUi();
+  }
+
+  search.addEventListener('input', applySearch);
+  listEl.addEventListener('change', (e) => {
+    if (e.target && e.target.classList && e.target.classList.contains('doc-check')) syncBatchUi();
+  });
+  selectAll.addEventListener('change', () => {
+    const on = selectAll.checked;
+    visibleRows().forEach((row) => {
+      const box = row.querySelector('.doc-check');
+      if (box) box.checked = on;
+    });
+    syncBatchUi();
+  });
+  batchDelete.addEventListener('click', async () => {
+    const rows = selectedRows();
+    if (!rows.length) return;
+    const versions = rows.reduce((sum, row) => sum + (Number(row.dataset.versions) || 1), 0);
+    say('Checking ' + rows.length + ' doc(s)…');
+    const counts = await Promise.all(rows.map((row) => countComments(row.dataset.slug)));
+    const comments = counts.reduce((a, b) => a + b, 0);
+    say('');
+    const proceed = await showConfirm({
+      title: rows.length === 1 ? ('Delete "' + (rows[0].dataset.title || rows[0].dataset.slug) + '"?') : ('Delete ' + rows.length + ' docs?'),
+      body: 'This permanently removes <b>' + rows.length + ' doc(s)</b>, <b>' + versions +
+        ' version(s)</b>, and <b>' + comments + ' comment(s)</b> from remote storage. No undo.',
+      confirmLabel: rows.length === 1 ? 'Delete' : ('Delete ' + rows.length),
+      danger: true,
+    });
+    if (!proceed) return;
+    batchDelete.disabled = true;
+    let ok = 0, failed = 0;
+    for (const row of rows) {
+      const slug = row.dataset.slug;
+      say('Deleting ' + slug + '…');
+      try {
+        await deleteDoc(slug);
+        row.remove();
+        ok += 1;
+      } catch {
+        failed += 1;
+      }
+    }
+    batchDelete.disabled = false;
+    applySearch();
+    if (failed) say('Deleted ' + ok + '; ' + failed + ' failed.', 'error');
+    else say('Deleted ' + ok + ' doc(s) from remote storage.', 'ok');
+  });
+  syncBatchUi();
 })();
 </script>
 </body></html>`;

--- a/worker/worker.js
+++ b/worker/worker.js
@@ -1148,9 +1148,9 @@ ${rows.length === 0 ? '<p class="empty">No published docs yet.</p>' :
     requestAnimationFrame(() => t.classList.add('is-in'));
     toastTimer = setTimeout(() => {
       t.classList.remove('is-in');
-      setTimeout(() => t.remove(), 200);
+      setTimeout(() => t.remove(), 220);
       toastTimer = null;
-    }, 1800);
+    }, 2600);
   }
   // Styled confirm — replaces window.confirm(). Resolves true/false; never
   // silently proceeds (Cancel and the backdrop both resolve false).

--- a/worker/worker.js
+++ b/worker/worker.js
@@ -1096,9 +1096,18 @@ async function indexHtml(env, session) {
   .row-menu[hidden] { display: none; }
   .row-delete { display: block; width: 100%; text-align: left; border: none; background: none; color: var(--td-danger); padding: 8px 12px; border-radius: 6px; white-space: nowrap; }
   .row-delete:hover { background: var(--td-danger-tint); }
-  .status { min-height: 20px; margin: 0 0 16px; color: var(--td-muted); font-size: 13px; }
-  .status[data-kind="error"] { color: var(--td-danger); }
-  .status[data-kind="ok"] { color: var(--td-ok); }
+  /* Floating toast — replaces the old inline status line. Same spirit as
+     overlay flashToast; kept inline because /me does not load overlay.js. */
+  .tdoc-toast {
+    position: fixed; left: 50%; bottom: 28px; z-index: 1100;
+    transform: translateX(-50%) translateY(10px); opacity: 0;
+    transition: opacity .18s ease, transform .18s ease;
+    background: #111; color: #fff; padding: 10px 16px; border-radius: 10px;
+    font: 13px/1.35 system-ui, -apple-system, sans-serif;
+    box-shadow: 0 10px 28px rgba(0,0,0,0.22); pointer-events: none;
+  }
+  .tdoc-toast.is-in { opacity: 0.96; transform: translateX(-50%) translateY(0); }
+  .tdoc-toast-error { background: var(--td-danger); }
   /* Styled confirm modal — replaces window.confirm() (JUL-36). Matches the
      doc overlay's .tdoc-modal-bg/.tdoc-modal visual language; kept as a
      standalone copy here since /me does not load overlay.js. */
@@ -1106,7 +1115,6 @@ async function indexHtml(env, session) {
   .tdoc-modal { background: #fff; color: var(--td-ink); border-radius: 12px; padding: 26px; width: 420px; max-width: calc(100vw - 32px); box-shadow: 0 20px 60px rgba(0,0,0,0.3); }
   .tdoc-modal h3 { margin: 0 0 10px; font-size: 18px; }
   .tdoc-modal p { margin: 0 0 14px; color: #444; line-height: 1.5; }
-  .tdoc-modal .status { color: #888; font-size: 13px; margin: 0 0 8px; }
   .tdoc-modal .actions { display: flex; gap: 8px; justify-content: flex-end; margin-top: 6px; }
   .tdoc-modal button { padding: 8px 16px; border-radius: 6px; border: 1px solid #ccc; background: #fff; }
   .tdoc-modal button.danger { background: var(--td-danger); border-color: var(--td-danger); color: #fff; }
@@ -1114,7 +1122,6 @@ async function indexHtml(env, session) {
 </style></head><body>
 <h1>My docs</h1>
 <p class="who">${session && session.login ? `Signed in as <b>${escapeHtml(session.login)}</b>` : 'Your published docs'}.</p>
-<p id="status" class="status" aria-live="polite"></p>
 ${rows.length === 0 ? '<p class="empty">No published docs yet.</p>' :
   `<div class="toolbar">
     <input type="search" id="doc-search" placeholder="Search title or slug…" autocomplete="off" aria-label="Search docs">
@@ -1127,11 +1134,24 @@ ${rows.length === 0 ? '<p class="empty">No published docs yet.</p>' :
   <p id="no-match" class="empty" hidden>No matches.</p>`}
 <script>
 (() => {
-  const status = document.getElementById('status');
-  const say = (message, kind = '') => {
-    status.textContent = message || '';
-    status.dataset.kind = kind;
-  };
+  // Floating toast — quiet feedback, no inline status row eating layout.
+  let toastTimer = null;
+  function toast(message, kind = '') {
+    if (!message) return;
+    document.querySelectorAll('.tdoc-toast').forEach((n) => n.remove());
+    if (toastTimer) { clearTimeout(toastTimer); toastTimer = null; }
+    const t = document.createElement('div');
+    t.className = 'tdoc-toast' + (kind === 'error' ? ' tdoc-toast-error' : '');
+    t.setAttribute('role', 'status');
+    t.textContent = message;
+    document.body.appendChild(t);
+    requestAnimationFrame(() => t.classList.add('is-in'));
+    toastTimer = setTimeout(() => {
+      t.classList.remove('is-in');
+      setTimeout(() => t.remove(), 200);
+      toastTimer = null;
+    }, 1800);
+  }
   // Styled confirm — replaces window.confirm(). Resolves true/false; never
   // silently proceeds (Cancel and the backdrop both resolve false).
   function showConfirm({ title, body, confirmLabel, danger }) {
@@ -1209,12 +1229,12 @@ ${rows.length === 0 ? '<p class="empty">No published docs yet.</p>' :
       try {
         await deleteDoc(slug);
       } catch {
-        say("Couldn't delete.", 'error');
+        toast("Couldn't delete", 'error');
         return;
       }
       button.closest('.doc-row').remove();
       syncBatchUi();
-      say('Deleted.', 'ok');
+      toast('Deleted');
     });
   });
 
@@ -1323,9 +1343,9 @@ ${rows.length === 0 ? '<p class="empty">No published docs yet.</p>' :
     }
     batchDelete.disabled = false;
     applySearch();
-    if (failed && ok) say("Deleted " + ok + ". Couldn't delete " + failed + '.', 'error');
-    else if (failed) say("Couldn't delete.", 'error');
-    else say(ok === 1 ? 'Deleted.' : ('Deleted ' + ok + '.'), 'ok');
+    if (failed && ok) toast("Deleted " + ok + " · couldn't delete " + failed, 'error');
+    else if (failed) toast("Couldn't delete", 'error');
+    else toast('Deleted');
   });
   syncBatchUi();
 })();

--- a/worker/worker.js
+++ b/worker/worker.js
@@ -1096,9 +1096,6 @@ async function indexHtml(env, session) {
   .row-menu[hidden] { display: none; }
   .row-delete { display: block; width: 100%; text-align: left; border: none; background: none; color: var(--td-danger); padding: 8px 12px; border-radius: 6px; white-space: nowrap; }
   .row-delete:hover { background: var(--td-danger-tint); }
-  /* Toastify skin — override the library's default purple gradient with
-     tdoc accent / danger. Library CSS still owns layout + animation. */
-  .toastify.tdoc-toast { box-shadow: 0 8px 24px rgba(0,0,0,0.14); border-radius: 8px; font: 500 14px/1.35 system-ui, -apple-system, sans-serif; padding: 12px 18px; }
   /* Styled confirm modal — replaces window.confirm() (JUL-36). Matches the
      doc overlay's .tdoc-modal-bg/.tdoc-modal visual language; kept as a
      standalone copy here since /me does not load overlay.js. */
@@ -1128,19 +1125,26 @@ ${rows.length === 0 ? '<p class="empty">No published docs yet.</p>' :
 <script src="https://cdn.jsdelivr.net/npm/toastify-js@1.12.0/src/toastify.min.js"></script>
 <script>
 (() => {
-  // toastify-js (CDN) — /me has no CSP, so the library can load. Skin via
-  // className + style; never the stock purple gradient.
+  // toastify-js (CDN) — /me has no CSP, so the library can load. Use the
+  // library's own layout/animation (top-right, rounded, close). Only swap
+  // the stock purple gradient for tdoc accent / danger.
   function toast(message, kind = '') {
     if (!message || typeof Toastify !== 'function') return;
     Toastify({
       text: message,
-      duration: 4500,
+      duration: 4000,
       gravity: 'top',
-      position: 'center',
+      position: 'right',
       stopOnFocus: true,
-      className: 'tdoc-toast',
+      close: true,
       style: {
-        background: kind === 'error' ? '#b42318' : '#1652f0',
+        background: kind === 'error'
+          ? 'linear-gradient(135deg, #b42318, #931c14)'
+          : 'linear-gradient(135deg, #1652f0, #1245d0)',
+        borderRadius: '8px',
+        fontFamily: 'system-ui, -apple-system, sans-serif',
+        fontSize: '14px',
+        boxShadow: '0 3px 6px -1px rgba(0,0,0,.12), 0 10px 28px -4px rgba(22,82,240,.35)',
       },
     }).showToast();
   }

--- a/worker/worker.js
+++ b/worker/worker.js
@@ -1096,20 +1096,9 @@ async function indexHtml(env, session) {
   .row-menu[hidden] { display: none; }
   .row-delete { display: block; width: 100%; text-align: left; border: none; background: none; color: var(--td-danger); padding: 8px 12px; border-radius: 6px; white-space: nowrap; }
   .row-delete:hover { background: var(--td-danger-tint); }
-  /* Floating toast — top-center so it stays in the content viewport
-     (bottom placement sat under the OS dock / recording crop). */
-  .tdoc-toast {
-    position: fixed; left: 50%; top: 72px; z-index: 2000;
-    transform: translateX(-50%) translateY(-8px); opacity: 0;
-    transition: opacity .2s ease, transform .2s ease;
-    background: #111; color: #fff; padding: 12px 20px; border-radius: 10px;
-    font: 14px/1.35 system-ui, -apple-system, sans-serif; font-weight: 500;
-    letter-spacing: 0.01em;
-    box-shadow: 0 12px 32px rgba(0,0,0,0.28); pointer-events: none;
-    min-width: 120px; text-align: center;
-  }
-  .tdoc-toast.is-in { opacity: 1; transform: translateX(-50%) translateY(0); }
-  .tdoc-toast-error { background: var(--td-danger); }
+  /* Toastify skin — override the library's default purple gradient with
+     tdoc accent / danger. Library CSS still owns layout + animation. */
+  .toastify.tdoc-toast { box-shadow: 0 8px 24px rgba(0,0,0,0.14); border-radius: 8px; font: 500 14px/1.35 system-ui, -apple-system, sans-serif; padding: 12px 18px; }
   /* Styled confirm modal — replaces window.confirm() (JUL-36). Matches the
      doc overlay's .tdoc-modal-bg/.tdoc-modal visual language; kept as a
      standalone copy here since /me does not load overlay.js. */
@@ -1121,7 +1110,9 @@ async function indexHtml(env, session) {
   .tdoc-modal button { padding: 8px 16px; border-radius: 6px; border: 1px solid #ccc; background: #fff; }
   .tdoc-modal button.danger { background: var(--td-danger); border-color: var(--td-danger); color: #fff; }
   .tdoc-modal button.danger:hover { background: var(--td-danger-hover); border-color: var(--td-danger-hover); }
-</style></head><body>
+</style>
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/toastify-js@1.12.0/src/toastify.min.css">
+</head><body>
 <h1>My docs</h1>
 <p class="who">${session && session.login ? `Signed in as <b>${escapeHtml(session.login)}</b>` : 'Your published docs'}.</p>
 ${rows.length === 0 ? '<p class="empty">No published docs yet.</p>' :
@@ -1134,28 +1125,24 @@ ${rows.length === 0 ? '<p class="empty">No published docs yet.</p>' :
   </div>
   <div class="doc-list">${rows.join('')}</div>
   <p id="no-match" class="empty" hidden>No matches.</p>`}
+<script src="https://cdn.jsdelivr.net/npm/toastify-js@1.12.0/src/toastify.min.js"></script>
 <script>
 (() => {
-  // Floating toast — top-center, forced reflow so the fade-in actually paints.
-  let toastTimer = null;
+  // toastify-js (CDN) — /me has no CSP, so the library can load. Skin via
+  // className + style; never the stock purple gradient.
   function toast(message, kind = '') {
-    if (!message) return;
-    document.querySelectorAll('.tdoc-toast').forEach((n) => n.remove());
-    if (toastTimer) { clearTimeout(toastTimer); toastTimer = null; }
-    const t = document.createElement('div');
-    t.className = 'tdoc-toast' + (kind === 'error' ? ' tdoc-toast-error' : '');
-    t.setAttribute('role', 'status');
-    t.textContent = message;
-    document.body.appendChild(t);
-    // Double rAF: first paint at opacity 0, then add .is-in so the transition runs.
-    requestAnimationFrame(() => {
-      requestAnimationFrame(() => { t.classList.add('is-in'); });
-    });
-    toastTimer = setTimeout(() => {
-      t.classList.remove('is-in');
-      setTimeout(() => t.remove(), 250);
-      toastTimer = null;
-    }, 3200);
+    if (!message || typeof Toastify !== 'function') return;
+    Toastify({
+      text: message,
+      duration: 3000,
+      gravity: 'top',
+      position: 'center',
+      stopOnFocus: true,
+      className: 'tdoc-toast',
+      style: {
+        background: kind === 'error' ? '#b42318' : '#1652f0',
+      },
+    }).showToast();
   }
   // Styled confirm — replaces window.confirm(). Resolves true/false; never
   // silently proceeds (Cancel and the backdrop both resolve false).

--- a/worker/worker.js
+++ b/worker/worker.js
@@ -1134,7 +1134,7 @@ ${rows.length === 0 ? '<p class="empty">No published docs yet.</p>' :
     if (!message || typeof Toastify !== 'function') return;
     Toastify({
       text: message,
-      duration: 3000,
+      duration: 4500,
       gravity: 'top',
       position: 'center',
       stopOnFocus: true,

--- a/worker/worker.js
+++ b/worker/worker.js
@@ -15,10 +15,6 @@
 
 const OVERLAY_JS = `__TDOC_OVERLAY_JS__`;
 
-// Vendored toastify-js@1.12.0 (MIT) — inlined so /me does not load a
-// third-party CDN on the owner session surface (Copilot review).
-const TOASTIFY_CSS = "/*! toastify-js 1.12.0 | MIT */\n/*!\n * Toastify js 1.12.0\n * https://github.com/apvarun/toastify-js\n * @license MIT licensed\n *\n * Copyright (C) 2018 Varun A P\n */\n.toastify{padding:12px 20px;color:#fff;display:inline-block;box-shadow:0 3px 6px -1px rgba(0,0,0,.12),0 10px 36px -4px rgba(77,96,232,.3);background:-webkit-linear-gradient(315deg,#73a5ff,#5477f5);background:linear-gradient(135deg,#73a5ff,#5477f5);position:fixed;opacity:0;transition:all .4s cubic-bezier(.215, .61, .355, 1);border-radius:2px;cursor:pointer;text-decoration:none;max-width:calc(50% - 20px);z-index:2147483647}.toastify.on{opacity:1}.toast-close{background:0 0;border:0;color:#fff;cursor:pointer;font-family:inherit;font-size:1em;opacity:.4;padding:0 5px}.toastify-right{right:15px}.toastify-left{left:15px}.toastify-top{top:-150px}.toastify-bottom{bottom:-150px}.toastify-rounded{border-radius:25px}.toastify-avatar{width:1.5em;height:1.5em;margin:-7px 5px;border-radius:2px}.toastify-center{margin-left:auto;margin-right:auto;left:0;right:0;max-width:fit-content;max-width:-moz-fit-content}@media only screen and (max-width:360px){.toastify-left,.toastify-right{margin-left:auto;margin-right:auto;left:0;right:0;max-width:fit-content}}\n/*# sourceMappingURL=/sm/cb4335d1b03e933ed85cb59fffa60cf51f07567ed09831438c60f59afd166464.map */";
-const TOASTIFY_JS = "/*! toastify-js 1.12.0 | MIT | https://github.com/apvarun/toastify-js */\n/*!\n * Toastify js 1.12.0\n * https://github.com/apvarun/toastify-js\n * @license MIT licensed\n *\n * Copyright (C) 2018 Varun A P\n */\n!function(t,o){\"object\"==typeof module&&module.exports?module.exports=o():t.Toastify=o()}(this,(function(t){var o=function(t){return new o.lib.init(t)};function i(t,o){return o.offset[t]?isNaN(o.offset[t])?o.offset[t]:o.offset[t]+\"px\":\"0px\"}function s(t,o){return!(!t||\"string\"!=typeof o)&&!!(t.className&&t.className.trim().split(/\\s+/gi).indexOf(o)>-1)}return o.defaults={oldestFirst:!0,text:\"Toastify is awesome!\",node:void 0,duration:3e3,selector:void 0,callback:function(){},destination:void 0,newWindow:!1,close:!1,gravity:\"toastify-top\",positionLeft:!1,position:\"\",backgroundColor:\"\",avatar:\"\",className:\"\",stopOnFocus:!0,onClick:function(){},offset:{x:0,y:0},escapeMarkup:!0,ariaLive:\"polite\",style:{background:\"\"}},o.lib=o.prototype={toastify:\"1.12.0\",constructor:o,init:function(t){return t||(t={}),this.options={},this.toastElement=null,this.options.text=t.text||o.defaults.text,this.options.node=t.node||o.defaults.node,this.options.duration=0===t.duration?0:t.duration||o.defaults.duration,this.options.selector=t.selector||o.defaults.selector,this.options.callback=t.callback||o.defaults.callback,this.options.destination=t.destination||o.defaults.destination,this.options.newWindow=t.newWindow||o.defaults.newWindow,this.options.close=t.close||o.defaults.close,this.options.gravity=\"bottom\"===t.gravity?\"toastify-bottom\":o.defaults.gravity,this.options.positionLeft=t.positionLeft||o.defaults.positionLeft,this.options.position=t.position||o.defaults.position,this.options.backgroundColor=t.backgroundColor||o.defaults.backgroundColor,this.options.avatar=t.avatar||o.defaults.avatar,this.options.className=t.className||o.defaults.className,this.options.stopOnFocus=void 0===t.stopOnFocus?o.defaults.stopOnFocus:t.stopOnFocus,this.options.onClick=t.onClick||o.defaults.onClick,this.options.offset=t.offset||o.defaults.offset,this.options.escapeMarkup=void 0!==t.escapeMarkup?t.escapeMarkup:o.defaults.escapeMarkup,this.options.ariaLive=t.ariaLive||o.defaults.ariaLive,this.options.style=t.style||o.defaults.style,t.backgroundColor&&(this.options.style.background=t.backgroundColor),this},buildToast:function(){if(!this.options)throw\"Toastify is not initialized\";var t=document.createElement(\"div\");for(var o in t.className=\"toastify on \"+this.options.className,this.options.position?t.className+=\" toastify-\"+this.options.position:!0===this.options.positionLeft?(t.className+=\" toastify-left\",console.warn(\"Property `positionLeft` will be depreciated in further versions. Please use `position` instead.\")):t.className+=\" toastify-right\",t.className+=\" \"+this.options.gravity,this.options.backgroundColor&&console.warn('DEPRECATION NOTICE: \"backgroundColor\" is being deprecated. Please use the \"style.background\" property.'),this.options.style)t.style[o]=this.options.style[o];if(this.options.ariaLive&&t.setAttribute(\"aria-live\",this.options.ariaLive),this.options.node&&this.options.node.nodeType===Node.ELEMENT_NODE)t.appendChild(this.options.node);else if(this.options.escapeMarkup?t.innerText=this.options.text:t.innerHTML=this.options.text,\"\"!==this.options.avatar){var s=document.createElement(\"img\");s.src=this.options.avatar,s.className=\"toastify-avatar\",\"left\"==this.options.position||!0===this.options.positionLeft?t.appendChild(s):t.insertAdjacentElement(\"afterbegin\",s)}if(!0===this.options.close){var e=document.createElement(\"button\");e.type=\"button\",e.setAttribute(\"aria-label\",\"Close\"),e.className=\"toast-close\",e.innerHTML=\"&#10006;\",e.addEventListener(\"click\",function(t){t.stopPropagation(),this.removeElement(this.toastElement),window.clearTimeout(this.toastElement.timeOutValue)}.bind(this));var n=window.innerWidth>0?window.innerWidth:screen.width;(\"left\"==this.options.position||!0===this.options.positionLeft)&&n>360?t.insertAdjacentElement(\"afterbegin\",e):t.appendChild(e)}if(this.options.stopOnFocus&&this.options.duration>0){var a=this;t.addEventListener(\"mouseover\",(function(o){window.clearTimeout(t.timeOutValue)})),t.addEventListener(\"mouseleave\",(function(){t.timeOutValue=window.setTimeout((function(){a.removeElement(t)}),a.options.duration)}))}if(void 0!==this.options.destination&&t.addEventListener(\"click\",function(t){t.stopPropagation(),!0===this.options.newWindow?window.open(this.options.destination,\"_blank\"):window.location=this.options.destination}.bind(this)),\"function\"==typeof this.options.onClick&&void 0===this.options.destination&&t.addEventListener(\"click\",function(t){t.stopPropagation(),this.options.onClick()}.bind(this)),\"object\"==typeof this.options.offset){var l=i(\"x\",this.options),r=i(\"y\",this.options),p=\"left\"==this.options.position?l:\"-\"+l,d=\"toastify-top\"==this.options.gravity?r:\"-\"+r;t.style.transform=\"translate(\"+p+\",\"+d+\")\"}return t},showToast:function(){var t;if(this.toastElement=this.buildToast(),!(t=\"string\"==typeof this.options.selector?document.getElementById(this.options.selector):this.options.selector instanceof HTMLElement||\"undefined\"!=typeof ShadowRoot&&this.options.selector instanceof ShadowRoot?this.options.selector:document.body))throw\"Root element is not defined\";var i=o.defaults.oldestFirst?t.firstChild:t.lastChild;return t.insertBefore(this.toastElement,i),o.reposition(),this.options.duration>0&&(this.toastElement.timeOutValue=window.setTimeout(function(){this.removeElement(this.toastElement)}.bind(this),this.options.duration)),this},hideToast:function(){this.toastElement.timeOutValue&&clearTimeout(this.toastElement.timeOutValue),this.removeElement(this.toastElement)},removeElement:function(t){t.className=t.className.replace(\" on\",\"\"),window.setTimeout(function(){this.options.node&&this.options.node.parentNode&&this.options.node.parentNode.removeChild(this.options.node),t.parentNode&&t.parentNode.removeChild(t),this.options.callback.call(t),o.reposition()}.bind(this),400)}},o.reposition=function(){for(var t,o={top:15,bottom:15},i={top:15,bottom:15},e={top:15,bottom:15},n=document.getElementsByClassName(\"toastify\"),a=0;a<n.length;a++){t=!0===s(n[a],\"toastify-top\")?\"toastify-top\":\"toastify-bottom\";var l=n[a].offsetHeight;t=t.substr(9,t.length-1);(window.innerWidth>0?window.innerWidth:screen.width)<=360?(n[a].style[t]=e[t]+\"px\",e[t]+=l+15):!0===s(n[a],\"toastify-left\")?(n[a].style[t]=o[t]+\"px\",o[t]+=l+15):(n[a].style[t]=i[t]+\"px\",i[t]+=l+15)}return this},o.lib.init.prototype=o.lib,o}));\n//# sourceMappingURL=/sm/e1ebbfe1bf0b0061f0726ebc83434e1c2f8308e6354c415fd05ecccdaad47617.map";
 
 const TDOC_BUILD_INFO = "__TDOC_BUILD_INFO__";
 
@@ -1058,7 +1054,7 @@ async function indexHtml(env, session) {
       </div>
     </div>`);
 
-  return `<!doctype html><html><head><meta charset="utf-8"><title>tdoc</title>
+  return `<!doctype html><html><head><meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1"><title>tdoc</title>
 <style>
   :root {
     --td-accent: #1652f0; --td-accent-hover: #1245d0; --td-accent-tint: #e8eeff;
@@ -1112,7 +1108,6 @@ async function indexHtml(env, session) {
   .tdoc-modal button { padding: 8px 16px; border-radius: 6px; border: 1px solid #ccc; background: #fff; }
   .tdoc-modal button.danger { background: var(--td-danger); border-color: var(--td-danger); color: #fff; }
   .tdoc-modal button.danger:hover { background: var(--td-danger-hover); border-color: var(--td-danger-hover); }
-${TOASTIFY_CSS}
 </style>
 </head><body>
 <h1>My docs</h1>
@@ -1127,36 +1122,14 @@ ${rows.length === 0 ? '<p class="empty">No published docs yet.</p>' :
   </div>
   <div class="doc-list">${rows.join('')}</div>
   <p id="no-match" class="empty" hidden>No matches.</p>`}
-<script>${TOASTIFY_JS}</script>
 <script>
 (() => {
-  // toastify-js@1.12.0 vendored above (not CDN) — keeps the owner /me session
-  // surface free of third-party script loads. Library owns layout/animation;
-  // only the purple default gradient is swapped for tdoc accent / danger.
+  // Tiny top-right toast — no third-party runtime on the privileged /me page.
   function toast(message, kind = '') {
     if (!message) return;
-    if (typeof Toastify === 'function') {
-      Toastify({
-        text: message,
-        duration: 4000,
-        gravity: 'top',
-        position: 'right',
-        stopOnFocus: true,
-        close: true,
-        style: {
-          background: kind === 'error'
-            ? 'linear-gradient(135deg, #b42318, #931c14)'
-            : 'linear-gradient(135deg, #1652f0, #1245d0)',
-          borderRadius: '8px',
-          fontFamily: 'system-ui, -apple-system, sans-serif',
-          fontSize: '14px',
-          boxShadow: '0 3px 6px -1px rgba(0,0,0,.12), 0 10px 28px -4px rgba(22,82,240,.35)',
-        },
-      }).showToast();
-      return;
-    }
-    // Quiet fallback if the vendored script somehow fails to define Toastify.
+    document.querySelectorAll('.tdoc-toast').forEach((n) => n.remove());
     const t = document.createElement('div');
+    t.className = 'tdoc-toast';
     t.textContent = message;
     t.setAttribute('role', 'status');
     t.style.cssText = 'position:fixed;top:18px;right:18px;z-index:2000;background:' +

--- a/worker/worker.js
+++ b/worker/worker.js
@@ -1015,10 +1015,9 @@ function landingHtml() {
 async function indexHtml(env, session) {
   // Catalog is title/slug/version from KV meta only. Do NOT HEAD R2 or fold
   // comment logs here — that was N serial Durable-Object + R2 round trips
-  // per page load (the HTML bodies were never downloaded, but the comment
-  // event log for every slug was). Comment counts for the delete confirm
-  // load lazily on click via GET /api/comments. Search + batch select are
-  // client-side over the rendered rows (no extra KV/R2 work).
+  // per page load. Search + batch select are client-side over the rendered
+  // rows (no extra KV/R2 work). Delete confirm is immediate (no comment
+  // pre-flight) so the catalog stays snappy.
   let list = [];
   let cursor;
   do {
@@ -1114,7 +1113,7 @@ async function indexHtml(env, session) {
   .tdoc-modal button.danger:hover { background: var(--td-danger-hover); border-color: var(--td-danger-hover); }
 </style></head><body>
 <h1>My docs</h1>
-<p class="who">Documents hosted on this worker${session && session.login ? ` · signed in as <b>${escapeHtml(session.login)}</b>` : ''}.</p>
+<p class="who">${session && session.login ? `Signed in as <b>${escapeHtml(session.login)}</b>` : 'Your published docs'}.</p>
 <p id="status" class="status" aria-live="polite"></p>
 ${rows.length === 0 ? '<p class="empty">No published docs yet.</p>' :
   `<div class="toolbar">
@@ -1125,7 +1124,7 @@ ${rows.length === 0 ? '<p class="empty">No published docs yet.</p>' :
     <button type="button" id="batch-delete" class="batch-delete">Delete selected</button>
   </div>
   <div class="doc-list">${rows.join('')}</div>
-  <p id="no-match" class="empty" hidden>No docs match that search.</p>`}
+  <p id="no-match" class="empty" hidden>No matches.</p>`}
 <script>
 (() => {
   const status = document.getElementById('status');
@@ -1182,17 +1181,8 @@ ${rows.length === 0 ? '<p class="empty">No published docs yet.</p>' :
   // page 302s away for anyone else), so the session cookie alone authorizes
   // DELETE /api/doc (authorizeOwnerMutation in worker.js). Plain same-origin
   // fetch sends the cookie automatically; no Authorization header needed.
-  async function countComments(slug) {
-    try {
-      const r = await fetch('/api/comments?slug=' + encodeURIComponent(slug) + '&version=all', { credentials: 'same-origin' });
-      if (!r.ok) return 0;
-      const list = await r.json();
-      if (!Array.isArray(list)) return 0;
-      let n = 0;
-      for (const c of list) n += 1 + (Array.isArray(c.replies) ? c.replies.length : 0);
-      return n;
-    } catch { return 0; }
-  }
+  // Confirm copy stays quiet ("This can't be undone.") — no version/comment
+  // inventory, no infra jargon, no pre-flight comment fetch.
   async function deleteDoc(slug) {
     const res = await fetch('/api/doc?slug=' + encodeURIComponent(slug), {
       method: 'DELETE',
@@ -1209,28 +1199,22 @@ ${rows.length === 0 ? '<p class="empty">No published docs yet.</p>' :
       closeMenus(null);
       const slug = button.dataset.slug;
       const title = button.dataset.title || slug;
-      const versions = button.dataset.versions || '1';
-      say('Checking ' + slug + '…');
-      const comments = await countComments(slug);
-      say('');
       const proceed = await showConfirm({
         title: 'Delete "' + title + '"?',
-        body: 'This permanently removes <b>' + versions + ' version(s)</b> and <b>' + comments +
-          ' comment(s)</b> from remote storage. No undo.',
+        body: "This can't be undone.",
         confirmLabel: 'Delete',
         danger: true,
       });
       if (!proceed) return;
-      say('Deleting ' + slug + '...');
       try {
         await deleteDoc(slug);
-      } catch (err) {
-        say('Delete failed: ' + (err && err.message ? err.message : 'unknown'), 'error');
+      } catch {
+        say("Couldn't delete.", 'error');
         return;
       }
       button.closest('.doc-row').remove();
       syncBatchUi();
-      say('Deleted ' + slug + ' from remote storage.', 'ok');
+      say('Deleted.', 'ok');
     });
   });
 
@@ -1263,7 +1247,7 @@ ${rows.length === 0 ? '<p class="empty">No published docs yet.</p>' :
       if (!(box && box.checked)) row.classList.remove('is-selected');
     });
     batchDelete.classList.toggle('is-visible', n > 0);
-    batchDelete.textContent = n === 1 ? 'Delete 1 selected' : ('Delete ' + n + ' selected');
+    batchDelete.textContent = n <= 1 ? 'Delete' : ('Delete ' + n);
     const allVisibleChecked = visible.length > 0 && visible.every((row) => {
       const box = row.querySelector('.doc-check');
       return box && box.checked;
@@ -1317,15 +1301,11 @@ ${rows.length === 0 ? '<p class="empty">No published docs yet.</p>' :
   batchDelete.addEventListener('click', async () => {
     const rows = selectedRows();
     if (!rows.length) return;
-    const versions = rows.reduce((sum, row) => sum + (Number(row.dataset.versions) || 1), 0);
-    say('Checking ' + rows.length + ' doc(s)…');
-    const counts = await Promise.all(rows.map((row) => countComments(row.dataset.slug)));
-    const comments = counts.reduce((a, b) => a + b, 0);
-    say('');
     const proceed = await showConfirm({
-      title: rows.length === 1 ? ('Delete "' + (rows[0].dataset.title || rows[0].dataset.slug) + '"?') : ('Delete ' + rows.length + ' docs?'),
-      body: 'This permanently removes <b>' + rows.length + ' doc(s)</b>, <b>' + versions +
-        ' version(s)</b>, and <b>' + comments + ' comment(s)</b> from remote storage. No undo.',
+      title: rows.length === 1
+        ? ('Delete "' + (rows[0].dataset.title || rows[0].dataset.slug) + '"?')
+        : ('Delete ' + rows.length + ' docs?'),
+      body: "This can't be undone.",
       confirmLabel: rows.length === 1 ? 'Delete' : ('Delete ' + rows.length),
       danger: true,
     });
@@ -1333,10 +1313,8 @@ ${rows.length === 0 ? '<p class="empty">No published docs yet.</p>' :
     batchDelete.disabled = true;
     let ok = 0, failed = 0;
     for (const row of rows) {
-      const slug = row.dataset.slug;
-      say('Deleting ' + slug + '…');
       try {
-        await deleteDoc(slug);
+        await deleteDoc(row.dataset.slug);
         row.remove();
         ok += 1;
       } catch {
@@ -1345,8 +1323,9 @@ ${rows.length === 0 ? '<p class="empty">No published docs yet.</p>' :
     }
     batchDelete.disabled = false;
     applySearch();
-    if (failed) say('Deleted ' + ok + '; ' + failed + ' failed.', 'error');
-    else say('Deleted ' + ok + ' doc(s) from remote storage.', 'ok');
+    if (failed && ok) say("Deleted " + ok + ". Couldn't delete " + failed + '.', 'error');
+    else if (failed) say("Couldn't delete.", 'error');
+    else say(ok === 1 ? 'Deleted.' : ('Deleted ' + ok + '.'), 'ok');
   });
   syncBatchUi();
 })();

--- a/worker/worker.js
+++ b/worker/worker.js
@@ -14,6 +14,12 @@
 // overlay/provenance would be missing.
 
 const OVERLAY_JS = `__TDOC_OVERLAY_JS__`;
+
+// Vendored toastify-js@1.12.0 (MIT) — inlined so /me does not load a
+// third-party CDN on the owner session surface (Copilot review).
+const TOASTIFY_CSS = "/*! toastify-js 1.12.0 | MIT */\n/*!\n * Toastify js 1.12.0\n * https://github.com/apvarun/toastify-js\n * @license MIT licensed\n *\n * Copyright (C) 2018 Varun A P\n */\n.toastify{padding:12px 20px;color:#fff;display:inline-block;box-shadow:0 3px 6px -1px rgba(0,0,0,.12),0 10px 36px -4px rgba(77,96,232,.3);background:-webkit-linear-gradient(315deg,#73a5ff,#5477f5);background:linear-gradient(135deg,#73a5ff,#5477f5);position:fixed;opacity:0;transition:all .4s cubic-bezier(.215, .61, .355, 1);border-radius:2px;cursor:pointer;text-decoration:none;max-width:calc(50% - 20px);z-index:2147483647}.toastify.on{opacity:1}.toast-close{background:0 0;border:0;color:#fff;cursor:pointer;font-family:inherit;font-size:1em;opacity:.4;padding:0 5px}.toastify-right{right:15px}.toastify-left{left:15px}.toastify-top{top:-150px}.toastify-bottom{bottom:-150px}.toastify-rounded{border-radius:25px}.toastify-avatar{width:1.5em;height:1.5em;margin:-7px 5px;border-radius:2px}.toastify-center{margin-left:auto;margin-right:auto;left:0;right:0;max-width:fit-content;max-width:-moz-fit-content}@media only screen and (max-width:360px){.toastify-left,.toastify-right{margin-left:auto;margin-right:auto;left:0;right:0;max-width:fit-content}}\n/*# sourceMappingURL=/sm/cb4335d1b03e933ed85cb59fffa60cf51f07567ed09831438c60f59afd166464.map */";
+const TOASTIFY_JS = "/*! toastify-js 1.12.0 | MIT | https://github.com/apvarun/toastify-js */\n/*!\n * Toastify js 1.12.0\n * https://github.com/apvarun/toastify-js\n * @license MIT licensed\n *\n * Copyright (C) 2018 Varun A P\n */\n!function(t,o){\"object\"==typeof module&&module.exports?module.exports=o():t.Toastify=o()}(this,(function(t){var o=function(t){return new o.lib.init(t)};function i(t,o){return o.offset[t]?isNaN(o.offset[t])?o.offset[t]:o.offset[t]+\"px\":\"0px\"}function s(t,o){return!(!t||\"string\"!=typeof o)&&!!(t.className&&t.className.trim().split(/\\s+/gi).indexOf(o)>-1)}return o.defaults={oldestFirst:!0,text:\"Toastify is awesome!\",node:void 0,duration:3e3,selector:void 0,callback:function(){},destination:void 0,newWindow:!1,close:!1,gravity:\"toastify-top\",positionLeft:!1,position:\"\",backgroundColor:\"\",avatar:\"\",className:\"\",stopOnFocus:!0,onClick:function(){},offset:{x:0,y:0},escapeMarkup:!0,ariaLive:\"polite\",style:{background:\"\"}},o.lib=o.prototype={toastify:\"1.12.0\",constructor:o,init:function(t){return t||(t={}),this.options={},this.toastElement=null,this.options.text=t.text||o.defaults.text,this.options.node=t.node||o.defaults.node,this.options.duration=0===t.duration?0:t.duration||o.defaults.duration,this.options.selector=t.selector||o.defaults.selector,this.options.callback=t.callback||o.defaults.callback,this.options.destination=t.destination||o.defaults.destination,this.options.newWindow=t.newWindow||o.defaults.newWindow,this.options.close=t.close||o.defaults.close,this.options.gravity=\"bottom\"===t.gravity?\"toastify-bottom\":o.defaults.gravity,this.options.positionLeft=t.positionLeft||o.defaults.positionLeft,this.options.position=t.position||o.defaults.position,this.options.backgroundColor=t.backgroundColor||o.defaults.backgroundColor,this.options.avatar=t.avatar||o.defaults.avatar,this.options.className=t.className||o.defaults.className,this.options.stopOnFocus=void 0===t.stopOnFocus?o.defaults.stopOnFocus:t.stopOnFocus,this.options.onClick=t.onClick||o.defaults.onClick,this.options.offset=t.offset||o.defaults.offset,this.options.escapeMarkup=void 0!==t.escapeMarkup?t.escapeMarkup:o.defaults.escapeMarkup,this.options.ariaLive=t.ariaLive||o.defaults.ariaLive,this.options.style=t.style||o.defaults.style,t.backgroundColor&&(this.options.style.background=t.backgroundColor),this},buildToast:function(){if(!this.options)throw\"Toastify is not initialized\";var t=document.createElement(\"div\");for(var o in t.className=\"toastify on \"+this.options.className,this.options.position?t.className+=\" toastify-\"+this.options.position:!0===this.options.positionLeft?(t.className+=\" toastify-left\",console.warn(\"Property `positionLeft` will be depreciated in further versions. Please use `position` instead.\")):t.className+=\" toastify-right\",t.className+=\" \"+this.options.gravity,this.options.backgroundColor&&console.warn('DEPRECATION NOTICE: \"backgroundColor\" is being deprecated. Please use the \"style.background\" property.'),this.options.style)t.style[o]=this.options.style[o];if(this.options.ariaLive&&t.setAttribute(\"aria-live\",this.options.ariaLive),this.options.node&&this.options.node.nodeType===Node.ELEMENT_NODE)t.appendChild(this.options.node);else if(this.options.escapeMarkup?t.innerText=this.options.text:t.innerHTML=this.options.text,\"\"!==this.options.avatar){var s=document.createElement(\"img\");s.src=this.options.avatar,s.className=\"toastify-avatar\",\"left\"==this.options.position||!0===this.options.positionLeft?t.appendChild(s):t.insertAdjacentElement(\"afterbegin\",s)}if(!0===this.options.close){var e=document.createElement(\"button\");e.type=\"button\",e.setAttribute(\"aria-label\",\"Close\"),e.className=\"toast-close\",e.innerHTML=\"&#10006;\",e.addEventListener(\"click\",function(t){t.stopPropagation(),this.removeElement(this.toastElement),window.clearTimeout(this.toastElement.timeOutValue)}.bind(this));var n=window.innerWidth>0?window.innerWidth:screen.width;(\"left\"==this.options.position||!0===this.options.positionLeft)&&n>360?t.insertAdjacentElement(\"afterbegin\",e):t.appendChild(e)}if(this.options.stopOnFocus&&this.options.duration>0){var a=this;t.addEventListener(\"mouseover\",(function(o){window.clearTimeout(t.timeOutValue)})),t.addEventListener(\"mouseleave\",(function(){t.timeOutValue=window.setTimeout((function(){a.removeElement(t)}),a.options.duration)}))}if(void 0!==this.options.destination&&t.addEventListener(\"click\",function(t){t.stopPropagation(),!0===this.options.newWindow?window.open(this.options.destination,\"_blank\"):window.location=this.options.destination}.bind(this)),\"function\"==typeof this.options.onClick&&void 0===this.options.destination&&t.addEventListener(\"click\",function(t){t.stopPropagation(),this.options.onClick()}.bind(this)),\"object\"==typeof this.options.offset){var l=i(\"x\",this.options),r=i(\"y\",this.options),p=\"left\"==this.options.position?l:\"-\"+l,d=\"toastify-top\"==this.options.gravity?r:\"-\"+r;t.style.transform=\"translate(\"+p+\",\"+d+\")\"}return t},showToast:function(){var t;if(this.toastElement=this.buildToast(),!(t=\"string\"==typeof this.options.selector?document.getElementById(this.options.selector):this.options.selector instanceof HTMLElement||\"undefined\"!=typeof ShadowRoot&&this.options.selector instanceof ShadowRoot?this.options.selector:document.body))throw\"Root element is not defined\";var i=o.defaults.oldestFirst?t.firstChild:t.lastChild;return t.insertBefore(this.toastElement,i),o.reposition(),this.options.duration>0&&(this.toastElement.timeOutValue=window.setTimeout(function(){this.removeElement(this.toastElement)}.bind(this),this.options.duration)),this},hideToast:function(){this.toastElement.timeOutValue&&clearTimeout(this.toastElement.timeOutValue),this.removeElement(this.toastElement)},removeElement:function(t){t.className=t.className.replace(\" on\",\"\"),window.setTimeout(function(){this.options.node&&this.options.node.parentNode&&this.options.node.parentNode.removeChild(this.options.node),t.parentNode&&t.parentNode.removeChild(t),this.options.callback.call(t),o.reposition()}.bind(this),400)}},o.reposition=function(){for(var t,o={top:15,bottom:15},i={top:15,bottom:15},e={top:15,bottom:15},n=document.getElementsByClassName(\"toastify\"),a=0;a<n.length;a++){t=!0===s(n[a],\"toastify-top\")?\"toastify-top\":\"toastify-bottom\";var l=n[a].offsetHeight;t=t.substr(9,t.length-1);(window.innerWidth>0?window.innerWidth:screen.width)<=360?(n[a].style[t]=e[t]+\"px\",e[t]+=l+15):!0===s(n[a],\"toastify-left\")?(n[a].style[t]=o[t]+\"px\",o[t]+=l+15):(n[a].style[t]=i[t]+\"px\",i[t]+=l+15)}return this},o.lib.init.prototype=o.lib,o}));\n//# sourceMappingURL=/sm/e1ebbfe1bf0b0061f0726ebc83434e1c2f8308e6354c415fd05ecccdaad47617.map";
+
 const TDOC_BUILD_INFO = "__TDOC_BUILD_INFO__";
 
 const CORS = {
@@ -1033,11 +1039,10 @@ async function indexHtml(env, session) {
     let meta = {};
     try { meta = JSON.parse(metaRaw || '{}'); } catch {}
     const latest = meta.versions?.[meta.versions.length - 1]?.n || 1;
-    const versionCount = Array.isArray(meta.versions) && meta.versions.length ? meta.versions.length : 1;
-    return { slug, title: meta.title || slug, latest, versionCount };
+    return { slug, title: meta.title || slug, latest };
   }));
 
-  const rows = docs.map(({ slug, title, latest, versionCount }) => `<div class="doc-row" data-slug="${escapeHtml(slug)}" data-title="${escapeHtml(title)}" data-versions="${versionCount}">
+  const rows = docs.map(({ slug, title, latest }) => `<div class="doc-row" data-slug="${escapeHtml(slug)}" data-title="${escapeHtml(title)}">
       <label class="row-check">
         <input type="checkbox" class="doc-check" aria-label="Select ${escapeHtml(title)}">
       </label>
@@ -1048,7 +1053,7 @@ async function indexHtml(env, session) {
       <div class="row-actions">
         <button class="row-menu-btn" aria-label="More actions" aria-haspopup="true" aria-expanded="false">⋯</button>
         <div class="row-menu" hidden>
-          <button class="row-delete" data-slug="${escapeHtml(slug)}" data-title="${escapeHtml(title)}" data-versions="${versionCount}">Delete…</button>
+          <button class="row-delete" data-slug="${escapeHtml(slug)}" data-title="${escapeHtml(title)}">Delete…</button>
         </div>
       </div>
     </div>`);
@@ -1107,8 +1112,8 @@ async function indexHtml(env, session) {
   .tdoc-modal button { padding: 8px 16px; border-radius: 6px; border: 1px solid #ccc; background: #fff; }
   .tdoc-modal button.danger { background: var(--td-danger); border-color: var(--td-danger); color: #fff; }
   .tdoc-modal button.danger:hover { background: var(--td-danger-hover); border-color: var(--td-danger-hover); }
+${TOASTIFY_CSS}
 </style>
-<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/toastify-js@1.12.0/src/toastify.min.css">
 </head><body>
 <h1>My docs</h1>
 <p class="who">${session && session.login ? `Signed in as <b>${escapeHtml(session.login)}</b>` : 'Your published docs'}.</p>
@@ -1122,31 +1127,43 @@ ${rows.length === 0 ? '<p class="empty">No published docs yet.</p>' :
   </div>
   <div class="doc-list">${rows.join('')}</div>
   <p id="no-match" class="empty" hidden>No matches.</p>`}
-<script src="https://cdn.jsdelivr.net/npm/toastify-js@1.12.0/src/toastify.min.js"></script>
+<script>${TOASTIFY_JS}</script>
 <script>
 (() => {
-  // toastify-js (CDN) — /me has no CSP, so the library can load. Use the
-  // library's own layout/animation (top-right, rounded, close). Only swap
-  // the stock purple gradient for tdoc accent / danger.
+  // toastify-js@1.12.0 vendored above (not CDN) — keeps the owner /me session
+  // surface free of third-party script loads. Library owns layout/animation;
+  // only the purple default gradient is swapped for tdoc accent / danger.
   function toast(message, kind = '') {
-    if (!message || typeof Toastify !== 'function') return;
-    Toastify({
-      text: message,
-      duration: 4000,
-      gravity: 'top',
-      position: 'right',
-      stopOnFocus: true,
-      close: true,
-      style: {
-        background: kind === 'error'
-          ? 'linear-gradient(135deg, #b42318, #931c14)'
-          : 'linear-gradient(135deg, #1652f0, #1245d0)',
-        borderRadius: '8px',
-        fontFamily: 'system-ui, -apple-system, sans-serif',
-        fontSize: '14px',
-        boxShadow: '0 3px 6px -1px rgba(0,0,0,.12), 0 10px 28px -4px rgba(22,82,240,.35)',
-      },
-    }).showToast();
+    if (!message) return;
+    if (typeof Toastify === 'function') {
+      Toastify({
+        text: message,
+        duration: 4000,
+        gravity: 'top',
+        position: 'right',
+        stopOnFocus: true,
+        close: true,
+        style: {
+          background: kind === 'error'
+            ? 'linear-gradient(135deg, #b42318, #931c14)'
+            : 'linear-gradient(135deg, #1652f0, #1245d0)',
+          borderRadius: '8px',
+          fontFamily: 'system-ui, -apple-system, sans-serif',
+          fontSize: '14px',
+          boxShadow: '0 3px 6px -1px rgba(0,0,0,.12), 0 10px 28px -4px rgba(22,82,240,.35)',
+        },
+      }).showToast();
+      return;
+    }
+    // Quiet fallback if the vendored script somehow fails to define Toastify.
+    const t = document.createElement('div');
+    t.textContent = message;
+    t.setAttribute('role', 'status');
+    t.style.cssText = 'position:fixed;top:18px;right:18px;z-index:2000;background:' +
+      (kind === 'error' ? '#b42318' : '#1652f0') +
+      ';color:#fff;padding:12px 16px;border-radius:8px;font:14px system-ui,sans-serif;box-shadow:0 8px 24px rgba(0,0,0,.18)';
+    document.body.appendChild(t);
+    setTimeout(() => t.remove(), 4000);
   }
   // Styled confirm — replaces window.confirm(). Resolves true/false; never
   // silently proceeds (Cancel and the backdrop both resolve false).
@@ -1229,7 +1246,7 @@ ${rows.length === 0 ? '<p class="empty">No published docs yet.</p>' :
         return;
       }
       button.closest('.doc-row').remove();
-      syncBatchUi();
+      applySearch();
       toast('Deleted');
     });
   });

--- a/worker/worker.js
+++ b/worker/worker.js
@@ -1096,17 +1096,19 @@ async function indexHtml(env, session) {
   .row-menu[hidden] { display: none; }
   .row-delete { display: block; width: 100%; text-align: left; border: none; background: none; color: var(--td-danger); padding: 8px 12px; border-radius: 6px; white-space: nowrap; }
   .row-delete:hover { background: var(--td-danger-tint); }
-  /* Floating toast — replaces the old inline status line. Same spirit as
-     overlay flashToast; kept inline because /me does not load overlay.js. */
+  /* Floating toast — top-center so it stays in the content viewport
+     (bottom placement sat under the OS dock / recording crop). */
   .tdoc-toast {
-    position: fixed; left: 50%; bottom: 28px; z-index: 1100;
-    transform: translateX(-50%) translateY(10px); opacity: 0;
-    transition: opacity .18s ease, transform .18s ease;
-    background: #111; color: #fff; padding: 10px 16px; border-radius: 10px;
-    font: 13px/1.35 system-ui, -apple-system, sans-serif;
-    box-shadow: 0 10px 28px rgba(0,0,0,0.22); pointer-events: none;
+    position: fixed; left: 50%; top: 72px; z-index: 2000;
+    transform: translateX(-50%) translateY(-8px); opacity: 0;
+    transition: opacity .2s ease, transform .2s ease;
+    background: #111; color: #fff; padding: 12px 20px; border-radius: 10px;
+    font: 14px/1.35 system-ui, -apple-system, sans-serif; font-weight: 500;
+    letter-spacing: 0.01em;
+    box-shadow: 0 12px 32px rgba(0,0,0,0.28); pointer-events: none;
+    min-width: 120px; text-align: center;
   }
-  .tdoc-toast.is-in { opacity: 0.96; transform: translateX(-50%) translateY(0); }
+  .tdoc-toast.is-in { opacity: 1; transform: translateX(-50%) translateY(0); }
   .tdoc-toast-error { background: var(--td-danger); }
   /* Styled confirm modal — replaces window.confirm() (JUL-36). Matches the
      doc overlay's .tdoc-modal-bg/.tdoc-modal visual language; kept as a
@@ -1134,7 +1136,7 @@ ${rows.length === 0 ? '<p class="empty">No published docs yet.</p>' :
   <p id="no-match" class="empty" hidden>No matches.</p>`}
 <script>
 (() => {
-  // Floating toast — quiet feedback, no inline status row eating layout.
+  // Floating toast — top-center, forced reflow so the fade-in actually paints.
   let toastTimer = null;
   function toast(message, kind = '') {
     if (!message) return;
@@ -1145,12 +1147,15 @@ ${rows.length === 0 ? '<p class="empty">No published docs yet.</p>' :
     t.setAttribute('role', 'status');
     t.textContent = message;
     document.body.appendChild(t);
-    requestAnimationFrame(() => t.classList.add('is-in'));
+    // Double rAF: first paint at opacity 0, then add .is-in so the transition runs.
+    requestAnimationFrame(() => {
+      requestAnimationFrame(() => { t.classList.add('is-in'); });
+    });
     toastTimer = setTimeout(() => {
       t.classList.remove('is-in');
-      setTimeout(() => t.remove(), 220);
+      setTimeout(() => t.remove(), 250);
       toastTimer = null;
-    }, 2600);
+    }, 3200);
   }
   // Styled confirm — replaces window.confirm(). Resolves true/false; never
   // silently proceeds (Cancel and the backdrop both resolve false).

--- a/worker/worker.js
+++ b/worker/worker.js
@@ -1078,6 +1078,7 @@ async function indexHtml(env, session) {
   .batch-delete:hover { background: var(--td-danger); color: #fff; }
   .batch-delete:disabled { opacity: 0.5; cursor: default; }
   .doc-list { display: flex; flex-direction: column; }
+  .doc-list[hidden], .doc-row[hidden], .empty[hidden] { display: none !important; }
   .doc-row { display: flex; align-items: center; gap: 12px; padding: 13px 4px; border-bottom: 1px solid var(--td-line); }
   .doc-row.is-selected { background: var(--td-accent-tint); border-radius: 8px; }
   .row-check { display: flex; align-items: center; flex-shrink: 0; cursor: pointer; }


### PR DESCRIPTION
## Summary
Adds search and multi-select batch delete to the owner **My docs** (`/me`) catalog.

- Filter by title or slug (client-side over the KV title list).
- Multi-select + batch delete via session `DELETE /api/doc`.
- Quiet confirm: **This can't be undone.** Feedback: tiny inline top-right toast (**Deleted**) — **no third-party toast library** on the privileged `/me` surface.
- Mobile viewport meta on `/me`.
- Access policy stays on the doc Share panel (JUL-36).

## Review
Addressed Serena + Copilot: dropped Toastify entirely (CDN and vendored), kept inline toast, added viewport, cleaned guards. Rebased onto `main`.

## Test plan
- [x] `npm test` (31/31 offline)
- [x] No third-party `<script src=>` on `/me`
- [x] `applySearch()` after single delete; no `data-versions`; no comment pre-flight

## Security note
`/me` remains owner-session-only. No third-party JS on the owner session surface. Batch delete reuses session `DELETE /api/doc`.