### PR TITLE
fix: stop clipping tables and diagrams in the reader

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ file and `.claude-plugin/plugin.json`.
 
 ### Fixed
 
+- **Tables and wide diagrams are no longer clipped in the reader.** Overlay
+  table styles used a -14px left margin that cropped the first column inside
+  any `overflow-x:auto` wrapper, and `display:block` on `<table>` broke row
+  layout on narrow viewports. Tables now keep real table layout and scroll in
+  a wrapper; document SVGs keep their viewBox aspect ratio with overflow
+  visible.
 - **Dark mode no longer recolors reaction emoji.** The page invert was
   turning ❤️ / 👍 into off-hue bitmaps. Color emoji in chips and the
   picker are wrapped and inverted back to native colors. Text reactions

--- a/server/overlay.js
+++ b/server/overlay.js
@@ -201,8 +201,10 @@
   :where(body pre) { font-family: ui-monospace, "SF Mono", Menlo, monospace; font-size: 14.5px; line-height: 1.6; background: var(--td-surface-2); color: var(--td-pre-ink); border: 1px solid var(--td-line); border-radius: 10px; padding: 16px 18px; margin: 20px 0; overflow-x: auto; }
   :where(body pre code) { background: transparent; color: inherit; padding: 0; border-radius: 0; }
   :where(body hr) { border: 0; border-top: 1px solid var(--td-line); margin: 36px 0; }
-  /* Tables: rounded cells with gutters — header tint comes from the theme. */
-  :where(body table) { border-collapse: separate; border-spacing: 3px; margin: 0 0 18px -14px; font-size: 16px; }
+  /* Tables: rounded cells with gutters — header tint comes from the theme.
+     No negative horizontal margin: that clips the first column inside any
+     overflow-x:auto wrapper (author skill tells agents to wrap tables). */
+  :where(body table) { border-collapse: separate; border-spacing: 3px; margin: 0 0 18px; font-size: 16px; }
   :where(body th, body td) { padding: 10px 14px; background: var(--td-surface); border-radius: 8px; border: 0; text-align: left; }
   :where(body th) { font-weight: 600; color: var(--td-th-ink); background: var(--td-th-bg); }
   :where(body figcaption) { font-size: 13px; color: var(--td-muted); margin-top: 6px; text-align: center; }
@@ -223,7 +225,7 @@
   }
   /* Doc imagery only — exclude overlay UI so icons inside the bar / chips /
      buttons / cards keep their inline layout instead of stacking to 16px tall. */
-  :where(body img, body svg, body canvas, body video):not(.tdoc-bar *):not(.tdoc-margin-comment *):not(.tdoc-popup *):not(.tdoc-modal-bg *):not(.tdoc-chip *):not(.tdoc-fab *):not(#tdoc-comment-layer *):not(#tdoc-pin-layer *):not(.tdoc-cluster-pop *):not(.tdoc-footer *) { display: block; margin: 16px auto; border-radius: 6px; }
+  :where(body img, body svg, body canvas, body video):not(.tdoc-bar *):not(.tdoc-margin-comment *):not(.tdoc-popup *):not(.tdoc-modal-bg *):not(.tdoc-chip *):not(.tdoc-fab *):not(#tdoc-comment-layer *):not(#tdoc-pin-layer *):not(.tdoc-cluster-pop *):not(.tdoc-footer *) { display: block; margin: 16px auto; border-radius: 6px; overflow: visible; }
   /* Reading column INVARIANT (JUL-21): doc content is always a centered 720px
      column, wrapper or not. Two halves: (a) recognized wrappers get max-width
      AND margin:auto (previously margin was missing, so wrapped docs without
@@ -258,16 +260,13 @@
   /* Canvas needs special handling: scaling its CSS size doesn't change its
      drawing-buffer size, but at least the box won't overflow. */
   :where(body canvas) { display: block; }
-  /* Wide tables: keep TRUE table layout on desktop — display:block on a
-     table element discards real table layout for anonymous-box fixup, which
-     some engines render with uneven row heights and gaps (seen on published
-     docs). Only degrade to a scrollable block on narrow viewports, where
-     horizontal overflow is the bigger evil. NOTE: no backticks in comments
-     here — this CSS lives inside a JS template literal. */
+  /* Wide tables: keep TRUE table layout always — display:block on a table
+     discards real table layout for anonymous-box fixup (uneven row heights).
+     Scroll a wrapper instead of the table element. NOTE: no backticks in
+     comments here — this CSS lives inside a JS template literal. */
   :where(body table) { max-width: 100%; }
-  @media (max-width: 760px) {
-    :where(body table) { display: block; overflow-x: auto; }
-  }
+  .tdoc-table-scroll { max-width: 100%; overflow-x: auto; -webkit-overflow-scrolling: touch; }
+  .tdoc-table-scroll > table { max-width: none; }
   /* Pre/code blocks scroll horizontally instead of breaking the layout. */
   :where(body pre) { max-width: 100%; overflow-x: auto; }
 
@@ -3978,6 +3977,38 @@
     } else if (!ok) flashToast('Copy failed');
   };
 
