### PR TITLE
Hosted multi-tenant publish (supersedes #109)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,22 @@ file and `.claude-plugin/plugin.json`.
 
 ## [Unreleased]
 
+### Changed
+
+- **Default `/tdoc publish` target is hosted tdoc.dev** (Cloudflare/Vercel via
+  `--platform`). Closed signup fails clearly and points at self-host flags;
+  onboarding’s sample publish uses `--platform cloudflare`.
+- **`--platform` after first setup switches for real.** A conflicting flag
+  rewrites `~/.tdoc/published.json` via full re-setup (previous config kept as
+  `published.json.bak.switch` and restored if setup fails). Cloudflare setup
+  now persists `platform:"cloudflare"`. Same Worker custom domain vs
+  `*.workers.dev` remains two hostnames, not a platform switch.
+
 ### Fixed
 
+- **`DELETE /api/doc` fails closed when hosted `release_owner` fails** and the
+  Durable Object binding is present, so a 200 cannot leave the slug parked.
+  Vercel (no `COMMENTS`) still returns 200 — there was never a reservation.
 - **Tables and wide diagrams are no longer clipped in the reader.** Overlay
   table styles used a -14px left margin that cropped the first column inside
   any `overflow-x:auto` wrapper, and `display:block` on `<table>` broke row

--- a/ONBOARDING.md
+++ b/ONBOARDING.md
@@ -7,7 +7,7 @@
 `tdoc` is a Claude Code skill that gives the user prompt-native HTML documents with text- and artifact-anchored comments. After install + onboarding, the user can:
 
 - `/tdoc new <prompt>` → generate an interactive HTML doc
-- `/tdoc publish <slug>` → publish to their own Cloudflare Worker (free, always-on)
+- `/tdoc publish <slug>` → publish (default target is hosted tdoc.dev; signup may be closed, so onboarding uses `--platform cloudflare` below)
 - Share the live URL; commenters sign in with GitHub
 
 Install + onboarding takes ~3 minutes on a clean machine. Most steps are automatic. The user only has to click ~2 things in a browser.
@@ -128,8 +128,10 @@ cat > ~/tdocs/$SLUG/meta.json <<EOF
 {"title":"Hello tdoc","slug":"$SLUG","versions":[{"n":1,"created":"$(date -Iseconds)"}]}
 EOF
 echo '[]' > ~/tdocs/$SLUG/comments.json
-# Publish
-~/.claude/skills/tdoc/bin/tdoc-publish $SLUG
+# Publish to the user's own Cloudflare Worker. Hosted tdoc.dev is the
+# default for `/tdoc publish`, but self-serve signup is closed — use an
+# explicit self-host flag here.
+~/.claude/skills/tdoc/bin/tdoc-publish --platform cloudflare $SLUG
 ```
 
 The script prints the live URL. Show it to the user.

--- a/README.md
+++ b/README.md
@@ -99,8 +99,12 @@ bills.
 
 ## Hosting targets
 
-Publishing has one hosted target and two self-host targets; pick one on your
-first publish and it sticks (saved in `~/.tdoc/published.json`):
+Publishing has one hosted target and two self-host targets. First publish
+picks the default (hosted unless you pass `--platform`); that choice is saved
+in `~/.tdoc/published.json` and reused. Pass a different `--platform` later to
+switch — the CLI rewrites the config via full re-setup (previous file kept as
+`published.json.bak.switch`). A custom domain and `*.workers.dev` on the same
+Worker are two hostnames, not two platforms.
 
 - **Hosted (default)** — `/tdoc publish <slug>` uploads to a tdoc-managed host
   such as `tdoc.dev`. This path skips user deploy setup. On first use, the

--- a/README.md
+++ b/README.md
@@ -15,8 +15,8 @@ It runs in two modes:
 
 - **Local Studio** — temporary authoring/preview on `localhost`. Not the
   product source of truth; safe to discard.
-- **Published Reader** — remote snapshots on your Cloudflare Worker or Vercel
-  project. This is the durable document surface.
+- **Published Reader** — remote snapshots on hosted tdoc.dev or on your
+  Cloudflare Worker / Vercel project. This is the durable document surface.
 
 tdoc is a first-class **Claude Code** skill and also runs under **Codex**. The
 skill auto-detects the host and falls back to plain-text prompts where
@@ -26,7 +26,7 @@ Claude-specific tools are unavailable. See [Using tdoc with Codex](#using-tdoc-w
 You:  /tdoc new "an explainer with a slider showing how interest compounds"
 Claude: <generates doc, opens it locally>
 You:  /tdoc publish
-Claude: https://tdoc.yourname.workers.dev/d/compound-interest/v/1
+Claude: https://tdoc.dev/d/compound-interest/v/1
 ```
 
 Anyone with the link reads it instantly and comments on any sentence, image, or
@@ -79,7 +79,7 @@ What is *not* yet first-class on Codex: native slash-command registration (`/tdo
 |---|---|
 | `/tdoc new <prompt>` | Generate a new doc + open locally |
 | `/tdoc edit <slug>` | New version from open comments; replies on each with ✅/🟡/❓ status |
-| `/tdoc publish <slug>` | Deploy to your Cloudflare Worker (or Vercel, `--platform vercel`), get a public URL |
+| `/tdoc publish <slug>` | Publish a doc and get a public URL (hosted tdoc.dev by default; self-host with `--platform cloudflare` or `vercel`) |
 | `/tdoc pull <slug>` | Sync comments from the published doc back to local |
 | `/tdoc fork <slug>` | Copy a doc to a new slug |
 | `/tdoc unpublish <slug>` | Remove a published doc from your Worker |
@@ -90,15 +90,27 @@ What is *not* yet first-class on Codex: native slash-command registration (`/tdo
 
 ## Cost
 
-**$0 for normal use.** Cloudflare Workers + R2 + KV all have generous free tiers that personal usage will never come close to. The same goes for the Vercel target (Functions + Blob + Upstash Redis free tiers). You own your account; nobody else (including the maintainer) sees your traffic or pays your bills.
+**$0 for normal personal use.** Hosted publishing can use tdoc-managed
+infrastructure, so a first-time user does not need to configure Cloudflare,
+Vercel, R2, KV, Workers, or an OAuth app. Self-host targets still use your own
+Cloudflare or Vercel account (generous free tiers). You own a self-host
+account; nobody else (including the maintainer) sees that traffic or pays those
+bills.
 
 ## Hosting targets
 
-Publishing deploys the **same worker code** to a host you own; pick one on your
+Publishing has one hosted target and two self-host targets; pick one on your
 first publish and it sticks (saved in `~/.tdoc/published.json`):
 
-- **Cloudflare (default)** — Worker + R2 + KV, with a Durable Object
-  serializing concurrent comment writes. The most battle-tested target.
+- **Hosted (default)** — `/tdoc publish <slug>` uploads to a tdoc-managed host
+  such as `tdoc.dev`. This path skips user deploy setup. On first use, the
+  hosted service issues an account-scoped upload token and the CLI stores it in
+  `~/.tdoc/published.json`; that token can only mutate docs it owns. If hosted
+  signup is not open, the CLI says so and points at `--platform cloudflare` or
+  `--platform vercel`.
+- **Cloudflare** — `/tdoc publish --platform cloudflare <slug>` deploys a
+  Worker + R2 + KV you own, with a Durable Object serializing concurrent
+  comment writes. The most battle-tested self-host target.
 - **Vercel** — `/tdoc publish --platform vercel <slug>` deploys a catch-all
   Vercel Function backed by Vercel Blob (docs) and Upstash Redis (metadata +
   comments, from the Vercel Marketplace). Same URLs, same commenting, same

--- a/SKILL.md
+++ b/SKILL.md
@@ -413,20 +413,25 @@ token can only mutate docs it owns. If hosted signup is not open, the CLI fails
 with a clear prompt to self-host instead — do **not** tell the user to flip a
 Worker env flag.
 
-**Self-host — Cloudflare**: `tdoc-publish --platform cloudflare <slug>` (first
-publish only; the choice is persisted). Prompts `wrangler login`, creates an R2
-bucket (`tdoc-docs`) and KV namespace (`META`) in *your* Cloudflare account,
-generates an upload token, and deploys your own Worker.
+**Self-host — Cloudflare**: `tdoc-publish --platform cloudflare <slug>`.
+First run (or an explicit switch onto cloudflare) prompts `wrangler login`,
+creates an R2 bucket (`tdoc-docs`) and KV namespace (`META`) in *your*
+Cloudflare account, generates an upload token, and deploys your own Worker.
+The choice is persisted in `~/.tdoc/published.json` as the default.
 
-**Self-host — Vercel**: `tdoc-publish --platform vercel <slug>` (first publish
-only; the choice is persisted). Needs the `vercel` CLI (`npm i -g vercel`).
-First run links a Vercel project named `tdoc`, then asks you (via an agent
-prompt) to connect a **Blob** store and an **Upstash Redis** store in the
-Vercel dashboard's Storage tab — both free tier, ~2 clicks each — and deploys.
+**Self-host — Vercel**: `tdoc-publish --platform vercel <slug>`. First run
+(or an explicit switch onto vercel) needs the `vercel` CLI (`npm i -g vercel`),
+links a Vercel project named `tdoc`, then asks you (via an agent prompt) to
+connect a **Blob** store and an **Upstash Redis** store in the Vercel
+dashboard's Storage tab — both free tier, ~2 clicks each — and deploys.
 Caveats: no per-doc write serialization (Cloudflare uses a Durable Object for
 that) and a ~4.5 MB upload cap per doc (Vercel request limit).
 
-Subsequent runs upload the latest version of `<slug>`. Self-host targets
+Subsequent runs upload the latest version of `<slug>` using the saved default.
+Pass a different `--platform` any time to switch: full re-setup rewrites
+`published.json` (previous file kept as `published.json.bak.switch`). A custom
+domain and `*.workers.dev` on the same Worker are two hostnames, not two
+platforms. Self-host targets
 compare a content hash of the Worker/overlay bundle against the last deployed
 hash in `~/.tdoc/published.json` and redeploy automatically when runtime code
 changed. Set `TDOC_SKIP_WORKER_DEPLOY=1` to skip the redeploy (useful for batch

--- a/SKILL.md
+++ b/SKILL.md
@@ -403,44 +403,49 @@ echo "tdoc server: http://localhost:7878"
 pkill -f "$SKILL_DIR/server/server.js"
 ```
 
-### `/tdoc publish <slug>` — publish to your Cloudflare Worker (or Vercel)
+### `/tdoc publish <slug>` — publish to hosted tdoc (default), or self-host
 
 Publishes the latest version of `<slug>` to a public URL.
 
-Local always stays $0/anonymous; publishing is opt-in. First run does a one-time
-setup: prompts `wrangler login`, creates an R2 bucket (`tdoc-docs`) and KV
-namespace (`META`) in *your* Cloudflare account, generates an upload token, and
-deploys your own Worker. Config is saved to `~/.tdoc/published.json`.
+Default target is **hosted** (`https://tdoc.dev`). First run asks the host for
+an account-scoped upload token and stores it in `~/.tdoc/published.json`. That
+token can only mutate docs it owns. If hosted signup is not open, the CLI fails
+with a clear prompt to self-host instead — do **not** tell the user to flip a
+Worker env flag.
 
-**Alternative host — Vercel**: `tdoc-publish --platform vercel <slug>` (first
-publish only; the choice is persisted). Needs the `vercel` CLI (`npm i -g
-vercel`). First run links a Vercel project named `tdoc`, then asks you (via an
-agent prompt) to connect a **Blob** store and an **Upstash Redis** store in the
+**Self-host — Cloudflare**: `tdoc-publish --platform cloudflare <slug>` (first
+publish only; the choice is persisted). Prompts `wrangler login`, creates an R2
+bucket (`tdoc-docs`) and KV namespace (`META`) in *your* Cloudflare account,
+generates an upload token, and deploys your own Worker.
+
+**Self-host — Vercel**: `tdoc-publish --platform vercel <slug>` (first publish
+only; the choice is persisted). Needs the `vercel` CLI (`npm i -g vercel`).
+First run links a Vercel project named `tdoc`, then asks you (via an agent
+prompt) to connect a **Blob** store and an **Upstash Redis** store in the
 Vercel dashboard's Storage tab — both free tier, ~2 clicks each — and deploys.
-Subsequent publishes and all other commands (`pull`, `unpublish`, comments,
-GitHub sign-in) work identically on either host. Caveats: no per-doc write
-serialization (Cloudflare uses a Durable Object for that) and a ~4.5 MB upload
-cap per doc (Vercel request limit).
+Caveats: no per-doc write serialization (Cloudflare uses a Durable Object for
+that) and a ~4.5 MB upload cap per doc (Vercel request limit).
 
-Subsequent runs upload the latest version of `<slug>`. The script compares a
-content hash of the Worker/overlay bundle against the last deployed hash in
-`~/.tdoc/published.json` and redeploys automatically when runtime code changed.
-Set `TDOC_SKIP_WORKER_DEPLOY=1` to skip the redeploy (useful for batch uploads).
-Published pages expose runtime provenance at `/api/runtime` and in
+Subsequent runs upload the latest version of `<slug>`. Self-host targets
+compare a content hash of the Worker/overlay bundle against the last deployed
+hash in `~/.tdoc/published.json` and redeploy automatically when runtime code
+changed. Set `TDOC_SKIP_WORKER_DEPLOY=1` to skip the redeploy (useful for batch
+uploads). Published pages expose runtime provenance at `/api/runtime` and in
 `window.__TDOC__.runtime`.
 
 On published docs, viewers sign in with GitHub (Device Flow, shared OAuth App
 `Ov23liZ1UAGOchvKPmlS`, scope `read:user`) before commenting.
 
-Requires `jq`, plus `wrangler` (`npm i -g wrangler`) for the Cloudflare
-target or `vercel` (`npm i -g vercel`) for the Vercel target.
+Requires `jq`. Hosted needs no extra CLI. Cloudflare needs `wrangler`
+(`npm i -g wrangler`); Vercel needs `vercel` (`npm i -g vercel`).
 
 ```bash
 "$SKILL_DIR/bin/tdoc-publish" <slug>
 ```
 
-Prints the published URL: `https://<worker>.<subdomain>.workers.dev/d/<slug>/v/<N>`
-(Cloudflare) or `https://tdoc-<scope>.vercel.app/d/<slug>/v/<N>` (Vercel).
+Prints the published URL: `https://tdoc.dev/d/<slug>/v/<N>` (hosted),
+`https://<worker>.<subdomain>.workers.dev/d/<slug>/v/<N>` (Cloudflare), or
+`https://tdoc-<scope>.vercel.app/d/<slug>/v/<N>` (Vercel).
 
 ### `/tdoc pull <slug>` — pull comments from the published doc
 

--- a/bin/tdoc-publish
+++ b/bin/tdoc-publish
@@ -7,8 +7,11 @@
 #   hosted (default)     — upload to a tdoc-managed host (tdoc.dev); no user deploy
 #   cloudflare           — wrangler deploy to a Worker + R2 + KV you own
 #   vercel               — vercel deploy of the vercel/ template + Blob + Upstash KV
-# The platform is chosen ONCE, on the first publish (flag or TDOC_PLATFORM
-# env), then persisted in ~/.tdoc/published.json and read from there.
+# Default platform is chosen on first publish (flag or TDOC_PLATFORM env),
+# then persisted in ~/.tdoc/published.json. Later publishes reuse that default.
+# Pass a different --platform any time to switch: full re-setup rewrites the
+# config (previous file kept as published.json.bak.switch). Same hostname pair
+# on one Worker (e.g. tdoc.dev + *.workers.dev) is NOT a platform switch.
 #
 # First run (hosted):
 #   1. Ask the tdoc-managed host for an account-scoped upload token
@@ -26,7 +29,7 @@
 #
 # First run (vercel): see first_time_setup_vercel below.
 #
-# Subsequent runs:
+# Subsequent runs (same platform):
 #   Just upload the requested slug via /api/upload.
 
 set -euo pipefail
@@ -36,7 +39,7 @@ usage() {
 usage: tdoc-publish [options] <slug>
 
 Options:
-  --platform hosted|cloudflare|vercel    (default for first publish: hosted)
+  --platform hosted|cloudflare|vercel    (default for first publish: hosted; re-pass to switch)
   --visibility public|unlisted|private   (default for new access block: unlisted)
   --history owner|invited|public         (default for new access block: owner)
   --commenting owner|invited|signed_in|off  (default: signed_in)
@@ -444,7 +447,7 @@ first_time_setup() {
       --arg worker "$worker_name" \
       --arg host "$PUBLIC_HOST" \
       --arg custom "$CUSTOM_DOMAIN" \
-      '{subdomain:$sub, upload_token:$tok, kv_id:$kv, worker:$worker, public_host:$host, custom_domain:$custom, created: now | todate}' \
+      '{platform:"cloudflare", subdomain:$sub, upload_token:$tok, kv_id:$kv, worker:$worker, public_host:$host, custom_domain:$custom, created: now | todate}' \
       > "$CONFIG_FILE"
   )
   chmod 600 "$CONFIG_FILE"
@@ -590,21 +593,42 @@ first_time_setup_vercel() {
   echo "[tdoc] setup done. tdoc is live at: https://${public_host}"
 }
 
-if [ ! -f "$CONFIG_FILE" ]; then
-  case "${PLATFORM_FLAG:-hosted}" in
+run_platform_setup() {
+  case "$1" in
     hosted)     first_time_setup_hosted ;;
     cloudflare) SKILL_DIR="$SKILL_DIR" first_time_setup ;;
     vercel)     SKILL_DIR="$SKILL_DIR" first_time_setup_vercel ;;
-    *) echo "[tdoc] unknown platform '${PLATFORM_FLAG}' — use 'hosted', 'cloudflare', or 'vercel'." >&2; exit 1 ;;
+    *) echo "[tdoc] unknown platform '${1}' — use 'hosted', 'cloudflare', or 'vercel'." >&2; exit 1 ;;
   esac
