### PR TITLE
fix: dark mode keeps document button labels visible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ file and `.claude-plugin/plugin.json`.
   layout on narrow viewports. Tables now keep real table layout and scroll in
   a wrapper; document SVGs keep their viewBox aspect ratio with overflow
   visible.
+- **Dark mode no longer erases document button labels.** `color-scheme: dark`
+  plus page invert made unselected chips like "Differences only" paint
+  light-on-light, so the text vanished. Form controls stay in the light
+  scheme and invert with the rest of the page.
 - **Dark mode no longer recolors reaction emoji.** The page invert was
   turning ❤️ / 👍 into off-hue bitmaps. Color emoji in chips and the
   picker are wrapped and inverted back to native colors. Text reactions

--- a/server/overlay.js
+++ b/server/overlay.js
@@ -682,6 +682,16 @@
     background: #fff;
     filter: invert(1) hue-rotate(180deg);
   }
+  /* Native buttons/inputs follow color-scheme. Dark UA styles paint light
+     text onto an author light fill; invert then makes the label vanish
+     (e.g. "Differences only" on a white chip). Keep form controls in the
+     light scheme so invert can flip their author colors as a unit. */
+  html[data-tdoc-theme="dark"] button,
+  html[data-tdoc-theme="dark"] input,
+  html[data-tdoc-theme="dark"] select,
+  html[data-tdoc-theme="dark"] textarea {
+    color-scheme: light;
+  }
   html[data-tdoc-theme="dark"] img,
   html[data-tdoc-theme="dark"] video,
   html[data-tdoc-theme="dark"] canvas,

--- a/test/dark-mode.test.js
+++ b/test/dark-mode.test.js
@@ -38,6 +38,18 @@ t('dark mode is a page invert, not a per-color palette', () => {
   assert(!src.includes('--td-ground: #111111'), 'old per-token dark palette came back');
 });
 
+t('dark mode keeps form-control labels visible under invert', () => {
+  assert(src.includes('color-scheme: dark'), 'html still sets color-scheme dark');
+  assert(
+    /html\[data-tdoc-theme="dark"\] button[\s\S]*?color-scheme:\s*light/.test(src),
+    'buttons must stay color-scheme light so UA does not paint light text on a light chip'
+  );
+  assert(
+    /html\[data-tdoc-theme="dark"\] input[\s\S]*?color-scheme:\s*light/.test(src),
+    'inputs must stay color-scheme light too'
+  );
+});
+
 t('dark mode restores native emoji colors (not inverted)', () => {
   assert(
     /html\[data-tdoc-theme="dark"\][\s\S]*?\.tdoc-emoji/.test(src),


### PR DESCRIPTION
## Why

Dark mode inverts the page and also sets `color-scheme: dark`. Native / lightly styled buttons (like **Differences only** next to **All**) then get browser dark-form colors: light text on a light chip. Invert leaves a blank white button.

## What

Under dark theme, `button` / `input` / `select` / `textarea` stay `color-scheme: light`. Invert still flips them with the rest of the page, so the unselected label stays readable.

## Test

- `node test/dark-mode.test.js` + `npm test` (29 suites)
- Local: inject All / Differences only on conway-life, switch to dark — **Differences only** is visible again.

Not merging unless you want it.