+  // Document tables/SVGs must stay fully visible in the 720px reading column.
+  // Negative-margin table styles used to clip the first column inside author
+  // overflow-x:auto wrappers; display:block on <table> broke row layout.
+  // Wrap remaining tables so wide ones scroll instead of overflowing or clipping.
+  function wrapScrollableTables() {
+    document.querySelectorAll('body table').forEach(table => {
+      if (table.closest(UI_CONTAINERS)) return;
+      if (table.parentElement && table.parentElement.closest('table')) return;
+      const parent = table.parentElement;
+      if (!parent) return;
+      if (parent.classList.contains('tdoc-table-scroll')) return;
+      const ox = getComputedStyle(parent).overflowX;
+      if (ox === 'auto' || ox === 'scroll') return;
+      const wrap = document.createElement('div');
+      wrap.className = 'tdoc-table-scroll';
+      parent.insertBefore(wrap, table);
+      wrap.appendChild(table);
+    });
+  }
+  function preserveSvgAspect() {
+    document.querySelectorAll('body svg[viewBox]').forEach(svg => {
+      if (svg.closest(UI_CONTAINERS)) return;
+      const parts = String(svg.getAttribute('viewBox') || '').trim().split(/[\s,]+/);
+      if (parts.length !== 4) return;
+      const w = parseFloat(parts[2]), h = parseFloat(parts[3]);
+      if (!(w > 0 && h > 0)) return;
+      if (!svg.style.aspectRatio) svg.style.aspectRatio = w + ' / ' + h;
+    });
+  }
+
   // ========== Wire it up ==========
+  wrapScrollableTables();
+  preserveSvgAspect();
   refreshComments();
 })();

--- a/test/fixtures/tdocs/sample-doc/v2/index.html
+++ b/test/fixtures/tdocs/sample-doc/v2/index.html
@@ -25,10 +25,12 @@
     <h2>Section Two</h2>
     <p>A second section with its own heading so reconcile fingerprinting has
     distinct nearest-heading values to key on.</p>