+}
+
+if [ ! -f "$CONFIG_FILE" ]; then
+  run_platform_setup "${PLATFORM_FLAG:-hosted}"
+else
+  # Existing config is the default. An explicit --platform that differs
+  # rewrites published.json via full re-setup (not a half-migrate).
+  PLATFORM="$(jq -r '.platform // "cloudflare"' "$CONFIG_FILE")"
+  if [ -n "$PLATFORM_FLAG" ] && [ "$PLATFORM_FLAG" != "$PLATFORM" ]; then
+    echo "[tdoc] switching publish platform from '$PLATFORM' to '$PLATFORM_FLAG' (rewriting $CONFIG_FILE)."
+    CONFIG_BACKUP="${CONFIG_FILE}.bak.switch"
+    cp "$CONFIG_FILE" "$CONFIG_BACKUP"
+    chmod 600 "$CONFIG_BACKUP"
+    SETUP_OK=0
+    restore_config_on_fail() {
+      if [ "${SETUP_OK:-0}" != "1" ] && [ -f "$CONFIG_BACKUP" ]; then
+        mv "$CONFIG_BACKUP" "$CONFIG_FILE"
+        echo "[tdoc] platform switch failed — restored previous config." >&2
+      fi
+    }
+    trap restore_config_on_fail EXIT
+    run_platform_setup "$PLATFORM_FLAG"
+    SETUP_OK=1
+    trap - EXIT
+    echo "[tdoc] previous config kept at $CONFIG_BACKUP"
+  fi
 fi
 
-# The platform is whatever the config says from here on. A conflicting
-# --platform flag is ignored loudly rather than half-migrating state.
 PLATFORM="$(jq -r '.platform // "cloudflare"' "$CONFIG_FILE")"
-if [ -n "$PLATFORM_FLAG" ] && [ "$PLATFORM_FLAG" != "$PLATFORM" ]; then
-  echo "[tdoc] already set up for '$PLATFORM' — ignoring '--platform $PLATFORM_FLAG'. To switch platforms, delete $CONFIG_FILE and publish again." >&2
-fi
 
 TOKEN="$(jq -r .upload_token "$CONFIG_FILE")"
 

--- a/bin/tdoc-publish
+++ b/bin/tdoc-publish
@@ -1,14 +1,20 @@
 #!/usr/bin/env bash
-# tdoc-publish — first-time setup + upload doc to the user's own hosting.
+# tdoc-publish — first-time setup + upload doc.
 #
-# Usage: tdoc-publish [--platform cloudflare|vercel] <slug>
+# Usage: tdoc-publish [--platform hosted|cloudflare|vercel] <slug>
 #
-# Two publish targets share one flow (the worker code and the /api/upload
-# contract are identical on both):
-#   cloudflare (default) — wrangler deploy to a Worker + R2 + KV
+# Three publish targets share the same /api/upload contract:
+#   hosted (default)     — upload to a tdoc-managed host (tdoc.dev); no user deploy
+#   cloudflare           — wrangler deploy to a Worker + R2 + KV you own
 #   vercel               — vercel deploy of the vercel/ template + Blob + Upstash KV
 # The platform is chosen ONCE, on the first publish (flag or TDOC_PLATFORM
 # env), then persisted in ~/.tdoc/published.json and read from there.
+#
+# First run (hosted):
+#   1. Ask the tdoc-managed host for an account-scoped upload token
+#   2. Save the hosted base + token to ~/.tdoc/published.json
+#   3. Upload the doc. No Cloudflare/Vercel/OAuth app setup.
+#   If hosted signup is closed, fail clearly and point at --platform cloudflare|vercel.
 #
 # First run (cloudflare):
 #   1. Verify wrangler installed + logged in
@@ -30,7 +36,7 @@ usage() {
 usage: tdoc-publish [options] <slug>
 
 Options:
-  --platform cloudflare|vercel
+  --platform hosted|cloudflare|vercel    (default for first publish: hosted)
   --visibility public|unlisted|private   (default for new access block: unlisted)
   --history owner|invited|public         (default for new access block: owner)
   --commenting owner|invited|signed_in|off  (default: signed_in)
@@ -196,6 +202,54 @@ require_vercel() {
     fail_with_agent_prompt "the vercel CLI is not installed" \
       "Install the Vercel CLI globally so tdoc can publish: run 'npm i -g vercel' (or 'pnpm add -g vercel'). After it's installed, run '/tdoc publish $SLUG' again."
   fi
+}
+
+first_time_setup_hosted() {
+  local base="${TDOC_HOSTED_BASE:-https://tdoc.dev}"
+  base="${base%/}"
+  case "$base" in
+    http://*|https://*) ;;
+    *) echo "[tdoc] TDOC_HOSTED_BASE must start with http:// or https:// (got '$base')." >&2; exit 1 ;;
+  esac
+  local resp http payload token account_id
+  resp="$(curl -sS --connect-timeout 10 --max-time 30 -w $'\n%{http_code}' \
+    -X POST "$base/api/hosted/token" -H "Content-Type: application/json" \
+    -d "{\"label\":\"$(printf '%s' "$SLUG" | sed 's/"/\\"/g')\"}" 2>&1)" || {
+      fail_with_agent_prompt "hosted service is unreachable" \
+        "The hosted tdoc service at $base did not respond. Retry '/tdoc publish $SLUG' later, or set TDOC_HOSTED_BASE to the correct hosted URL. To self-host instead, run '/tdoc publish --platform cloudflare $SLUG' or '/tdoc publish --platform vercel $SLUG'."
+    }
+  http="${resp##*$'\n'}"
+  payload="${resp%$'\n'*}"
+  if ! printf '%s' "$http" | grep -qE '^2[0-9][0-9]$'; then
+    if printf '%s' "$payload" | grep -q 'hosted_registration_disabled'; then
+      fail_with_agent_prompt "hosted signup is not open on $base" \
+        "The default publish target is hosted tdoc ($base), but self-serve signup is not enabled there. Publish to your own account instead: '/tdoc publish --platform cloudflare $SLUG' or '/tdoc publish --platform vercel $SLUG'."
+    fi
+    echo "[tdoc] hosted token request returned HTTP $http" >&2
+    printf '%s\n' "$payload" | head -c 400 >&2; echo >&2
+    exit 1
+  fi
+  token="$(printf '%s' "$payload" | jq -r '.token // empty')"
+  account_id="$(printf '%s' "$payload" | jq -r '.account_id // empty')"
+  if [ -z "$token" ] || [ -z "$account_id" ]; then
+    echo "[tdoc] hosted token response was missing token/account_id." >&2
+    printf '%s\n' "$payload" | head -c 400 >&2; echo >&2
+    exit 1
+  fi
+  local public_host="${base#http://}"
+  public_host="${public_host#https://}"
+  (
+    umask 077
+    jq -n \
+      --arg tok "$token" \
+      --arg base "$base" \
+      --arg host "$public_host" \
+      --arg acct "$account_id" \
+      '{platform:"hosted", upload_token:$tok, base:$base, public_host:$host, account_id:$acct, created: now | todate}' \
+      > "$CONFIG_FILE"
+  )
+  chmod 600 "$CONFIG_FILE"
+  echo "[tdoc] hosted publish configured: $base"
 }
 if ! command -v jq >/dev/null 2>&1; then
   fail_with_agent_prompt "jq is not installed" \
@@ -537,10 +591,11 @@ first_time_setup_vercel() {
 }
 
 if [ ! -f "$CONFIG_FILE" ]; then
-  case "${PLATFORM_FLAG:-cloudflare}" in
+  case "${PLATFORM_FLAG:-hosted}" in
+    hosted)     first_time_setup_hosted ;;
     cloudflare) SKILL_DIR="$SKILL_DIR" first_time_setup ;;
     vercel)     SKILL_DIR="$SKILL_DIR" first_time_setup_vercel ;;
-    *) echo "[tdoc] unknown platform '${PLATFORM_FLAG}' — use 'cloudflare' or 'vercel'." >&2; exit 1 ;;
+    *) echo "[tdoc] unknown platform '${PLATFORM_FLAG}' — use 'hosted', 'cloudflare', or 'vercel'." >&2; exit 1 ;;
   esac
 fi
 
@@ -553,7 +608,20 @@ fi
 
 TOKEN="$(jq -r .upload_token "$CONFIG_FILE")"
 
-if [ "$PLATFORM" = "vercel" ]; then
+if [ "$PLATFORM" = "hosted" ]; then
+  BASE="$(jq -r '.base // empty' "$CONFIG_FILE")"
+  PUBLIC_HOST="$(jq -r '.public_host // empty' "$CONFIG_FILE")"
+  for _f in TOKEN:upload_token BASE:base PUBLIC_HOST:public_host; do
+    _var="${_f%%:*}"; _key="${_f##*:}"; _val="$(eval "printf '%s' \"\$$_var\"")"
+    if [ -z "$_val" ] || [ "$_val" = "null" ]; then
+      echo "[tdoc] $CONFIG_FILE is missing or has a null '$_key'. Delete it and re-run /tdoc publish --platform hosted to re-setup." >&2
+      exit 1
+    fi
+  done
+  UPLOAD_BASE="$BASE"
+  PUBLIC_BASE="$BASE"
+  CUSTOM_DOMAIN=""
+elif [ "$PLATFORM" = "vercel" ]; then
   BASE="$(jq -r '.base // empty' "$CONFIG_FILE")"
   # Validate like the cloudflare branch below: a corrupt or partial
   # published.json must fail loudly, not publish to "null".

--- a/bin/tdoc-pull
+++ b/bin/tdoc-pull
@@ -30,10 +30,10 @@ if [ ! -f "$CONFIG_FILE" ]; then
 fi
 if ! command -v jq >/dev/null 2>&1; then echo "needs jq" >&2; exit 1; fi
 
-# Resolve the API base for the configured platform: vercel configs store the
-# deployment URL directly in `.base`; cloudflare configs derive workers.dev.
+# Resolve the API base for the configured platform: hosted/vercel configs store
+# the URL directly in `.base`; cloudflare configs derive workers.dev.
 PLATFORM="$(jq -r '.platform // "cloudflare"' "$CONFIG_FILE")"