-    <table>
-      <thead><tr><th>Key</th><th>Value</th></tr></thead>
-      <tbody><tr><td>alpha</td><td>1</td></tr><tr><td>beta</td><td>2</td></tr></tbody>
-    </table>
+    <div class="matrix-wrap" style="overflow-x:auto">
+      <table>
+        <thead><tr><th>Key</th><th>Value</th></tr></thead>
+        <tbody><tr><td>alpha</td><td>1</td></tr><tr><td>beta</td><td>2</td></tr></tbody>
+      </table>
+    </div>
 
     <h2>Section Three</h2>
     <pre>function demo() {

--- a/test/reader-overflow.test.js
+++ b/test/reader-overflow.test.js
@@ -1,0 +1,56 @@
+// Reader overflow invariants (tables + diagrams).
+//
+// Overlay default table styles used a -14px left margin to optically align
+// padded cells with prose. Inside any overflow-x:auto wrapper (the author
+// skill tells agents to wrap tables) that margin clips the first column —
+// seen on published docs as "CAPABILITY" rendering as "APABILITY".
+// display:block on <table> also discarded real table layout.
+//
+// These are provider CSS/JS contracts in overlay.js, not author-HTML luck.
+//
+// Run with: node test/reader-overflow.test.js
+
+const fs = require('fs');
+const path = require('path');
+
+let pass = 0, fail = 0;
+function ok(n) { console.log(`  ✓ ${n}`); pass++; }
+function bad(n, e) { console.log(`  ✗ ${n}\n    ${e}`); fail++; }
+function t(n, fn) { try { fn(); ok(n); } catch (e) { bad(n, e.message); } }
+function assert(c, m) { if (!c) throw new Error(m || 'assertion failed'); }
+
+const src = fs.readFileSync(path.join(__dirname, '..', 'server', 'overlay.js'), 'utf8');
+
+console.log('reader-overflow (tables + diagrams stay unclipped)');
+
+t('overlay table style has no negative horizontal margin', () => {
+  assert(!/body table[^}]*margin:\s*[^;]*-\d+px/.test(src),
+    'table rule still uses a negative margin (clips inside overflow wrappers)');
+  assert(src.includes(':where(body table) { border-collapse: separate; border-spacing: 3px; margin: 0 0 18px; font-size: 16px; }'),
+    'default table margin must be 0 0 18px with no left pull');
+});
+
+t('overlay never display:block a document table', () => {
+  assert(!/body table\) \{ display: block; overflow-x: auto; \}/.test(src),
+    'display:block on table is back (breaks table layout)');
+});
+
+t('wide tables scroll via a wrapper, not the table element', () => {
+  assert(src.includes('.tdoc-table-scroll'), 'missing .tdoc-table-scroll wrapper class');
+  assert(src.includes('function wrapScrollableTables('), 'missing wrapScrollableTables()');
+  assert(src.includes("wrap.className = 'tdoc-table-scroll'"), 'wrapper is not applied to document tables');
+});
+
+t('document SVGs use overflow:visible so viewBox content is not cropped', () => {
+  assert(/body img, body svg, body canvas, body video[\s\S]*?overflow: visible/.test(src),
+    'doc svg/img rule must set overflow: visible');
+  assert(src.includes('function preserveSvgAspect('), 'missing preserveSvgAspect()');
+});
+
+t('layout helpers run at overlay boot', () => {
+  assert(/wrapScrollableTables\(\);\s*preserveSvgAspect\(\);\s*refreshComments\(\);/.test(src),
+    'boot must wrap tables and pin svg aspect before refreshComments');
+});
+
+console.log(`\n${pass} passed, ${fail} failed.`);
+process.exit(fail ? 1 : 0);

--- a/test/run.js
+++ b/test/run.js
@@ -33,6 +33,7 @@ const OFFLINE = [
   'no-drift.test.js',         // duplicated-helper drift guard
   'coverage.test.js',         // migration, bundle inlining, pull-merge, rich fold
   'overlay-pure.test.js',     // overlay pure helpers (escape/normalize/prefix)
+  'reader-overflow.test.js',  // tables/diagrams must not clip in the reader
   'agent-runtime.test.js',    // host-runtime detect + agent logos
   'pins-layout.test.js',      // v0.8.0 pins clustering/spread/overflow-fold core
   'comment-upload.test.js',   // local→worker comment merge (non-destructive)

--- a/test/ui.test.js
+++ b/test/ui.test.js
@@ -96,6 +96,63 @@ async function tPub(name, fn) {
     if (stored !== 'light') throw new Error(`storage should be light, got "${stored}"`);
   });
 
+  await t('Table in overflow-x:auto wrapper is not clipped on the left', async () => {
+    const m = await page.evaluate(() => {
+      const table = document.querySelector('.wrap table');
+      const wrap = table && table.parentElement;
+      const th = table && table.querySelector('th');
+      if (!table || !wrap || !th) return { missing: true };
+      const t = table.getBoundingClientRect();
+      const w = wrap.getBoundingClientRect();
+      const h = th.getBoundingClientRect();
+      return {
+        tableLeft: t.left,
+        wrapLeft: w.left,
+        thLeft: h.left,
+        thText: th.textContent.trim(),
+        tableMarginLeft: getComputedStyle(table).marginLeft,
+        wrapOverflowX: getComputedStyle(wrap).overflowX,
+      };
+    });
+    if (m.missing) throw new Error('fixture table/wrapper missing');
+    if (m.wrapOverflowX !== 'auto' && m.wrapOverflowX !== 'scroll') {
+      throw new Error(`expected overflow-x auto wrapper, got ${m.wrapOverflowX}`);
+    }
+    if (m.tableLeft < m.wrapLeft - 1) {
+      throw new Error(`table left ${m.tableLeft.toFixed(1)} is clipped inside wrapper ${m.wrapLeft.toFixed(1)}`);
+    }
+    if (m.thLeft < m.wrapLeft - 1) {
+      throw new Error(`first th left ${m.thLeft.toFixed(1)} is clipped inside wrapper ${m.wrapLeft.toFixed(1)}`);
+    }
+    if (parseFloat(m.tableMarginLeft) < 0) {
+      throw new Error(`table still has negative margin-left ${m.tableMarginLeft}`);
+    }
+    if (m.thText !== 'Key') throw new Error(`first th text was "${m.thText}"`);
+  });
+
+  await t('Doc SVG keeps viewBox aspect ratio and is not overflow-clipped', async () => {
+    const m = await page.evaluate(() => {
+      const svg = document.querySelector('.wrap svg[viewBox]');
+      if (!svg) return { missing: true };
+      const r = svg.getBoundingClientRect();
+      const parts = svg.getAttribute('viewBox').trim().split(/[\s,]+/).map(Number);
+      const vw = parts[2], vh = parts[3];
+      return {
+        w: r.width, h: r.height, vw, vh,
+        overflow: getComputedStyle(svg).overflow,
+        aspect: svg.style.aspectRatio,
+      };
+    });
+    if (m.missing) throw new Error('fixture svg missing');
+    if (m.overflow !== 'visible') throw new Error(`svg overflow is ${m.overflow}, expected visible`);
+    if (!(m.w > 8 && m.h > 8)) throw new Error(`svg collapsed to ${m.w}x${m.h}`);
+    const used = m.w / m.h;
+    const box = m.vw / m.vh;
+    if (Math.abs(used - box) / box > 0.05) {
+      throw new Error(`svg ratio ${used.toFixed(3)} != viewBox ${box.toFixed(3)}`);
+    }
+  });
+
   await t('Copy button exists with icon + label', async () => {
     const btn = await page.$('#tdoc-copy-md-btn');
     if (!btn) throw new Error('no #tdoc-copy-md-btn');


### PR DESCRIPTION
## Summary
- Overlay table styles used a `-14px` left margin that cropped the first column inside `overflow-x:auto` wrappers (the cf-vs-vercel matrix showed `CAPABILITY` as `APABILITY`).
- Keep real table layout (no `display:block` on `<table>`), scroll wide tables in a wrapper, and preserve SVG viewBox aspect so diagrams are not cropped.
- Reading column stays ~720px. This is a clip fix, not a wider page.

## Test plan
- [ ] `node test/run.js` (includes new `reader-overflow.test.js`)
- [ ] `node test/ui.test.js` (table not clipped on the left; SVG aspect preserved)
- [ ] Local smoke: serve `~/tdocs/cf-vs-vercel` with this overlay and confirm the capability column and architecture SVG are fully visible
- [ ] After tdoc.dev Worker deploy, reload https://tdoc.dev/d/cf-vs-vercel/v/1


Made with [Cursor](https://cursor.com)