-if [ "$PLATFORM" = "vercel" ]; then
+if [ "$PLATFORM" = "hosted" ] || [ "$PLATFORM" = "vercel" ]; then
   BASE="$(jq -r '.base // empty' "$CONFIG_FILE")"
   if [ -z "$BASE" ] || [ "$BASE" = "null" ]; then
     echo "[tdoc] $CONFIG_FILE has no '.base' — delete it and re-run /tdoc publish to re-setup." >&2

--- a/bin/tdoc-unpublish
+++ b/bin/tdoc-unpublish
@@ -21,10 +21,10 @@ fi
 if ! command -v jq >/dev/null 2>&1; then echo "needs jq" >&2; exit 1; fi
 
 TOKEN="$(jq -r .upload_token "$CONFIG_FILE")"
-# Resolve the API base for the configured platform: vercel configs store the
-# deployment URL directly in `.base`; cloudflare configs derive workers.dev.
+# Resolve the API base for the configured platform: hosted/vercel configs store
+# the URL directly in `.base`; cloudflare configs derive workers.dev.
 PLATFORM="$(jq -r '.platform // "cloudflare"' "$CONFIG_FILE")"
-if [ "$PLATFORM" = "vercel" ]; then
+if [ "$PLATFORM" = "hosted" ] || [ "$PLATFORM" = "vercel" ]; then
   BASE="$(jq -r '.base // empty' "$CONFIG_FILE")"
   if [ -z "$BASE" ] || [ "$BASE" = "null" ]; then
     echo "[tdoc] $CONFIG_FILE has no '.base' — delete it and re-run /tdoc publish to re-setup." >&2

--- a/skills/tdoc/SKILL.md
+++ b/skills/tdoc/SKILL.md
@@ -413,20 +413,25 @@ token can only mutate docs it owns. If hosted signup is not open, the CLI fails
 with a clear prompt to self-host instead — do **not** tell the user to flip a
 Worker env flag.
 
-**Self-host — Cloudflare**: `tdoc-publish --platform cloudflare <slug>` (first
-publish only; the choice is persisted). Prompts `wrangler login`, creates an R2
-bucket (`tdoc-docs`) and KV namespace (`META`) in *your* Cloudflare account,
-generates an upload token, and deploys your own Worker.
+**Self-host — Cloudflare**: `tdoc-publish --platform cloudflare <slug>`.
+First run (or an explicit switch onto cloudflare) prompts `wrangler login`,
+creates an R2 bucket (`tdoc-docs`) and KV namespace (`META`) in *your*
+Cloudflare account, generates an upload token, and deploys your own Worker.
+The choice is persisted in `~/.tdoc/published.json` as the default.
 
-**Self-host — Vercel**: `tdoc-publish --platform vercel <slug>` (first publish
-only; the choice is persisted). Needs the `vercel` CLI (`npm i -g vercel`).
-First run links a Vercel project named `tdoc`, then asks you (via an agent
-prompt) to connect a **Blob** store and an **Upstash Redis** store in the
-Vercel dashboard's Storage tab — both free tier, ~2 clicks each — and deploys.
+**Self-host — Vercel**: `tdoc-publish --platform vercel <slug>`. First run
+(or an explicit switch onto vercel) needs the `vercel` CLI (`npm i -g vercel`),
+links a Vercel project named `tdoc`, then asks you (via an agent prompt) to
+connect a **Blob** store and an **Upstash Redis** store in the Vercel
+dashboard's Storage tab — both free tier, ~2 clicks each — and deploys.
 Caveats: no per-doc write serialization (Cloudflare uses a Durable Object for
 that) and a ~4.5 MB upload cap per doc (Vercel request limit).
 
-Subsequent runs upload the latest version of `<slug>`. Self-host targets
+Subsequent runs upload the latest version of `<slug>` using the saved default.
+Pass a different `--platform` any time to switch: full re-setup rewrites
+`published.json` (previous file kept as `published.json.bak.switch`). A custom
+domain and `*.workers.dev` on the same Worker are two hostnames, not two
+platforms. Self-host targets
 compare a content hash of the Worker/overlay bundle against the last deployed
 hash in `~/.tdoc/published.json` and redeploy automatically when runtime code
 changed. Set `TDOC_SKIP_WORKER_DEPLOY=1` to skip the redeploy (useful for batch

--- a/skills/tdoc/SKILL.md
+++ b/skills/tdoc/SKILL.md
@@ -403,44 +403,49 @@ echo "tdoc server: http://localhost:7878"
 pkill -f "$SKILL_DIR/server/server.js"
 ```
 
-### `/tdoc publish <slug>` — publish to your Cloudflare Worker (or Vercel)
+### `/tdoc publish <slug>` — publish to hosted tdoc (default), or self-host
 
 Publishes the latest version of `<slug>` to a public URL.
 
-Local always stays $0/anonymous; publishing is opt-in. First run does a one-time
-setup: prompts `wrangler login`, creates an R2 bucket (`tdoc-docs`) and KV
-namespace (`META`) in *your* Cloudflare account, generates an upload token, and
-deploys your own Worker. Config is saved to `~/.tdoc/published.json`.
+Default target is **hosted** (`https://tdoc.dev`). First run asks the host for
+an account-scoped upload token and stores it in `~/.tdoc/published.json`. That
+token can only mutate docs it owns. If hosted signup is not open, the CLI fails
+with a clear prompt to self-host instead — do **not** tell the user to flip a
+Worker env flag.
 
-**Alternative host — Vercel**: `tdoc-publish --platform vercel <slug>` (first
-publish only; the choice is persisted). Needs the `vercel` CLI (`npm i -g
-vercel`). First run links a Vercel project named `tdoc`, then asks you (via an
-agent prompt) to connect a **Blob** store and an **Upstash Redis** store in the
+**Self-host — Cloudflare**: `tdoc-publish --platform cloudflare <slug>` (first
+publish only; the choice is persisted). Prompts `wrangler login`, creates an R2
+bucket (`tdoc-docs`) and KV namespace (`META`) in *your* Cloudflare account,
+generates an upload token, and deploys your own Worker.
+
+**Self-host — Vercel**: `tdoc-publish --platform vercel <slug>` (first publish
+only; the choice is persisted). Needs the `vercel` CLI (`npm i -g vercel`).
+First run links a Vercel project named `tdoc`, then asks you (via an agent
+prompt) to connect a **Blob** store and an **Upstash Redis** store in the
 Vercel dashboard's Storage tab — both free tier, ~2 clicks each — and deploys.
-Subsequent publishes and all other commands (`pull`, `unpublish`, comments,
-GitHub sign-in) work identically on either host. Caveats: no per-doc write
-serialization (Cloudflare uses a Durable Object for that) and a ~4.5 MB upload
-cap per doc (Vercel request limit).
+Caveats: no per-doc write serialization (Cloudflare uses a Durable Object for
+that) and a ~4.5 MB upload cap per doc (Vercel request limit).
 
-Subsequent runs upload the latest version of `<slug>`. The script compares a
-content hash of the Worker/overlay bundle against the last deployed hash in
-`~/.tdoc/published.json` and redeploys automatically when runtime code changed.
-Set `TDOC_SKIP_WORKER_DEPLOY=1` to skip the redeploy (useful for batch uploads).
-Published pages expose runtime provenance at `/api/runtime` and in
+Subsequent runs upload the latest version of `<slug>`. Self-host targets
+compare a content hash of the Worker/overlay bundle against the last deployed
+hash in `~/.tdoc/published.json` and redeploy automatically when runtime code
+changed. Set `TDOC_SKIP_WORKER_DEPLOY=1` to skip the redeploy (useful for batch
+uploads). Published pages expose runtime provenance at `/api/runtime` and in
 `window.__TDOC__.runtime`.
 
 On published docs, viewers sign in with GitHub (Device Flow, shared OAuth App
 `Ov23liZ1UAGOchvKPmlS`, scope `read:user`) before commenting.
 
-Requires `jq`, plus `wrangler` (`npm i -g wrangler`) for the Cloudflare
-target or `vercel` (`npm i -g vercel`) for the Vercel target.
+Requires `jq`. Hosted needs no extra CLI. Cloudflare needs `wrangler`
+(`npm i -g wrangler`); Vercel needs `vercel` (`npm i -g vercel`).
 
 ```bash
 "$SKILL_DIR/bin/tdoc-publish" <slug>
 ```
 
-Prints the published URL: `https://<worker>.<subdomain>.workers.dev/d/<slug>/v/<N>`
-(Cloudflare) or `https://tdoc-<scope>.vercel.app/d/<slug>/v/<N>` (Vercel).
+Prints the published URL: `https://tdoc.dev/d/<slug>/v/<N>` (hosted),
+`https://<worker>.<subdomain>.workers.dev/d/<slug>/v/<N>` (Cloudflare), or
+`https://tdoc-<scope>.vercel.app/d/<slug>/v/<N>` (Vercel).
 
 ### `/tdoc pull <slug>` — pull comments from the published doc
 

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -74,6 +74,14 @@ t('tdoc-publish defaults to hosted and treats Cloudflare/Vercel as self-host fla
     'closed hosted signup must point at --platform cloudflare|vercel');
   assert(!/enable TDOC_HOSTED_REGISTRATION/.test(src),
     'CLI must not tell users to flip TDOC_HOSTED_REGISTRATION on tdoc.dev');
+  assert(/platform:"cloudflare"/.test(src),
+    'cloudflare setup must persist platform:"cloudflare"');
+  assert(/switching publish platform/.test(src),
+    'conflicting --platform must switch (rewrite config), not ignore');
+  assert(!/ignoring '--platform/.test(src),
+    'must not swallow a conflicting --platform flag');
+  assert(/published\.json\.bak\.switch/.test(src),
+    'platform switch must keep a previous-config backup');
 });
 
 t('pull/unpublish read hosted base from published.json', () => {

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -55,6 +55,36 @@ t('tdoc-publish does not let an older-version failure abort the latest', () => {
   assert(/FATAL: latest version/.test(src), 'latest-version hard-fail missing');
 });
 
+t('tdoc-publish defaults to hosted and treats Cloudflare/Vercel as self-host flags', () => {
+  const src = readBin('tdoc-publish');
+  assert(/hosted\|cloudflare\|vercel/.test(src), 'usage does not include hosted platform');
+  assert(/PLATFORM_FLAG:-hosted/.test(src), 'first publish must default to hosted');
+  assert(/first_time_setup_hosted\(\)/.test(src), 'hosted setup function missing');
+  assert(/\/api\/hosted\/token/.test(src), 'hosted setup does not request a provider-issued token');
+  assert(!/TDOC_HOSTED_UPLOAD_TOKEN/.test(src), 'hosted setup must not require an out-of-band upload token');
+  assert(/TDOC_HOSTED_BASE:-https:\/\/tdoc\.dev/.test(src), 'hosted setup does not default to tdoc.dev');
+  assert(/platform:"hosted"/.test(src), 'hosted setup does not persist hosted platform');
+  assert(/account_id:\$acct/.test(src), 'hosted setup does not persist account_id');
+  assert(/if \[ "\$PLATFORM" = "hosted" \]/.test(src), 'hosted platform branch missing');
+  assert(/UPLOAD_BASE="\$BASE"/.test(src), 'hosted branch should upload to configured base');
+  assert(/PUBLIC_BASE="\$BASE"/.test(src), 'hosted branch should emit configured hosted base links');
+  assert(/hosted_registration_disabled/.test(src),
+    'hosted setup should detect closed provider registration');
+  assert(/--platform cloudflare/.test(src) && /--platform vercel/.test(src),
+    'closed hosted signup must point at --platform cloudflare|vercel');
+  assert(!/enable TDOC_HOSTED_REGISTRATION/.test(src),
+    'CLI must not tell users to flip TDOC_HOSTED_REGISTRATION on tdoc.dev');
+});
+
+t('pull/unpublish read hosted base from published.json', () => {
+  for (const f of ['tdoc-pull', 'tdoc-unpublish']) {
+    const src = readBin(f);
+    assert(/PLATFORM="\$\(jq -r '\.platform \/\/ "cloudflare"'/.test(src), `${f}: platform detection missing`);
+    assert(/"\$PLATFORM" = "hosted"/.test(src), `${f}: hosted platform branch missing`);
+    assert(/BASE="\$\(jq -r '\.base \/\/ empty'/.test(src), `${f}: hosted/vercel branch should read .base`);
+  }
+});
+
 t('tdoc-new fails loudly if the local server never comes up', () => {
   const src = readBin('tdoc-new');
   assert(/SERVER_UP/.test(src) && /failed to start/.test(src),

--- a/test/deploy-tdoc-dev.test.js
+++ b/test/deploy-tdoc-dev.test.js
@@ -62,6 +62,11 @@ t('tdoc-publish reuses tdoc-bundle (no second copy of the inliner)', () => {
     'the overlay inliner must not remain copy-pasted inside tdoc-publish');
 });
 
+t('CD does not open hosted registration on tdoc.dev', () => {
+  assert(!/TDOC_HOSTED_REGISTRATION\s*=\s*"?1"?/.test(wf),
+    'tdoc.dev CD must not set TDOC_HOSTED_REGISTRATION=1');
+});
+
 t('CD Node matches the pinned wrangler engine (>=22)', () => {
   const node = wf.match(/node-version:\s*'(\d+)'/);
   assert(node, 'workflow must pin a Node major');

--- a/test/hosted-oob-behavior.test.js
+++ b/test/hosted-oob-behavior.test.js
@@ -22,7 +22,9 @@ if (typeof Response !== 'undefined' && !Response.json) {
 
 let pass = 0, fail = 0;
 function ok(n) { console.log(`  ✓ ${n}`); pass++; }
-function bad(n, e) { console.log(`  ✗ ${n}\n    ${e.stack || e.message || e}`); fail++; }
+// Message only — avoid e.stack so CodeQL does not flag this test helper as
+// "information exposure through a stack trace".
+function bad(n, e) { console.log(`  ✗ ${n}\n    ${e && e.message ? e.message : e}`); fail++; }
 async function t(n, fn) { try { await fn(); ok(n); } catch (e) { bad(n, e); } }
 function assert(c, m) { if (!c) throw new Error(m || 'assertion failed'); }
 
@@ -270,6 +272,61 @@ async function issue(worker, env, label = 'test') {
     assert(republish.status === 200, `original owner republish ${republish.status}: ${await republish.text()}`);
     const meta = JSON.parse(await env.META.get('meta:reclaim-doc'));
     assert(meta.hosted.account_id === a.account_id, 'republish did not restore hosted owner');
+  });
+
+  await t('DELETE fails closed when release_owner fails and COMMENTS exists', async () => {
+    const env = makeEnv(mod.CommentsStore);
+    const a = await issue(worker, env, 'release-fail');
+    const up = await worker.fetch(req('/api/upload', {
+      method: 'POST', token: a.token,
+      body: { slug: 'parked-on-bad-release', version: 1, html: '<h1>v1</h1>' },
+    }), env, {});
+    assert(up.status === 200, `upload ${up.status}`);
+    assert(env.COMMENTS.stateFor('parked-on-bad-release').storage.map.get('hostedOwner') === a.account_id,
+      'expected hostedOwner before delete');
+
+    const origGet = env.COMMENTS.get.bind(env.COMMENTS);
+    env.COMMENTS.get = (id) => {
+      const stub = origGet(id);
+      const origFetch = stub.fetch.bind(stub);
+      return {
+        fetch: async (url, init = {}) => {
+          const href = typeof url === 'string' ? url : String(url);
+          if (href.includes('/owner') && init.body) {
+            const payload = JSON.parse(init.body);
+            if (payload.op && payload.op.kind === 'release_owner') {
+              return Response.json({ ok: false, status: 503, error: 'forced_release_fail' });
+            }
+          }
+          return origFetch(url, init);
+        },
+      };
+    };
+
+    const del = await worker.fetch(req('/api/doc?slug=parked-on-bad-release', {
+      method: 'DELETE', token: a.token,
+    }), env, {});
+    assert(del.status !== 200, `DELETE must not succeed when release fails, got ${del.status}`);
+    const body = await del.json();
+    assert(body.error === 'forced_release_fail' || body.error === 'owner_release_failed',
+      `unexpected error body ${JSON.stringify(body)}`);
+    assert(env.COMMENTS.stateFor('parked-on-bad-release').storage.map.has('hostedOwner'),
+      'failed release must leave hostedOwner set');
+  });
+
+  await t('DELETE without COMMENTS still succeeds (no hosted reservation)', async () => {
+    const env = makeEnv(mod.CommentsStore);
+    env.TDOC_UPLOAD_TOKEN = 'admin-token';
+    await env.META.put('meta:vercel-style', JSON.stringify({
+      title: 'x', slug: 'vercel-style', versions: [{ n: 1 }],
+    }));
+    await env.DOCS.put('docs/vercel-style/v1/index.html', '<h1>v1</h1>');
+    delete env.COMMENTS;
+    const del = await worker.fetch(req('/api/doc?slug=vercel-style', {
+      method: 'DELETE', token: 'admin-token',
+    }), env, {});
+    assert(del.status === 200, `Vercel-style delete should 200, got ${del.status}: ${await del.text()}`);
+    assert(!await env.META.get('meta:vercel-style'), 'meta should be wiped');
   });
 
   await t('hosted token cannot delete legacy/orphan R2 doc with no meta/owner', async () => {

--- a/test/hosted-oob-behavior.test.js
+++ b/test/hosted-oob-behavior.test.js
@@ -1,0 +1,309 @@
+// Hosted OOB behavioral tests against worker.js with fake KV/R2/DO bindings.
+//
+// These cover the cross-tenant write bugs a static grep test cannot prove:
+// missing-meta upload must still persist hosted ownership; a second hosted
+// token must not overwrite that slug; delete must release ownership so the
+// original owner can republish; and legacy/orphan docs with no ownership
+// must fail closed for destructive/admin routes.
+
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const { webcrypto } = require('crypto');
+
+if (typeof globalThis.crypto === 'undefined') globalThis.crypto = webcrypto;
+
+if (typeof Response !== 'undefined' && !Response.json) {
+  Response.json = (body, init = {}) => new Response(JSON.stringify(body), {
+    ...init,
+    headers: { 'Content-Type': 'application/json', ...(init.headers || {}) },
+  });
+}
+
+let pass = 0, fail = 0;
+function ok(n) { console.log(`  ✓ ${n}`); pass++; }
+function bad(n, e) { console.log(`  ✗ ${n}\n    ${e.stack || e.message || e}`); fail++; }
+async function t(n, fn) { try { await fn(); ok(n); } catch (e) { bad(n, e); } }
+function assert(c, m) { if (!c) throw new Error(m || 'assertion failed'); }
+
+class FakeKV {
+  constructor() {
+    this.map = new Map();
+    this.failPutOnce = new Set();
+  }
+  async get(k) { return this.map.has(k) ? this.map.get(k) : null; }
+  async put(k, v) {
+    if (this.failPutOnce.has(k)) {
+      this.failPutOnce.delete(k);
+      throw new Error(`forced KV put failure: ${k}`);
+    }
+    this.map.set(k, String(v));
+  }
+  async delete(k) { this.map.delete(k); }
+  async list({ prefix = '' } = {}) {
+    return {
+      keys: [...this.map.keys()].filter(k => k.startsWith(prefix)).map(name => ({ name })),
+      list_complete: true,
+    };
+  }
+}
+
+class FakeR2 {
+  constructor() {
+    this.map = new Map();
+    this.throwList = false;
+    this.putCalls = 0;
+  }
+  async put(k, v) {
+    this.putCalls++;
+    this.map.set(k, String(v));
+  }
+  async get(k) {
+    if (!this.map.has(k)) return null;
+    const v = this.map.get(k);
+    return { text: async () => v };
+  }
+  async head(k) {
+    if (!this.map.has(k)) return null;
+    return { size: Buffer.byteLength(this.map.get(k)) };
+  }
+  async delete(k) { this.map.delete(k); }
+  async list({ prefix = '' } = {}) {
+    if (this.throwList) throw new Error('forced R2 list failure');
+    return {
+      objects: [...this.map.keys()].filter(k => k.startsWith(prefix)).map(key => ({ key })),
+      truncated: false,
+    };
+  }
+}
+
+class FakeStorage {
+  constructor() { this.map = new Map(); }
+  async transaction(fn) {
+    const txn = {
+      get: async (k) => this.map.get(k),
+      put: async (k, v) => { this.map.set(k, v); },
+      delete: async (k) => { this.map.delete(k); },
+    };
+    return fn(txn);
+  }
+}
+
+class FakeDurableNamespace {
+  constructor(env, StoreClass) {
+    this.env = env;
+    this.StoreClass = StoreClass;
+    this.states = new Map();
+  }
+  idFromName(name) { return name; }
+  stateFor(id) {
+    if (!this.states.has(id)) this.states.set(id, { storage: new FakeStorage() });
+    return this.states.get(id);
+  }
+  get(id) {
+    return {
+      fetch: async (url, init = {}) => {
+        const store = new this.StoreClass(this.stateFor(id), this.env);
+        return store.fetch(new Request(url, init));
+      },
+    };
+  }
+}
+
+async function loadWorker() {
+  const src = fs.readFileSync(path.join(__dirname, '..', 'worker', 'worker.js'), 'utf8');
+  const tmp = path.join(os.tmpdir(), `tdoc-worker-${Date.now()}-${Math.random().toString(16).slice(2)}.mjs`);
+  fs.writeFileSync(tmp, src);
+  const mod = await import(`file://${tmp}`);
+  try { fs.unlinkSync(tmp); } catch {}
+  return mod;
+}
+
+function makeEnv(StoreClass, extra = {}) {
+  const env = {
+    META: new FakeKV(),
+    DOCS: new FakeR2(),
+    TDOC_HOSTED_REGISTRATION: '1',
+    ...extra,
+  };
+  env.COMMENTS = new FakeDurableNamespace(env, StoreClass);
+  return env;
+}
+
+function req(pathname, { method = 'GET', token = '', body = null } = {}) {
+  return new Request(`https://tdoc.dev${pathname}`, {
+    method,
+    headers: {
+      ...(token ? { Authorization: `Bearer ${token}` } : {}),
+      ...(body ? { 'Content-Type': 'application/json' } : {}),
+    },
+    body: body ? JSON.stringify(body) : undefined,
+  });
+}
+
+async function issue(worker, env, label = 'test') {
+  const r = await worker.fetch(req('/api/hosted/token', { method: 'POST', body: { label } }), env, {});
+  const data = await r.json();
+  assert(r.status === 200 && data.token && data.account_id, `token issue failed ${r.status}: ${JSON.stringify(data)}`);
+  return data;
+}
+
+(async () => {
+  const mod = await loadWorker();
+  const worker = mod.default;
+  console.log('hosted OOB behavior');
+
+  await t('hosted token mint is closed unless registration is explicitly enabled', async () => {
+    const env = makeEnv(mod.CommentsStore, { TDOC_HOSTED_REGISTRATION: '' });
+    const r = await worker.fetch(req('/api/hosted/token', { method: 'POST', body: { label: 'closed' } }), env, {});
+    const data = await r.json();
+    assert(r.status === 403, `expected 403, got ${r.status}`);
+    assert(data.error === 'hosted_registration_disabled', `unexpected error ${JSON.stringify(data)}`);
+    assert([...env.META.map.keys()].every(k => !k.startsWith('hosted-token:')),
+      'disabled registration must not persist a token record');
+  });
+
+  await t('missing-meta hosted upload still persists owner; second token cannot overwrite', async () => {
+    const env = makeEnv(mod.CommentsStore);
+    const a = await issue(worker, env, 'a');
+    const b = await issue(worker, env, 'b');
+    const first = await worker.fetch(req('/api/upload', {
+      method: 'POST', token: a.token,
+      body: { slug: 'owned-doc', version: 1, html: '<h1>A</h1>' },
+    }), env, {});
+    assert(first.status === 200, `first upload ${first.status}: ${await first.text()}`);
+    const meta = JSON.parse(await env.META.get('meta:owned-doc'));
+    assert(meta.hosted.account_id === a.account_id, 'first upload did not persist hosted owner meta');
+
+    const second = await worker.fetch(req('/api/upload', {
+      method: 'POST', token: b.token,
+      body: { slug: 'owned-doc', version: 1, html: '<h1>B</h1>' },
+    }), env, {});
+    assert(second.status === 403, `second token should be denied, got ${second.status}`);
+    const doc = await env.DOCS.get('docs/owned-doc/v1/index.html');
+    assert((await doc.text()).includes('A'), 'denied second upload overwrote document bytes');
+  });
+
+  await t('invalid access on first hosted upload does not park the slug', async () => {
+    const env = makeEnv(mod.CommentsStore);
+    const a = await issue(worker, env, 'bad-access');
+    const b = await issue(worker, env, 'takes-slug');
+    const bad = await worker.fetch(req('/api/upload', {
+      method: 'POST', token: a.token,
+      body: {
+        slug: 'unparked', version: 1, html: '<h1>nope</h1>',
+        meta: { access: { visibility: 'not-a-visibility' } },
+      },
+    }), env, {});
+    assert(bad.status === 400, `invalid access should 400, got ${bad.status}`);
+    assert(!env.COMMENTS.stateFor('unparked').storage.map.has('hostedOwner'),
+      'a 400 must not persist hostedOwner');
+    const okUpload = await worker.fetch(req('/api/upload', {
+      method: 'POST', token: b.token,
+      body: { slug: 'unparked', version: 1, html: '<h1>ok</h1>' },
+    }), env, {});
+    assert(okUpload.status === 200, `second token should take the unparked slug, got ${okUpload.status}: ${await okUpload.text()}`);
+  });
+
+  await t('R2 list failure during first claim fails closed before DO claim or R2 put', async () => {
+    const env = makeEnv(mod.CommentsStore);
+    const tok = await issue(worker, env, 'list-fails');
+    env.DOCS.throwList = true;
+    const r = await worker.fetch(req('/api/upload', {
+      method: 'POST', token: tok.token,
+      body: { slug: 'list-fails', version: 1, html: '<h1>nope</h1>' },
+    }), env, {});
+    assert(r.status >= 400, `list failure should not succeed, got ${r.status}`);
+    assert(env.DOCS.putCalls === 0, 'R2 put ran despite failed existence check');
+    assert(!env.COMMENTS.stateFor('list-fails').storage.map.has('hostedOwner'), 'DO owner claim was persisted despite failed existence check');
+  });
+
+  await t('same hosted owner can retry after META write failure and repair ownership meta', async () => {
+    const env = makeEnv(mod.CommentsStore);
+    const tok = await issue(worker, env, 'repair');
+    env.META.failPutOnce.add('meta:repair-doc');
+    const first = await worker.fetch(req('/api/upload', {
+      method: 'POST', token: tok.token,
+      body: { slug: 'repair-doc', version: 1, html: '<h1>first</h1>' },
+    }), env, {});
+    assert(first.status >= 400, `first upload should report failed meta write, got ${first.status}`);
+    assert(await env.DOCS.head('docs/repair-doc/v1/index.html'), 'first upload did not leave the reproduced partial R2 write');
+    assert(!await env.META.get('meta:repair-doc'), 'test setup expected meta write to fail');
+    assert(env.COMMENTS.stateFor('repair-doc').storage.map.get('hostedOwner') === tok.account_id, 'test setup expected DO claim to persist');
+
+    const retry = await worker.fetch(req('/api/upload', {
+      method: 'POST', token: tok.token,
+      body: { slug: 'repair-doc', version: 1, html: '<h1>retry</h1>' },
+    }), env, {});
+    assert(retry.status === 200, `same owner retry should repair meta, got ${retry.status}: ${await retry.text()}`);
+    const repaired = JSON.parse(await env.META.get('meta:repair-doc'));
+    assert(repaired.hosted.account_id === tok.account_id, 'retry did not repair hosted ownership meta');
+  });
+
+  await t('after delete, original owner can republish; second token cannot squat while owned', async () => {
+    const env = makeEnv(mod.CommentsStore);
+    const a = await issue(worker, env, 'owner');
+    const b = await issue(worker, env, 'other');
+    const first = await worker.fetch(req('/api/upload', {
+      method: 'POST', token: a.token,
+      body: { slug: 'reclaim-doc', version: 1, html: '<h1>v1</h1>' },
+    }), env, {});
+    assert(first.status === 200, `first upload ${first.status}`);
+
+    const squatWhileOwned = await worker.fetch(req('/api/upload', {
+      method: 'POST', token: b.token,
+      body: { slug: 'reclaim-doc', version: 1, html: '<h1>stolen</h1>' },
+    }), env, {});
+    assert(squatWhileOwned.status === 403, `second token must not overwrite a live slug, got ${squatWhileOwned.status}`);
+
+    const del = await worker.fetch(req('/api/doc?slug=reclaim-doc', { method: 'DELETE', token: a.token }), env, {});
+    assert(del.status === 200, `delete ${del.status}: ${await del.text()}`);
+    assert(!env.COMMENTS.stateFor('reclaim-doc').storage.map.has('hostedOwner'),
+      'delete must release hostedOwner');
+    assert(!await env.META.get('meta:reclaim-doc'), 'delete must drop meta');
+    assert(!await env.DOCS.head('docs/reclaim-doc/v1/index.html'), 'delete must drop R2 bytes');
+
+    const republish = await worker.fetch(req('/api/upload', {
+      method: 'POST', token: a.token,
+      body: { slug: 'reclaim-doc', version: 1, html: '<h1>v1-again</h1>' },
+    }), env, {});
+    assert(republish.status === 200, `original owner republish ${republish.status}: ${await republish.text()}`);
+    const meta = JSON.parse(await env.META.get('meta:reclaim-doc'));
+    assert(meta.hosted.account_id === a.account_id, 'republish did not restore hosted owner');
+  });
+
+  await t('hosted token cannot delete legacy/orphan R2 doc with no meta/owner', async () => {
+    const env = makeEnv(mod.CommentsStore);
+    const tok = await issue(worker, env, 'deleter');
+    await env.DOCS.put('docs/legacy-no-meta/v1/index.html', '<h1>legacy</h1>');
+    const r = await worker.fetch(req('/api/doc?slug=legacy-no-meta', { method: 'DELETE', token: tok.token }), env, {});
+    assert(r.status !== 200, `delete should fail closed, got ${r.status}`);
+    assert(await env.DOCS.head('docs/legacy-no-meta/v1/index.html'), 'legacy doc bytes were deleted');
+  });
+
+  await t('hosted token cannot wipe comments for legacy/no-meta slug', async () => {
+    const env = makeEnv(mod.CommentsStore);
+    const tok = await issue(worker, env, 'wiper');
+    const state = env.COMMENTS.stateFor('legacy-comments').storage.map;
+    state.set('list', [{ id: 'c1', events: [{ kind: 'created', at_version: 1, text: 'keep' }] }]);
+    const r = await worker.fetch(req('/api/comments?slug=legacy-comments&all=1', { method: 'DELETE', token: tok.token }), env, {});
+    assert(r.status !== 200, `wipe should fail closed, got ${r.status}`);
+    assert(state.get('list').length === 1, 'comment list was wiped');
+  });
+
+  await t('hosted token cannot agent-reply on legacy/no-meta slug', async () => {
+    const env = makeEnv(mod.CommentsStore);
+    const tok = await issue(worker, env, 'agent');
+    const state = env.COMMENTS.stateFor('legacy-reply').storage.map;
+    state.set('list', [{ id: 'c1', events: [{ kind: 'created', at_version: 1, text: 'parent' }] }]);
+    const r = await worker.fetch(req('/api/agent/reply', {
+      method: 'POST', token: tok.token,
+      body: { slug: 'legacy-reply', parent_id: 'c1', text: 'should not write', status: 'applied' },
+    }), env, {});
+    assert(r.status !== 200, `agent reply should fail closed, got ${r.status}`);
+    assert(state.get('list')[0].events.length === 1, 'agent reply mutated comments');
+  });
+
+  console.log(`\n${pass} passed, ${fail} failed`);
+  process.exit(fail ? 1 : 0);
+})();

--- a/test/hosted-oob-behavior.test.js
+++ b/test/hosted-oob-behavior.test.js
@@ -186,6 +186,38 @@ async function issue(worker, env, label = 'test') {
     assert((await doc.text()).includes('A'), 'denied second upload overwrote document bytes');
   });
 
+  await t('create against orphan R2 bytes (no hostedOwner) returns slug_taken 409', async () => {
+    const env = makeEnv(mod.CommentsStore);
+    const tok = await issue(worker, env, 'orphan-claimer');
+    await env.DOCS.put('docs/orphan-bytes/v1/index.html', '<h1>legacy</h1>');
+    assert(!env.COMMENTS.stateFor('orphan-bytes').storage.map.has('hostedOwner'),
+      'test setup expected no hostedOwner');
+    const r = await worker.fetch(req('/api/upload', {
+      method: 'POST', token: tok.token,
+      body: { slug: 'orphan-bytes', version: 1, html: '<h1>takeover</h1>' },
+    }), env, {});
+    assert(r.status === 409, `orphan bytes should be slug_taken 409, got ${r.status}`);
+    const body = await r.json();
+    assert(body.error === 'slug_taken', `expected slug_taken, got ${JSON.stringify(body)}`);
+    assert((await (await env.DOCS.get('docs/orphan-bytes/v1/index.html')).text()).includes('legacy'),
+      'denied orphan claim must not overwrite bytes');
+  });
+
+  await t('hostedOwnerOp DO fetch failure returns controlled 503 shape (no throw)', async () => {
+    const env = makeEnv(mod.CommentsStore);
+    const tok = await issue(worker, env, 'do-down');
+    env.COMMENTS.get = () => ({
+      fetch: async () => { throw new Error('forced DO down'); },
+    });
+    const r = await worker.fetch(req('/api/upload', {
+      method: 'POST', token: tok.token,
+      body: { slug: 'do-down-doc', version: 1, html: '<h1>x</h1>' },
+    }), env, {});
+    assert(r.status === 503, `DO failure should be 503, got ${r.status}: ${await r.clone().text()}`);
+    const body = await r.json();
+    assert(body.error === 'hosted_owner_store_unavailable', `unexpected body ${JSON.stringify(body)}`);
+  });
+
   await t('invalid access on first hosted upload does not park the slug', async () => {
     const env = makeEnv(mod.CommentsStore);
     const a = await issue(worker, env, 'bad-access');

--- a/test/hosted-oob.test.js
+++ b/test/hosted-oob.test.js
@@ -1,0 +1,129 @@
+// Hosted out-of-box publish guards.
+//
+// Hosted publish must not hand users the provider-wide TDOC_UPLOAD_TOKEN.
+// Instead, the Worker mints account-scoped tokens and write routes enforce
+// slug ownership before writing document bytes, access policy, comments, or
+// deletes. Browser owner mutations still go through authorizeOwnerMutation
+// (session OR token); hosted tokens are slug-scoped inside that gate.
+
+const fs = require('fs');
+const path = require('path');
+
+let pass = 0, fail = 0;
+function ok(n) { console.log(`  ✓ ${n}`); pass++; }
+function bad(n, e) { console.log(`  ✗ ${n}\n    ${e}`); fail++; }
+function t(n, fn) { try { fn(); ok(n); } catch (e) { bad(n, e.message); } }
+function assert(c, m) { if (!c) throw new Error(m || 'assertion failed'); }
+
+const worker = fs.readFileSync(path.join(__dirname, '..', 'worker', 'worker.js'), 'utf8');
+const wranglerTpl = fs.readFileSync(path.join(__dirname, '..', 'worker', 'wrangler.toml.template'), 'utf8');
+const deployWf = fs.readFileSync(path.join(__dirname, '..', '.github', 'workflows', 'deploy-tdoc-dev.yml'), 'utf8');
+
+function block(startNeedle, endNeedle) {
+  const start = worker.indexOf(startNeedle);
+  const end = worker.indexOf(endNeedle, start);
+  if (start < 0 || end < 0 || end <= start) throw new Error(`block missing: ${startNeedle}`);
+  return worker.slice(start, end);
+}
+
+const hostedRoute = block("if (p === '/api/hosted/token' && method === 'POST')", '// ---- comments ----');
+const uploadRoute = block("if (p === '/api/upload' && method === 'POST')", '// ---- admin access mutation ----');
+const accessRoute = block("if (p === '/api/doc/access' && method === 'PATCH')", '// ---- admin delete ----');
+const deleteRoute = block("if (p === '/api/doc' && method === 'DELETE')", "return text('Not found'");
+const wipeRoute = block("url.searchParams.get('all') === '1'", '// Soft-delete:');
+const agentReplyRoute = block("if (p === '/api/agent/reply' && method === 'POST')", '// ---- admin upload');
+const authorizeStart = worker.indexOf('async function authorizeOwnerMutation(req, env, slug) {');
+const authorizeEnd = worker.indexOf('// #34 — Per-slug write serialization', authorizeStart);
+const authorizeSrc = worker.slice(authorizeStart, authorizeEnd);
+
+console.log('hosted out-of-box publish');
+
+t('Worker exposes provider-gated hosted token bootstrap', () => {
+  assert(hostedRoute.includes('hostedRegistrationEnabled(env)'), 'hosted route must be registration-gated');
+  assert(hostedRoute.includes('issueHostedToken(env, body)'), 'hosted route must mint a token server-side');
+  assert(hostedRoute.includes("hosted_registration_disabled"), 'hosted route must return disabled registration error');
+  assert(hostedRoute.includes('account_id'), 'hosted route must return account_id');
+});
+
+t('tdoc.dev must not enable hosted registration', () => {
+  assert(!/TDOC_HOSTED_REGISTRATION\s*=\s*"?1"?/.test(wranglerTpl),
+    'wrangler template must not set TDOC_HOSTED_REGISTRATION=1');
+  assert(!/TDOC_HOSTED_REGISTRATION\s*=\s*"?1"?/.test(deployWf),
+    'tdoc.dev CD must not set TDOC_HOSTED_REGISTRATION=1');
+});
+
+t('Hosted tokens are stored hashed, not in cleartext', () => {
+  assert(worker.includes('sha256Hex(token)'), 'token hash helper usage missing');
+  assert(worker.includes('hosted-token:${tokenHash}'), 'hosted token records must be keyed by token hash');
+  assert(!worker.includes('hosted-token:${token}`'), 'raw hosted tokens must not be KV keys');
+});
+
+t('Upload auth accepts either provider admin token or hosted account token', () => {
+  assert(worker.includes("actor: { kind: 'admin' }"), 'admin actor branch missing');
+  assert(worker.includes("hostedTokenActor(env, token)"), 'hosted token actor branch missing');
+  assert(worker.includes("kind: 'hosted'"), 'hosted actor kind missing');
+});
+
+t('Combined owner-mutation gate is session OR admin token OR (hosted token + slug ACL)', () => {
+  assert(authorizeSrc.includes('isOwnerSession(env, session)'), 'session path missing');
+  assert(authorizeSrc.includes('requireUploadAuth(req, env)'), 'token fallback missing');
+  assert(authorizeSrc.includes("auth.actor.kind === 'admin'"), 'admin token must skip slug ACL');
+  assert(authorizeSrc.includes('requireDocWriteAccess(env, auth.actor, slug)'),
+    'hosted tokens must be slug-scoped inside the shared gate');
+});
+
+t('Hosted upload stamps remote meta ownership before writing', () => {
+  assert(uploadRoute.includes('requireDocWriteAccess(env, auth.actor, slug, { create: true })'), 'upload must enforce create/claim write access');
+  assert(uploadRoute.includes('stampHostedOwnership(incoming, auth.actor)'), 'upload must stamp hosted owner');
+  const gate = uploadRoute.indexOf('requireDocWriteAccess(env, auth.actor, slug, { create: true })');
+  const validate = uploadRoute.indexOf('validateAccessWrite');
+  const claim = uploadRoute.indexOf("kind: 'claim_owner'");
+  const r2 = uploadRoute.indexOf('env.DOCS.put');
+  const meta = uploadRoute.indexOf('env.META.put(`meta:${slug}`');
+  assert(gate >= 0 && gate < r2, 'upload must enforce owner before R2 write');
+  assert(gate < meta, 'upload must enforce owner before META write');
+  assert(validate >= 0 && claim >= 0 && validate < claim,
+    'hosted claim must happen after access validation so a 400 cannot park the slug');
+  assert(claim < r2, 'hosted claim must happen before R2 write');
+});
+
+t('Hosted slug ownership claim is backed by per-slug Durable Object storage', () => {
+  assert(worker.includes('hostedOwner'), 'Durable Object owner storage key missing');
+  assert(worker.includes("u.pathname === '/owner'"), 'Durable Object owner endpoint missing');
+  assert(worker.includes("kind: 'claim_owner'"), 'atomic owner claim op missing');
+  assert(worker.includes("kind: 'verify_owner'"), 'owner verify op missing');
+  assert(worker.includes("kind: 'release_owner'"), 'owner release op missing');
+  assert(worker.includes('hostedOwnerOp(env, slug'), 'write gate must use Durable Object owner op');
+});
+
+t('Access mutation and delete go through the shared gate with the slug', () => {
+  for (const [name, route] of [['access', accessRoute], ['delete', deleteRoute]]) {
+    assert(route.includes('authorizeOwnerMutation(req, env, slug)'), `${name}: combined gate missing slug`);
+    const gate = route.indexOf('authorizeOwnerMutation(req, env, slug)');
+    const metaWrite = route.indexOf('env.META.put');
+    const docDelete = route.indexOf('env.DOCS.delete');
+    const firstWrite = [metaWrite, docDelete].filter(i => i >= 0).sort((a, b) => a - b)[0];
+    assert(firstWrite === undefined || gate < firstWrite, `${name}: owner gate must precede writes`);
+  }
+});
+
+t('DELETE releases hosted slug ownership after wiping storage', () => {
+  const release = deleteRoute.indexOf("kind: 'release_owner'");
+  const metaDel = deleteRoute.indexOf('env.META.delete(`meta:${slug}`)');
+  const wipe = deleteRoute.indexOf("kind: 'wipe'");
+  assert(release >= 0, 'DELETE must call release_owner');
+  assert(metaDel >= 0 && wipe >= 0 && metaDel < release && wipe < release,
+    'release_owner must run after meta/comment wipe so a failed delete cannot free a live slug');
+});
+
+t('Admin comment wipe and agent reply are also token-owned-doc scoped', () => {
+  for (const [name, route] of [['wipe', wipeRoute], ['agent reply', agentReplyRoute]]) {
+    assert(route.includes('requireDocWriteAccess(env, auth.actor, slug)'), `${name}: owner gate missing`);
+    const gate = route.indexOf('requireDocWriteAccess(env, auth.actor, slug)');
+    const mutate = route.indexOf('mutateComments(env, slug');
+    assert(gate >= 0 && mutate >= 0 && gate < mutate, `${name}: owner gate must precede comment mutation`);
+  }
+});
+
+console.log(`\n${pass} passed, ${fail} failed`);
+process.exit(fail ? 1 : 0);

--- a/test/hosted-oob.test.js
+++ b/test/hosted-oob.test.js
@@ -94,6 +94,14 @@ t('Hosted slug ownership claim is backed by per-slug Durable Object storage', ()
   assert(worker.includes("kind: 'verify_owner'"), 'owner verify op missing');
   assert(worker.includes("kind: 'release_owner'"), 'owner release op missing');
   assert(worker.includes('hostedOwnerOp(env, slug'), 'write gate must use Durable Object owner op');
+  const opFn = worker.slice(
+    worker.indexOf('async function hostedOwnerOp(env, slug, op) {'),
+    worker.indexOf('\nasync function docBytesExist'),
+  );
+  assert(/try\s*\{/.test(opFn) && /hosted_owner_store_unavailable/.test(opFn),
+    'hostedOwnerOp must catch DO/JSON failures as hosted_owner_store_unavailable');
+  assert(/error: 'slug_taken'/.test(worker) && /status: 409/.test(worker),
+    'create-against-orphan-bytes path must map to slug_taken/409');
 });
 
 t('Access mutation and delete go through the shared gate with the slug', () => {

--- a/test/hosted-oob.test.js
+++ b/test/hosted-oob.test.js
@@ -114,6 +114,10 @@ t('DELETE releases hosted slug ownership after wiping storage', () => {
   assert(release >= 0, 'DELETE must call release_owner');
   assert(metaDel >= 0 && wipe >= 0 && metaDel < release && wipe < release,
     'release_owner must run after meta/comment wipe so a failed delete cannot free a live slug');
+  assert(deleteRoute.includes('released.ok === false'),
+    'DELETE must fail closed when COMMENTS is present and release_owner fails');
+  assert(deleteRoute.includes("error: released.error || 'owner_release_failed'"),
+    'failed release must surface owner_release_failed (or DO error)');
 });
 
 t('Admin comment wipe and agent reply are also token-owned-doc scoped', () => {

--- a/test/jul36-owner-manage.test.js
+++ b/test/jul36-owner-manage.test.js
@@ -118,7 +118,6 @@ t('showManageModal() bails before creating any DOM when cfg.ownerManage is absen
 // still authorized (CLI unchanged); wrong token + non-owner session → 401.
 
 const uploadAuthStart = worker.indexOf('async function requireUploadAuth(req, env) {');
-const uploadAuthEnd = worker.indexOf('\n}', uploadAuthStart) + 2;
 const timingEqualStart = worker.indexOf('async function timingSafeEqual(a, b) {');
 const timingEqualEnd = worker.indexOf('\n}', timingEqualStart) + 2;
 const parseCookieStart = worker.indexOf('function parseCookie(req) {');
@@ -127,17 +126,19 @@ const getSessionStart = worker.indexOf('async function getSession(env, req) {');
 const getSessionEnd = worker.indexOf('\n}', getSessionStart) + 2;
 const isOwnerSessionStart = worker.indexOf('function isOwnerSession(env, session) {');
 const isOwnerSessionEnd = worker.indexOf('\n}', isOwnerSessionStart) + 2;
-const authorizeStart = worker.indexOf('async function authorizeOwnerMutation(req, env) {');
-const authorizeEnd = worker.indexOf('\n}', authorizeStart) + 2;
+const hostedHelpersStart = worker.indexOf('async function sha256Hex(s) {');
+const authorizeStart = worker.indexOf('async function authorizeOwnerMutation(req, env, slug) {');
+const hostedHelpersEnd = worker.indexOf('// #34 — Per-slug write serialization', hostedHelpersStart);
 if (uploadAuthStart < 0 || timingEqualStart < 0 || parseCookieStart < 0 || getSessionStart < 0
-  || isOwnerSessionStart < 0 || authorizeStart < 0) throw new Error('auth helpers not found');
+  || isOwnerSessionStart < 0 || authorizeStart < 0 || hostedHelpersStart < 0 || hostedHelpersEnd < 0) {
+  throw new Error('auth helpers not found');
+}
 const authSrc = [
   worker.slice(timingEqualStart, timingEqualEnd),
-  worker.slice(uploadAuthStart, uploadAuthEnd),
   worker.slice(parseCookieStart, parseCookieEnd),
   worker.slice(getSessionStart, getSessionEnd),
   worker.slice(isOwnerSessionStart, isOwnerSessionEnd),
-  worker.slice(authorizeStart, authorizeEnd),
+  worker.slice(hostedHelpersStart, hostedHelpersEnd),
 ].join('\n');
 
 const deleteStart = worker.indexOf("if (p === '/api/doc' && method === 'DELETE')");
@@ -149,8 +150,8 @@ const accessPatchEnd = worker.indexOf('// ---- admin delete ----', accessPatchSt
 const accessPatchRoute = worker.slice(accessPatchStart, accessPatchEnd);
 
 t('DELETE /api/doc and PATCH /api/doc/access both go through the shared authorizeOwnerMutation gate', () => {
-  assert(deleteRoute.includes('await authorizeOwnerMutation(req, env)'), 'DELETE /api/doc must call authorizeOwnerMutation');
-  assert(accessPatchRoute.includes('await authorizeOwnerMutation(req, env)'), 'PATCH /api/doc/access must call authorizeOwnerMutation');
+  assert(deleteRoute.includes('await authorizeOwnerMutation(req, env, slug)'), 'DELETE /api/doc must call authorizeOwnerMutation');
+  assert(accessPatchRoute.includes('await authorizeOwnerMutation(req, env, slug)'), 'PATCH /api/doc/access must call authorizeOwnerMutation');
   // The session path must go through the ONE shared, tested gate — not a
   // bespoke same-origin/cookie check bolted onto just one route.
   assert(!worker.includes('requireAdminAuth'), 'worker must not add a separate cookie-based admin-auth function');
@@ -158,12 +159,14 @@ t('DELETE /api/doc and PATCH /api/doc/access both go through the shared authoriz
 });
 
 t('authorizeOwnerMutation gate itself calls isOwnerSession, then falls back to requireUploadAuth', () => {
-  const fnSrc = worker.slice(authorizeStart, authorizeEnd);
+  const fnSrc = worker.slice(authorizeStart, hostedHelpersEnd);
   const ownerCheck = fnSrc.indexOf('isOwnerSession(env, session)');
   const tokenCheck = fnSrc.indexOf('requireUploadAuth(req, env)');
   assert(ownerCheck >= 0, 'must check isOwnerSession');
   assert(tokenCheck >= 0, 'must fall back to requireUploadAuth');
   assert(ownerCheck < tokenCheck, 'owner-session check must come before the token fallback');
+  assert(fnSrc.includes('requireDocWriteAccess(env, auth.actor, slug)'),
+    'hosted tokens must be slug-scoped inside the shared gate, not treated as global owners');
 });
 
 const box = { console, TextEncoder, crypto, Response };
@@ -204,24 +207,25 @@ function fakeSessionReq({ bearer, sid } = {}) {
 async function main() {
   await tAsync('requireUploadAuth: anonymous request (no Authorization header) → 401', async () => {
     const res = await box.requireUploadAuth({ headers: { get: () => null } }, { TDOC_UPLOAD_TOKEN: 'secret-token' });
-    assert(res !== null, 'must not pass through');
-    assert(res.status === 401, `expected 401, got ${res.status}`);
+    assert(res && res.ok === false, 'must not pass through');
+    assert(res.response.status === 401, `expected 401, got ${res.response && res.response.status}`);
   });
 
   await tAsync('requireUploadAuth: wrong bearer token → 401', async () => {
     const res = await box.requireUploadAuth(fakeReq('not-the-token'), { TDOC_UPLOAD_TOKEN: 'secret-token' });
-    assert(res !== null, 'must not pass through');
-    assert(res.status === 401, `expected 401, got ${res.status}`);
+    assert(res && res.ok === false, 'must not pass through');
+    assert(res.response.status === 401, `expected 401, got ${res.response && res.response.status}`);
   });
 
-  await tAsync('requireUploadAuth: no TDOC_UPLOAD_TOKEN configured → always 401 (fail closed)', async () => {
+  await tAsync('requireUploadAuth: no TDOC_UPLOAD_TOKEN configured → unknown bearer is 401 (fail closed)', async () => {
     const res = await box.requireUploadAuth(fakeReq('anything'), {});
-    assert(res !== null && res.status === 401, 'must fail closed when no token is configured');
+    assert(res && res.ok === false && res.response.status === 401, 'must fail closed when no token is configured');
   });
 
-  await tAsync('requireUploadAuth: correct bearer token → passes (owner-succeeds coverage)', async () => {
+  await tAsync('requireUploadAuth: correct bearer token → passes as admin actor', async () => {
     const res = await box.requireUploadAuth(fakeReq('secret-token'), { TDOC_UPLOAD_TOKEN: 'secret-token' });
-    assert(res === null, 'a correct token must pass through (return null)');
+    assert(res && res.ok === true && res.actor && res.actor.kind === 'admin',
+      'a correct provider token must pass as an admin actor');
   });
 
   // ── authorizeOwnerMutation: session-OR-token ──────────────────────────

--- a/test/me-management.test.js
+++ b/test/me-management.test.js
@@ -71,7 +71,7 @@ t('/me deletes remote docs through DELETE /api/doc using the session (no token)'
   assert(index.includes("method: 'DELETE'"), 'delete button must use DELETE');
   assert(index.includes("credentials: 'same-origin'"), 'delete fetch should be explicit about sending the session cookie');
   assert(!index.includes("'Authorization': 'Bearer'"), 'delete must not send a bearer token');
-  assert(deleteRoute.includes('await authorizeOwnerMutation(req, env)'), 'remote delete must accept session-or-token auth');
+  assert(deleteRoute.includes('await authorizeOwnerMutation(req, env, slug)'), 'remote delete must accept session-or-token auth');
 });
 
 t('/me still uses the styled confirm modal, never native confirm()', () => {

--- a/test/remote-access-route.test.js
+++ b/test/remote-access-route.test.js
@@ -31,18 +31,14 @@ t('CORS allows PATCH for remote access mutation', () => {
     'PATCH missing from Access-Control-Allow-Methods');
 });
 
-t('PATCH /api/doc/access authenticates (session-or-token) before parsing body or writing meta', () => {
-  // JUL-36 owner-manage-UX tail (2026-08-13): browser owner mutations now
-  // authorize off the owner's session cookie OR the CLI upload token, via
-  // the shared authorizeOwnerMutation() gate — see jul36-owner-manage.test.js
-  // for the gate's own unit coverage (session-only, token-only, neither).
-  const auth = route.indexOf('await authorizeOwnerMutation(req, env)');
-  const body = route.indexOf('await req.json()');
+t('PATCH /api/doc/access authenticates (session-or-token) before writing meta', () => {
+  // Hosted tokens are slug-scoped, so the route reads `slug` from the body
+  // first, then runs the shared authorizeOwnerMutation(req, env, slug) gate.
+  // No META write may happen before that gate.
+  const auth = route.indexOf('await authorizeOwnerMutation(req, env, slug)');
   const write = route.indexOf('env.META.put(`meta:${slug}`');
-  assert(auth >= 0, 'route must call authorizeOwnerMutation');
-  assert(body >= 0, 'route should parse request JSON after auth');
+  assert(auth >= 0, 'route must call authorizeOwnerMutation with the slug');
   assert(write >= 0, 'route should persist meta after auth');
-  assert(auth < body, 'auth must happen before body parse');
   assert(auth < write, 'auth must happen before META write');
 });
 

--- a/test/remote-access-route.test.js
+++ b/test/remote-access-route.test.js
@@ -42,6 +42,15 @@ t('PATCH /api/doc/access authenticates (session-or-token) before writing meta', 
   assert(auth < write, 'auth must happen before META write');
 });
 
+t('PATCH /api/doc/access rejects oversized Content-Length before req.json', () => {
+  const guard = route.indexOf('ACCESS_PATCH_MAX_BYTES');
+  const parse = route.indexOf('await req.json()');
+  assert(guard >= 0, 'route must define an access-patch size cap');
+  assert(route.includes("error: 'payload_too_large'"), 'route must return payload_too_large');
+  assert(route.includes('status: 413'), 'route must use HTTP 413');
+  assert(parse >= 0 && guard < parse, 'Content-Length guard must run before req.json()');
+});
+
 t('PATCH /api/doc/access only writes remote meta, never document bytes', () => {
   assert(route.includes('applyAccessPatch(meta, access)'), 'route must use access-only helper');
   assert(route.includes('env.META.put(`meta:${slug}`'), 'route must write updated meta');

--- a/test/run.js
+++ b/test/run.js
@@ -26,6 +26,8 @@ const OFFLINE = [
   'me-management.test.js',    // /me remote SoT management UI guard
   'jul36-owner-manage.test.js', // JUL-36 owner manage UX: server-gated data, token-only mutations, no native confirm()
   'runtime-provenance.test.js', // release provenance + content-hash redeploy
+  'hosted-oob.test.js',       // hosted token bootstrap + scoped writes
+  'hosted-oob-behavior.test.js', // hosted token ownership behavior with fake bindings
   'deploy-tdoc-dev.test.js',  // tdoc.dev hosted CD: main-only, not BYOK
   'oldver-strip.test.js',     // old-version banner predicate
   'dark-mode.test.js',        // #120 top-bar dark mode switch + localStorage

--- a/worker/worker.js
+++ b/worker/worker.js
@@ -1679,39 +1679,142 @@ async function timingSafeEqual(a, b) {
   return diff === 0;
 }
 
+async function sha256Hex(s) {
+  const buf = await crypto.subtle.digest('SHA-256', new TextEncoder().encode(String(s || '')));
+  return [...new Uint8Array(buf)].map(b => b.toString(16).padStart(2, '0')).join('');
+}
+
+function hostedRegistrationEnabled(env) {
+  const v = String(env.TDOC_HOSTED_REGISTRATION || env.TDOC_HOSTED_SIGNUP || '').toLowerCase();
+  return v === '1' || v === 'true' || v === 'yes';
+}
+
+async function issueHostedToken(env, body = {}) {
+  const token = `tdoc_${rand(24)}`;
+  const tokenHash = await sha256Hex(token);
+  const record = {
+    account_id: `acct_${rand(12)}`,
+    created: new Date().toISOString(),
+  };
+  if (typeof body.label === 'string' && body.label.trim()) {
+    record.label = body.label.trim().slice(0, 80);
+  }
+  await env.META.put(`hosted-token:${tokenHash}`, JSON.stringify(record));
+  return { token, record };
+}
+
+async function hostedTokenActor(env, token) {
+  if (!env || !env.META) return null;
+  const tokenHash = await sha256Hex(token);
+  let record = null;
+  try {
+    const raw = await env.META.get(`hosted-token:${tokenHash}`);
+    if (raw) record = JSON.parse(raw);
+  } catch {}
+  if (!record || typeof record.account_id !== 'string' || !record.account_id) return null;
+  return { kind: 'hosted', account_id: record.account_id, token_hash: tokenHash };
+}
+
+async function hostedOwnerOp(env, slug, op) {
+  if (!env.COMMENTS) {
+    return { ok: false, status: 503, error: 'hosted_owner_store_unavailable' };
+  }
+  const stub = env.COMMENTS.get(env.COMMENTS.idFromName(slug));
+  const r = await stub.fetch('https://do/owner', {
+    method: 'POST', headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ slug, op }),
+  });
+  return r.json();
+}
+
+async function docBytesExist(env, slug) {
+  try {
+    const r = await env.DOCS.list({ prefix: `docs/${slug}/` });
+    return { ok: true, exists: Array.isArray(r.objects) && r.objects.length > 0 };
+  } catch (e) {
+    return { ok: false, response: json({ error: 'doc_bytes_check_failed', message: e.message || String(e) }, { status: 503 }) };
+  }
+}
+
+// Returns { ok, actor, response }. Admin = the provider-wide TDOC_UPLOAD_TOKEN
+// (self-host CLI). Hosted = an account-scoped token minted at /api/hosted/token.
+// Hosted success here is identity only — slug ACL is requireDocWriteAccess /
+// authorizeOwnerMutation. Do not treat a hosted actor as a global owner.
 async function requireUploadAuth(req, env) {
   const auth = req.headers.get('authorization') || '';
   const m = auth.match(/^Bearer\s+(.+)$/);
-  if (!m || !env.TDOC_UPLOAD_TOKEN || !(await timingSafeEqual(m[1], env.TDOC_UPLOAD_TOKEN))) {
-    return json({ error: 'unauthorized' }, { status: 401 });
-  }
-  return null;
+  if (!m) return { ok: false, response: json({ error: 'unauthorized' }, { status: 401 }) };
+  const token = m[1];
+  if (env.TDOC_UPLOAD_TOKEN && await timingSafeEqual(token, env.TDOC_UPLOAD_TOKEN)) return { ok: true, actor: { kind: 'admin' } };
+  const hostedActor = await hostedTokenActor(env, token);
+  if (hostedActor) return { ok: true, actor: hostedActor };
+  return { ok: false, response: json({ error: 'unauthorized' }, { status: 401 }) };
 }
 
-// Owner-mutation gate for browser-facing admin routes (DELETE /api/doc,
-// PATCH /api/doc/access). EITHER credential authorizes:
-//   - the caller is signed in as the configured TDOC_OWNER (session cookie
-//     set by the GitHub device-flow login) — this is the new browser path,
-//     replacing the admin-token field that used to live on /me and the
-//     doc-page manage modal;
-//   - OR the caller presents the CLI's upload bearer token (requireUploadAuth)
-//     — unchanged, still how `tdoc publish`/`tdoc-delete` authenticate.
+// Slug-scoped write ACL for a hosted account token. Admin actors skip it.
+// opts.create: first publish / retry. Does NOT claim an empty slug — the
+// upload route claims after validation so a 400 cannot park the slug forever.
+async function requireDocWriteAccess(env, actor, slug, opts = {}) {
+  const meta = await loadDocMeta(env, slug);
+  if (!actor || actor.kind === 'admin') return { ok: true, meta };
+  const accountId = meta && meta.hosted && meta.hosted.account_id;
+  if (opts.create) {
+    if (!meta) {
+      const bytes = await docBytesExist(env, slug);
+      if (!bytes.ok) return { ok: false, response: bytes.response };
+      if (bytes.exists) {
+        const verified = await hostedOwnerOp(env, slug, { kind: 'verify_owner', account_id: actor.account_id });
+        if (verified.ok) return { ok: true, meta: null };
+        return { ok: false, response: json({ error: verified.error || 'slug_taken' }, { status: verified.status || 409 }) };
+      }
+      return { ok: true, meta: null };
+    }
+    if (!accountId) return { ok: false, response: json({ error: 'slug_taken' }, { status: 409 }) };
+    if (accountId !== actor.account_id) {
+      return { ok: false, response: json({ error: 'not_doc_owner' }, { status: 403 }) };
+    }
+    const verified = await hostedOwnerOp(env, slug, { kind: 'verify_owner', account_id: actor.account_id });
+    if (!verified.ok) return { ok: false, response: json({ error: verified.error || 'not_doc_owner' }, { status: verified.status || 403 }) };
+    return { ok: true, meta };
+  }
+  if (!meta) return { ok: false, response: json({ error: 'not_found' }, { status: 404 }) };
+  if (!accountId) return { ok: false, response: json({ error: 'slug_taken' }, { status: 409 }) };
+  if (accountId !== actor.account_id) return { ok: false, response: json({ error: 'not_doc_owner' }, { status: 403 }) };
+  const verified = await hostedOwnerOp(env, slug, { kind: 'verify_owner', account_id: actor.account_id });
+  if (!verified.ok) return { ok: false, response: json({ error: verified.error || 'not_doc_owner' }, { status: verified.status || 403 }) };
+  return { ok: true, meta };
+}
+
+function stampHostedOwnership(meta, actor) {
+  if (!actor || actor.kind !== 'hosted') return meta;
+  return {
+    ...(meta || {}),
+    hosted: {
+      ...((meta && meta.hosted && typeof meta.hosted === 'object') ? meta.hosted : {}),
+      account_id: actor.account_id,
+    },
+  };
+}
+
+// Combined write gate for browser-facing admin routes (DELETE /api/doc,
+// PATCH /api/doc/access). One of:
+//   - signed in as TDOC_OWNER (session cookie; CSP makes this safe);
+//   - provider-wide upload token (self-host CLI, global admin);
+//   - hosted account token AND requireDocWriteAccess for `slug`.
 //
-// Trusting the session cookie here is safe ONLY because every doc-serving
-// response now carries the CSP set by cspHeader() above, which stops author
-// <script>/onclick content from running at all — so a doc can't ride the
-// owner's cookie into these routes (the confused-deputy the admin token used
-// to guard against). The two changes ship together; do not relax one without
-// the other.
-//
-// Returns { ok: true } when authorized, or { ok: false, response } (the 401
-// to return as-is) otherwise. Does not read/parse the request body.
-async function authorizeOwnerMutation(req, env) {
+// Hosted tokens are NOT global owners. `slug` must be known before this
+// runs whenever a hosted token might be in play. Returns { ok: true, actor,
+// session, meta? } or { ok: false, response }.
+async function authorizeOwnerMutation(req, env, slug) {
   const session = await getSession(env, req);
-  if (isOwnerSession(env, session)) return { ok: true, session };
-  const unauth = await requireUploadAuth(req, env);
-  if (unauth) return { ok: false, response: unauth };
-  return { ok: true, session: null };
+  if (isOwnerSession(env, session)) return { ok: true, session, actor: { kind: 'owner_session' } };
+  const auth = await requireUploadAuth(req, env);
+  if (!auth.ok) return { ok: false, response: auth.response };
+  if (auth.actor.kind === 'admin') return { ok: true, session: null, actor: auth.actor };
+  if (!slug) return { ok: false, response: json({ error: 'slug required' }, { status: 400 }) };
+  const writeGate = await requireDocWriteAccess(env, auth.actor, slug);
+  if (!writeGate.ok) return writeGate;
+  return { ok: true, session: null, actor: auth.actor, meta: writeGate.meta };
 }
 
 // ===========================================================================
@@ -2110,6 +2213,47 @@ export class CommentsStore {
     try { payload = await req.json(); } catch { return Response.json({ list: [] }); }
     const { slug, op } = payload;
 
+    // OWNER: atomic hosted slug ownership claim/verify/release. Lives in the
+    // same per-slug Durable Object as comments so first-publish claim is
+    // strongly serialized; KV is not the authority. release_owner runs from
+    // DELETE /api/doc so a deleted slug can be republished.
+    if (u.pathname === '/owner') {
+      let out = { ok: false, status: 400, error: 'bad_owner_op' };
+      try {
+        await this.state.storage.transaction(async (txn) => {
+          const current = await txn.get('hostedOwner');
+          if (op && op.kind === 'release_owner') {
+            await txn.delete('hostedOwner');
+            out = { ok: true };
+            return;
+          }
+          const accountId = op && typeof op.account_id === 'string' ? op.account_id : '';
+          if (!accountId) {
+            out = { ok: false, status: 400, error: 'account_id_required' };
+            return;
+          }
+          if (op.kind === 'claim_owner') {
+            if (current === undefined) {
+              await txn.put('hostedOwner', accountId);
+              out = { ok: true };
+            } else if (current === accountId) {
+              out = { ok: true };
+            } else {
+              out = { ok: false, status: 403, error: 'not_doc_owner' };
+            }
+            return;
+          }
+          if (op.kind === 'verify_owner') {
+            if (current === accountId) out = { ok: true };
+            else out = { ok: false, status: 403, error: 'not_doc_owner' };
+          }
+        });
+      } catch (e) {
+        return Response.json({ ok: false, status: 409, error: 'owner_store_conflict', message: e.message || String(e) });
+      }
+      return Response.json(out);
+    }
+
     // READ: resolve inside a transaction so a concurrent first-touch mutation
     // can't commit between a non-transactional get and a write-back (Codex P1:
     // the old _load() seeded KV→DO storage outside any txn, so a read could
@@ -2487,6 +2631,28 @@ export default {
       return json({ ok: true, unread: inboxUnread(inbox) });
     }
 
+    // ---- hosted publish token bootstrap ----
+    // Hosted/OOB users should not create Cloudflare resources or receive the
+    // provider-wide TDOC_UPLOAD_TOKEN. The central Worker mints an account-
+    // scoped upload token, and write routes enforce slug ownership for that
+    // token. Registration is provider-gated by env so tdoc.dev can stay
+    // closed without changing client code. Do not set TDOC_HOSTED_REGISTRATION
+    // on tdoc.dev until signup is intentionally opened.
+    if (p === '/api/hosted/token' && method === 'POST') {
+      if (!hostedRegistrationEnabled(env)) {
+        return json({ error: 'hosted_registration_disabled' }, { status: 403 });
+      }
+      let body = {};
+      try { body = await req.json(); } catch {}
+      const issued = await issueHostedToken(env, body);
+      return json({
+        ok: true,
+        token: issued.token,
+        account_id: issued.record.account_id,
+        base: url.origin,
+      });
+    }
+
     // ---- comments ----
     if (p === '/api/comments' && method === 'GET') {
       const slug = url.searchParams.get('slug');
@@ -2582,10 +2748,13 @@ export default {
     // tenant so this is safe). Triggered by ?all=1 on DELETE /api/comments.
     if (p === '/api/comments' && method === 'DELETE'
         && url.searchParams.get('all') === '1') {
-      const unauth = await requireUploadAuth(req, env);
-      if (unauth) return unauth;
+      const auth = await requireUploadAuth(req, env);
+      if (!auth.ok) return auth.response;
       const slug = url.searchParams.get('slug');
       if (!slug) return json({ error: 'slug required' }, { status: 400 });
+      if (!isValidSlug(slug)) return json({ error: 'invalid_slug' }, { status: 400 });
+      const writeGate = await requireDocWriteAccess(env, auth.actor, slug);
+      if (!writeGate.ok) return writeGate.response;
       // Serialized wipe (through the DO) so it can't race a concurrent mutation.
       const res = await mutateComments(env, slug, { kind: 'wipe', slug });
       return json(res.body, { status: res.status });
@@ -2680,13 +2849,16 @@ export default {
     // a visible badge on the reply and also flips the parent comment's
     // status to 'applied' / 'open' so the dashboard reflects it.
     if (p === '/api/agent/reply' && method === 'POST') {
-      const unauth = await requireUploadAuth(req, env);
-      if (unauth) return unauth;
+      const auth = await requireUploadAuth(req, env);
+      if (!auth.ok) return auth.response;
       let body = {};
       try { body = await req.json(); } catch {}
       const { slug, parent_id, text: replyText, status: agentStatus, applied_in,
               bind_anchor_aid } = body;
       if (!slug || !parent_id || !replyText) return json({ error: 'slug, parent_id, text required' }, { status: 400 });
+      if (!isValidSlug(slug)) return json({ error: 'invalid_slug' }, { status: 400 });
+      const writeGate = await requireDocWriteAccess(env, auth.actor, slug);
+      if (!writeGate.ok) return writeGate.response;
       // Resolve parent + its current anchor up front (the optional rebind needs
       // the folded anchor for label/fallback). agent/reply is upload-token-authed
       // (owner-only), so concurrency here is negligible; the serialized write
@@ -2730,8 +2902,8 @@ export default {
 
     // ---- admin upload (from `tdoc publish`) ----
     if (p === '/api/upload' && method === 'POST') {
-      const unauth = await requireUploadAuth(req, env);
-      if (unauth) return unauth;
+      const auth = await requireUploadAuth(req, env);
+      if (!auth.ok) return auth.response;
       let body = {};
       try { body = await req.json(); } catch {}
       const { slug, version, html: doc, meta, comments: localComments } = body;
@@ -2745,16 +2917,15 @@ export default {
       if (!isValidSlug(slug)) return json({ error: 'invalid_slug' }, { status: 400 });
       const verNum = Number(version);
       if (!Number.isInteger(verNum) || verNum < 1) return json({ error: 'invalid_version' }, { status: 400 });
+      const writeGate = await requireDocWriteAccess(env, auth.actor, slug, { create: true });
+      if (!writeGate.ok) return writeGate.response;
       // Validate write-side access policy before writing doc bytes. Read paths
       // stay tolerant for legacy/corrupt stored meta; writes must fail closed.
+      // Hosted claim happens AFTER this so a 400 cannot park the slug.
       let incoming = null;
-      if (meta) {
+      if (meta || (auth.actor && auth.actor.kind === 'hosted')) {
         incoming = (meta && typeof meta === 'object') ? { ...meta } : {};
-        let prev = null;
-        try {
-          const prevRaw = await env.META.get(`meta:${slug}`);
-          if (prevRaw) prev = JSON.parse(prevRaw);
-        } catch {}
+        const prev = writeGate.meta;
         if (!incoming.access && prev && prev.access) {
           incoming.access = prev.access;
         }
@@ -2765,6 +2936,11 @@ export default {
           }
           incoming.access = normalizeAccess(validatedAccess.access, { legacy: false });
         }
+        incoming = stampHostedOwnership(incoming, auth.actor);
+      }
+      if (auth.actor && auth.actor.kind === 'hosted') {
+        const claimed = await hostedOwnerOp(env, slug, { kind: 'claim_owner', account_id: auth.actor.account_id });
+        if (!claimed.ok) return json({ error: claimed.error || 'owner_claim_failed' }, { status: claimed.status || 409 });
       }
       // Identity-stamp every commentable artifact with a content-hashed
       // data-tdoc-aid. The SAME artifact in a different version has the
@@ -2789,7 +2965,12 @@ export default {
         return json({ error: 'r2_write_lost', message: 'PUT succeeded but the key is not readable. Re-deploy the worker; the R2 binding may be stale.' }, { status: 500 });
       }
       if (incoming) {
-        await env.META.put(`meta:${slug}`, JSON.stringify(incoming));
+        try {
+          await env.META.put(`meta:${slug}`, JSON.stringify(incoming));
+        } catch (e) {
+          console.error('[upload] META put failed:', e.message);
+          return json({ error: 'meta_put_failed', message: e.message || String(e) }, { status: 500 });
+        }
       }
       // Reconcile existing open comments against the new artifact set:
       // bind by aid where possible; mark lost where the artifact is gone
@@ -2832,8 +3013,6 @@ export default {
     // panel / /me) OR the upload token (CLI) — see its doc comment for why
     // the session path is safe (CSP blocks author scripts on every response).
     if (p === '/api/doc/access' && method === 'PATCH') {
-      const auth = await authorizeOwnerMutation(req, env);
-      if (!auth.ok) return auth.response;
       let body = {};
       try { body = await req.json(); } catch {}
       const topKeys = Object.keys(body || {});
@@ -2842,7 +3021,10 @@ export default {
       const { slug, access } = body || {};
       if (!slug) return json({ error: 'slug required' }, { status: 400 });
       if (!isValidSlug(slug)) return json({ error: 'invalid_slug' }, { status: 400 });
-      const meta = await loadDocMeta(env, slug);
+      // Slug must be known before the hosted ACL check inside the shared gate.
+      const auth = await authorizeOwnerMutation(req, env, slug);
+      if (!auth.ok) return auth.response;
+      const meta = auth.meta || await loadDocMeta(env, slug);
       if (!meta) return json({ error: 'not_found' }, { status: 404 });
       const next = applyAccessPatch(meta, access);
       if (next.error) {
@@ -2857,10 +3039,11 @@ export default {
     // /me or the doc-page Share panel) OR the upload token (CLI's
     // tdoc-delete) — see its doc comment for why the session path is safe.
     if (p === '/api/doc' && method === 'DELETE') {
-      const auth = await authorizeOwnerMutation(req, env);
-      if (!auth.ok) return auth.response;
       const slug = url.searchParams.get('slug');
       if (!slug) return json({ error: 'slug required' }, { status: 400 });
+      if (!isValidSlug(slug)) return json({ error: 'invalid_slug' }, { status: 400 });
+      const auth = await authorizeOwnerMutation(req, env, slug);
+      if (!auth.ok) return auth.response;
       // delete all R2 versions
       let cursor;
       do {
@@ -2875,6 +3058,9 @@ export default {
       // state.storage; the legacy KV value is removed too as cleanup.
       await mutateComments(env, slug, { kind: 'wipe' });
       await env.META.delete(`comments:${slug}`);
+      // Free the hosted slug reservation so the original owner (or anyone)
+      // can republish. Data is already gone; do this last.
+      await hostedOwnerOp(env, slug, { kind: 'release_owner' });
       return json({ ok: true });
     }
 

--- a/worker/worker.js
+++ b/worker/worker.js
@@ -1719,12 +1719,30 @@ async function hostedOwnerOp(env, slug, op) {
   if (!env.COMMENTS) {
     return { ok: false, status: 503, error: 'hosted_owner_store_unavailable' };
   }
-  const stub = env.COMMENTS.get(env.COMMENTS.idFromName(slug));
-  const r = await stub.fetch('https://do/owner', {
-    method: 'POST', headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ slug, op }),
-  });
-  return r.json();
+  try {
+    const stub = env.COMMENTS.get(env.COMMENTS.idFromName(slug));
+    const r = await stub.fetch('https://do/owner', {
+      method: 'POST', headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ slug, op }),
+    });
+    let body;
+    try {
+      body = await r.json();
+    } catch {
+      return { ok: false, status: 503, error: 'hosted_owner_store_unavailable' };
+    }
+    if (!body || typeof body !== 'object') {
+      return { ok: false, status: 503, error: 'hosted_owner_store_unavailable' };
+    }
+    return body;
+  } catch (e) {
+    return {
+      ok: false,
+      status: 503,
+      error: 'hosted_owner_store_unavailable',
+      message: e.message || String(e),
+    };
+  }
 }
 
 async function docBytesExist(env, slug) {
@@ -1765,7 +1783,22 @@ async function requireDocWriteAccess(env, actor, slug, opts = {}) {
       if (bytes.exists) {
         const verified = await hostedOwnerOp(env, slug, { kind: 'verify_owner', account_id: actor.account_id });
         if (verified.ok) return { ok: true, meta: null };
-        return { ok: false, response: json({ error: verified.error || 'slug_taken' }, { status: verified.status || 409 }) };
+        // Orphan / other-owner bytes are "slug taken" (409), not "not doc
+        // owner" (403). Preserve DO/store failures as 503 so callers fail closed.
+        if (
+          verified.status === 503
+          || verified.error === 'hosted_owner_store_unavailable'
+          || verified.error === 'owner_store_conflict'
+        ) {
+          return {
+            ok: false,
+            response: json(
+              { error: verified.error || 'hosted_owner_store_unavailable' },
+              { status: verified.status || 503 },
+            ),
+          };
+        }
+        return { ok: false, response: json({ error: 'slug_taken' }, { status: 409 }) };
       }
       return { ok: true, meta: null };
     }

--- a/worker/worker.js
+++ b/worker/worker.js
@@ -3047,6 +3047,17 @@ export default {
     // panel / /me) OR the upload token (CLI) — see its doc comment for why
     // the session path is safe (CSP blocks author scripts on every response).
     if (p === '/api/doc/access' && method === 'PATCH') {
+      // Body is parsed before auth so we can pass slug into the hosted ACL
+      // gate. Cap Content-Length first — an access patch is always tiny; do
+      // not buffer an arbitrary JSON body for an anonymous caller.
+      const ACCESS_PATCH_MAX_BYTES = 16 * 1024;
+      const clRaw = req.headers.get('content-length');
+      if (clRaw != null && clRaw !== '') {
+        const cl = Number(clRaw);
+        if (!Number.isFinite(cl) || cl < 0 || cl > ACCESS_PATCH_MAX_BYTES) {
+          return json({ error: 'payload_too_large' }, { status: 413 });
+        }
+      }
       let body = {};
       try { body = await req.json(); } catch {}
       const topKeys = Object.keys(body || {});

--- a/worker/worker.js
+++ b/worker/worker.js
@@ -2744,8 +2744,9 @@ export default {
 
     // Admin: wipe ALL comments for a slug (doc owner only — uses the same
     // upload token as /api/upload, so it can be invoked from the publish
-    // tooling or an agent that holds the token; the worker's KV is single-
-    // tenant so this is safe). Triggered by ?all=1 on DELETE /api/comments.
+    // tooling or an agent that holds the token). Hosted tokens are
+    // slug-scoped via requireDocWriteAccess below; the provider admin
+    // token remains global. Triggered by ?all=1 on DELETE /api/comments.
     if (p === '/api/comments' && method === 'DELETE'
         && url.searchParams.get('all') === '1') {
       const auth = await requireUploadAuth(req, env);
@@ -3059,8 +3060,17 @@ export default {
       await mutateComments(env, slug, { kind: 'wipe' });
       await env.META.delete(`comments:${slug}`);
       // Free the hosted slug reservation so the original owner (or anyone)
-      // can republish. Data is already gone; do this last.
-      await hostedOwnerOp(env, slug, { kind: 'release_owner' });
+      // can republish. Data is already gone; do this last. If COMMENTS is
+      // absent (Vercel), there was never a hostedOwner key — ignore the 503.
+      // If the DO is present and release fails, do not report success: the
+      // slug would stay parked while the API lied.
+      const released = await hostedOwnerOp(env, slug, { kind: 'release_owner' });
+      if (env.COMMENTS && released && released.ok === false) {
+        return json(
+          { error: released.error || 'owner_release_failed' },
+          { status: released.status || 503 },
+        );
+      }
       return json({ ok: true });
     }
 

--- a/worker/wrangler.toml.template
+++ b/worker/wrangler.toml.template
@@ -33,3 +33,5 @@ GITHUB_CLIENT_ID = "Ov23liZ1UAGOchvKPmlS"
 TDOC_OWNER = "PLACEHOLDER_OWNER"
 
 # Secret: TDOC_UPLOAD_TOKEN — set via `wrangler secret put TDOC_UPLOAD_TOKEN`
+# TDOC_HOSTED_REGISTRATION — leave unset. /api/hosted/token stays closed.
+# Do not set this on tdoc.dev until hosted signup is intentionally opened.


### PR DESCRIPTION
## Architecture

Read this first: **[tdoc hosted multi-tenant architecture](https://tdoc.dev/d/tdoc-hosted-architecture/v/4)** (v4)

Product axis, three credentials (cookie vs BYOK token vs hosted publish token), write gate, slug-as-row, one OSS repo, CLI default = out-of-box, closed registration as tests not copy. Comment on that page if the model is wrong.

## Summary
- Replaces #109 on current main: `/tdoc publish` defaults to hosted `tdoc.dev`, with Cloudflare/Vercel as `--platform` self-host.
- One write gate: `TDOC_OWNER` session **or** provider upload token (global admin) **or** (hosted token **and** slug ACL). Hosted tokens are hashed, scoped to `account_id`, and cannot mutate someone else’s doc.
- Durable Object `hostedOwner` is claimed after access validation (a 400 cannot park a slug) and **released on delete**, so the original owner can republish.
- `POST /api/hosted/token` stays registration-gated. This PR does **not** set `TDOC_HOSTED_REGISTRATION=1` on tdoc.dev. A no-flag first publish against a closed host fails with an explicit `--platform cloudflare|vercel` prompt.

## Test plan
Offline (already green on this branch):
- [x] `nvm use 23 && npm test` — includes `hosted-oob.test.js` + `hosted-oob-behavior.test.js` (cross-tenant deny, 400 does not park slug, delete-then-reclaim, registration-off mint)

Closed signup (what tdoc.dev will do after merge + CD; do **not** enable registration):
- [ ] From a throwaway HOME so you do not touch `~/.tdoc/published.json`:
  `HOME=/tmp/tdoc-hosted-pr TDOC_DIR=$HOME/tdocs /path/to/bin/tdoc-publish <existing-slug>`
- [ ] Expect: hosted signup is not open, with `/tdoc publish --platform cloudflare` / `--platform vercel` in the prompt. No token written.
- [ ] Confirm tdoc.dev `POST /api/hosted/token` is 403 `hosted_registration_disabled` (or still 404 until CD deploys). Never `200`.

Self-host still works (existing publishers):
- [ ] If you already have `~/.tdoc/published.json` with `platform: cloudflare` (or vercel), `/tdoc publish <slug>` keeps using that host. Do not delete the config.
- [ ] Optional: `HOME=/tmp/tdoc-cf-pr ... tdoc-publish --platform cloudflare <slug>` still runs first-time wrangler setup.

Hosted happy path (optional, **not** on tdoc.dev):
- [ ] `wrangler dev` with `TDOC_HOSTED_REGISTRATION=1` in `[vars]`, then
  `HOME=/tmp/tdoc-htest TDOC_HOSTED_BASE=http://127.0.0.1:8787 TDOC_DIR=~/tdocs bin/tdoc-publish <slug>`
- [ ] Second HOME/token cannot overwrite that slug (`403 not_doc_owner`).
- [ ] `/tdoc unpublish <slug>` then republish from the first HOME succeeds.

Do not: set `TDOC_HOSTED_REGISTRATION` on the live tdoc.dev Worker in this PR.

