### PR TITLE
feat: sandboxed interactive widget islands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,11 @@ file and `.claude-plugin/plugin.json`.
 ### Added
 
 - **Sandboxed interactive widgets.** Author JS still does not run in the host
-  document. Computation lives in `/d/:slug/v/:n/widget/:name`, framed with
-  `sandbox="allow-scripts"` (no `allow-same-origin`). Top-level widget URLs
-  403. Overlay comments on the iframe as one artifact.
+  document. Computation lives in `/d/:slug/v/:n/widget/:name`, loaded only as
+  `Sec-Fetch-Dest: iframe`, with `sandbox="allow-scripts"` on the iframe and
+  `Content-Security-Policy: sandbox allow-scripts` on the widget response
+  (unique origin even if the host iframe rewrite misses). Overlay comments
+  on the iframe as one artifact.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ file and `.claude-plugin/plugin.json`.
 
 ## [Unreleased]
 
+### Added
+
+- **Sandboxed interactive widgets.** Author JS still does not run in the host
+  document. Computation lives in `/d/:slug/v/:n/widget/:name`, framed with
+  `sandbox="allow-scripts"` (no `allow-same-origin`). Top-level widget URLs
+  403. Overlay comments on the iframe as one artifact.
+
 ### Fixed
 
 - **Tables and wide diagrams are no longer clipped in the reader.** Overlay

--- a/SKILL.md
+++ b/SKILL.md
@@ -168,6 +168,7 @@ sharing, with GitHub auth gating comments.
   <slug>/
     meta.json          # { title, created, versions: [...] }
     v1/index.html
+    v1/widgets/<name>.html  # optional; sandboxed JS island, served at /widget/<name>
     v2/index.html
     comments.json      # [{ id, version, anchor, text, status }]
 ```
@@ -175,6 +176,7 @@ sharing, with GitHub auth gating comments.
 Server runs at `http://localhost:7878` (override with `TDOC_PORT`) and serves:
 - `/` — index of all docs
 - `/d/<slug>/v/<n>` — a specific version (injects comment overlay)
+- `/d/<slug>/v/<n>/widget/<name>` — sandboxed interactive island (no overlay)
 - `/api/comments` GET/POST — comment persistence
 - `/api/ping` — health check; responds `{"ok":true,"service":"tdoc"}`. The
   `service` field is the identity marker — a foreign service answering 200 on
@@ -228,7 +230,7 @@ sleep 1
    - All CSS inline in `<style>`. **No JavaScript** — author `<script>` tags do not execute (CSP; see "Interactivity: CSS only" under HTML generation rules).
    - No external CDNs unless requested. No build step.
    - Clean reading-typography (system font stack, generous line-height, max-width ~720px for prose) UNLESS the doc is primarily a diagram, in which case go full-bleed.
-   - Interactive: if the prompt implies a model or diagram, build it with the CSS-only techniques in "Interactivity: CSS only" — `:checked` toggles, CSS keyframes, `<style>` inside the `<svg>`. If the idea genuinely needs computation, follow the fallbacks in that section; do NOT emit JavaScript, which fails silently and leaves the reader an empty box.
+   - Interactive: if the prompt implies a model or diagram, build it with the CSS-only techniques in "Interactivity: CSS only" — `:checked` toggles, CSS keyframes, `<style>` inside the `<svg>`. If the idea genuinely needs computation, emit a sandboxed widget island (see that section); do NOT put `<script>` in the host document.
 3. Write `meta.json`:
    ```json
    { "title": "...", "slug": "...", "created": "<iso>", "versions": [{ "n": 1, "created": "<iso>", "prompt": "..." }] }
@@ -619,17 +621,40 @@ Give each SVG its own class names and `@keyframes` names (`flow-a` / `flowdash-a
 
 **When the prompt wants something CSS can't express**
 
-Game of Life, a Monte Carlo model, a parameter sweep. Don't write the JS anyway: it
-fails silently and the reader gets an empty rectangle where the point of the doc was.
-Pick one:
+Game of Life, a live calculator, a parameter sweep. Do **not** put `<script>` in
+the host document — it is inert under CSP. Two options:
 
-- Pre-compute the interesting states and switch between them with `:checked`.
-- Render the outcome as a static SVG chart or diagram with the numbers baked in.
-- Show a short CSS-animated loop of the phenomenon.
+1. **Sandboxed island (preferred when it must compute).** Write a second HTML
+   file and embed it as an iframe. Overlay comments on the iframe as one
+   artifact (`iframe[src]` is already commentable). Do not walk into the frame.
 
-Then note in the doc what was simplified, so the reader isn't misled about what
-they're looking at. Do not invent a `/widget/` iframe or a sandboxed island —
-that route does not exist yet (issue #138).
+   ```
+   ~/tdocs/<slug>/v1/index.html
+   ~/tdocs/<slug>/v1/widgets/compound-interest.html
+   ```
+
+   Host document:
+
+   ```html
+   <iframe
+     sandbox="allow-scripts"
+     src="/d/<slug>/v/1/widget/compound-interest"
+     title="Compound interest"
+     style="width:100%;height:320px;border:0">
+   </iframe>
+   ```
+
+   The `sandbox` attribute must be `allow-scripts` only — never add
+   `allow-same-origin`. The server rewrites matching widget iframes to that
+   value even if the author HTML forgets or adds extra flags. Widget HTML is a
+   full document; inline `<script>` there **does** run. Do not use `srcdoc`,
+   `data:`, or `blob:` — those inherit the host CSP and the script stays dead.
+
+2. **Precompute** if an island is overkill: `:checked` panels, a static SVG, or
+   a CSS loop, and note in the doc what was simplified.
+
+Fork/export of a doc with islands is not supported in v1 (the downloaded file
+cannot fetch `/widget/` URLs).
 
 ### Default styling — DO NOT re-style the doc
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -226,9 +226,9 @@ sleep 1
 ### `/tdoc new <prompt>` — create a new doc
 
 1. Pick a slug from the prompt (kebab-case, ≤4 words).
-2. Create `~/tdocs/<slug>/v1/index.html` — a **fully self-contained** HTML file:
-   - All CSS inline in `<style>`. **No JavaScript** — author `<script>` tags do not execute (CSP; see "Interactivity: CSS only" under HTML generation rules).
-   - No external CDNs unless requested. No build step.
+2. Create `~/tdocs/<slug>/v1/index.html` — the host document:
+   - All host CSS inline in `<style>`. **No JavaScript in the host** — those tags do not execute (CSP; see HTML generation rules). If the idea needs computation, also write `v1/widgets/<name>.html` and iframe it.
+   - No external CDNs in the host unless requested. No build step.
    - Clean reading-typography (system font stack, generous line-height, max-width ~720px for prose) UNLESS the doc is primarily a diagram, in which case go full-bleed.
    - Interactive: if the prompt implies a model or diagram, build it with the CSS-only techniques in "Interactivity: CSS only" — `:checked` toggles, CSS keyframes, `<style>` inside the `<svg>`. If the idea genuinely needs computation, emit a sandboxed widget island (see that section); do NOT put `<script>` in the host document.
 3. Write `meta.json`:
@@ -537,20 +537,22 @@ When the user reports a problem, check these first:
 
 ## HTML generation rules
 
-- **Author JavaScript does not run — write none.** Every doc is served under a nonce-based CSP (`script-src 'nonce-<n>' 'strict-dynamic'; object-src 'none'; base-uri 'none';`) and the nonce is stamped onto the two injected overlay scripts *only*. Author `<script>` tags (inline or `src`), `onclick=`/`onchange=` attributes, and `javascript:` URLs have no nonce, so the browser refuses them: no error in the page, no visible failure — just a widget that never does anything. This is true on **both** the local server (`server/server.js` → `cspHeader`, `injectOverlay`) and published docs (`worker/worker.js` → `cspHeader`, `injectOverlayCfg`). Build interactivity with CSS instead — see "Interactivity: CSS only" below.
-- Self-contained: one HTML file. No imports. External `<script src>` is blocked by the same CSP, so a CDN library (D3, Chart.js, …) will not load even if the user asks for one — say so rather than shipping a dead reference.
+- **Host HTML does not run author JavaScript.** Every host document is served under a nonce-based CSP (`script-src 'nonce-<n>' 'strict-dynamic'; object-src 'none'; base-uri 'none';`) and the nonce is stamped onto the two injected overlay scripts *only*. Host `<script>` tags (inline or `src`), `onclick=`/`onchange=` attributes, and `javascript:` URLs have no nonce, so the browser refuses them: no error in the page, no visible failure — just a control that never does anything. This is true on **both** the local server (`server/server.js` → `cspHeader`, `injectOverlay`) and published docs (`worker/worker.js` → `cspHeader`, `injectOverlayCfg`).
+  **Exception — sandboxed island:** if the doc needs computation, write `v<n>/widgets/<name>.html` and embed `<iframe sandbox="allow-scripts" src="/d/<slug>/v/<n>/widget/<name>">`. Inline `<script>` in that widget file **does** run. Never put author JS in the host document. See "When the prompt wants something CSS can't express" below.
+- Host document is one HTML file (no imports). Optional islands are extra files under `v<n>/widgets/`. External `<script src>` in the host is blocked by the same CSP, so a CDN library (D3, Chart.js, …) will not load in the host — put it in a widget island or say so rather than shipping a dead reference.
 - Sandboxed-safe: the server serves docs inside an iframe overlay-host, so don't rely on top-level navigation or parent-frame access.
 - The comment overlay is injected by the server — **don't** add commenting UI yourself.
 - Don't add a "made with tdoc" footer, version selector, or share button. The shell handles those.
-- Use SVG for diagrams (commentable text, and CSS can animate it). **Don't use `<canvas>`** — nothing can draw to it without JS, so it renders as a blank box.
+- Use SVG for diagrams (commentable text, and CSS can animate it). **Don't use `<canvas>` in the host** — nothing can draw to it without JS. Draw inside a widget island if needed.
 - Default font stack: `system-ui, -apple-system, "Segoe UI", Roboto, sans-serif`. Mono: `ui-monospace, "SF Mono", Menlo, monospace`.
 
 ### Interactivity: CSS only
 
-Author `<script>` never executes (see above), so every moving or switchable part
-of a doc has to be declarative. The patterns below are verified on this runtime;
-a working reference doc using all three is at
-`~/tdocs/agent-gui-integration/v1/index.html`.
+Author `<script>` in the **host** document never executes (see above), so every
+moving or switchable part of the host has to be declarative. The patterns below
+are verified on this runtime; a working reference doc using all three is at
+`~/tdocs/agent-gui-integration/v1/index.html`. Computed state belongs in a
+sandboxed island, not in the host.
 
 **1. Toggles and mode switches — `:checked` + sibling selectors**
 
@@ -609,15 +611,16 @@ fully self-contained:
 Give each SVG its own class names and `@keyframes` names (`flow-a` / `flowdash-a`,
 `flow-b` / `flowdash-b`) so two figures on one page don't collide.
 
-**What does NOT work**
+**What does NOT work in the host document**
 
-- `<script>` of any kind, `on*=` handler attributes, `javascript:` URLs — all inert.
+- `<script>` of any kind, `on*=` handler attributes, `javascript:` URLs — all inert
+  in the host. The same tags **do** run inside `v<n>/widgets/<name>.html`.
 - **SMIL** (`<animate>`, `<animateMotion>`, `<animateTransform>`): verified not to
   run here — the SVG timeline stays frozen at `getCurrentTime() === 0`. Use CSS
   animation instead.
-- `<canvas>`: a blank box without JS.
-- Anything with computed state — simulations, a slider that recalculates a model,
-  live data, sorting or filtering a table, form validation.
+- `<canvas>` in the host: a blank box without JS. Draw inside a widget island if needed.
+- Computed state in the host — simulations, a slider that recalculates a model,
+  live data, sorting or filtering a table, form validation. Use a sandboxed island.
 
 **When the prompt wants something CSS can't express**
 
@@ -685,8 +688,8 @@ What to write:
     <h1>{title}</h1>
     <p class="meta">{subtitle or attribution}</p>
     <!-- content here using plain <h2>, <h3>, <p>, <ul>, <pre>, <table>, etc. -->
-    <!-- interactivity goes in <style>, not <script>: author scripts are
-         blocked by CSP. See "Interactivity: CSS only" above. -->
+    <!-- host interactivity goes in <style>, not <script>. Computation
+         belongs in v1/widgets/<name>.html. See HTML generation rules. -->
   </div>
 </body></html>
 ```

--- a/bin/tdoc-publish
+++ b/bin/tdoc-publish
@@ -716,6 +716,16 @@ upload_version() {
   # upload is safe. Default to [] when there's no local comments.json.
   local comments_file="$DOC_DIR/comments.json"
   local payload
+  local widgets_json="{}"
+  local wdir="$DOC_DIR/v${v}/widgets"
+  if [ -d "$wdir" ]; then
+    local wf wname
+    for wf in "$wdir"/*.html; do
+      [ -f "$wf" ] || continue
+      wname="$(basename "$wf" .html)"
+      widgets_json="$(jq -n --argjson acc "$widgets_json" --arg name "$wname" --rawfile html "$wf" '$acc + {($name): $html}')" || return 1
+    done
+  fi
   if [ -f "$comments_file" ] && jq -e 'type == "array" and length > 0' "$comments_file" >/dev/null 2>&1; then
     payload="$(jq -n \
       --arg slug "$SLUG" \
@@ -723,14 +733,16 @@ upload_version() {
       --rawfile html "$html_path" \
       --slurpfile meta "$META_FILE" \
       --slurpfile comments "$comments_file" \
-      '{slug:$slug, version:$version, html:$html, meta: $meta[0], comments: $comments[0]}')"
+      --argjson widgets "$widgets_json" \
+      '{slug:$slug, version:$version, html:$html, meta: $meta[0], comments: $comments[0]} + (if $widgets == {} then {} else {widgets:$widgets} end)')"
   else
     payload="$(jq -n \
       --arg slug "$SLUG" \
       --argjson version "$v" \
       --rawfile html "$html_path" \
       --slurpfile meta "$META_FILE" \
-      '{slug:$slug, version:$version, html:$html, meta: $meta[0]}')"
+      --argjson widgets "$widgets_json" \
+      '{slug:$slug, version:$version, html:$html, meta: $meta[0]} + (if $widgets == {} then {} else {widgets:$widgets} end)')"
   fi
   # Pass the payload via a temp file, not an argument — docs with embedded
   # images exceed ARG_MAX as a curl argument (curl: Argument list too long).

--- a/server/server.js
+++ b/server/server.js
@@ -244,19 +244,26 @@ function isValidWidgetName(name) {
   return typeof name === 'string' && /^[a-z0-9][a-z0-9-]{0,63}$/.test(name);
 }
 function widgetCspHeader() {
-  return "default-src 'none'; script-src 'unsafe-inline'; style-src 'unsafe-inline'; object-src 'none'; base-uri 'none'; frame-ancestors 'self'; worker-src 'none'; form-action 'none'";
+  return "default-src 'none'; script-src 'unsafe-inline'; style-src 'unsafe-inline'; object-src 'none'; base-uri 'none'; frame-ancestors 'self'; worker-src 'none'; form-action 'none'; sandbox allow-scripts";
 }
 function isWidgetFrameRequest(dest) {
-  const d = String(dest || '').toLowerCase();
-  return d === 'iframe' || d === 'embed' || d === 'frame';
+  return String(dest || '').toLowerCase() === 'iframe';
 }
 function forceWidgetSandbox(html) {
   if (typeof html !== 'string') return html;
   return html.replace(/<iframe\b([^>]*?)>/gi, (full, attrs) => {
     const srcM = /\bsrc\s*=\s*(?:"([^"]*)"|'([^']*)'|([^\s>]+))/i.exec(attrs);
     if (!srcM) return full;
-    const src = srcM[1] || srcM[2] || srcM[3] || '';
-    if (!/\/d\/[a-z0-9][a-z0-9-]{0,63}\/v\/\d+\/widget\/[a-z0-9][a-z0-9-]{0,63}\/?$/i.test(src.split('?')[0])) return full;
+    const src = String(srcM[1] || srcM[2] || srcM[3] || '').trim();
+    let path;
+    try {
+      const u = new URL(src, 'https://tdoc-widget-src.invalid');
+      if (u.hostname !== 'tdoc-widget-src.invalid') return full;
+      path = u.pathname;
+    } catch {
+      return full;
+    }
+    if (!/^\/d\/[a-z0-9][a-z0-9-]{0,63}\/v\/\d+\/widget\/[a-z0-9][a-z0-9-]{0,63}\/?$/i.test(path)) return full;
     const stripped = attrs.replace(/\s*sandbox\s*=\s*(?:"[^"]*"|'[^']*'|[^\s>]+)/gi, '');
     return '<iframe sandbox="allow-scripts"' + stripped + '>';
   });
@@ -529,6 +536,8 @@ const server = http.createServer(async (req, res) => {
       'Content-Type': 'text/html; charset=utf-8',
       'Content-Security-Policy': widgetCspHeader(),
       'X-Content-Type-Options': 'nosniff',
+      'Cache-Control': 'no-store',
+      'Vary': 'Sec-Fetch-Dest',
     });
   }
 

--- a/server/server.js
+++ b/server/server.js
@@ -236,7 +236,34 @@ function cspHeader(nonce) {
   return `script-src 'nonce-${nonce}' 'strict-dynamic'; object-src 'none'; base-uri 'none';`;
 }
 
+// Interactive islands (#138). Host documents keep cspHeader(); computation
+// lives in a separately served HTML resource framed with sandbox="allow-scripts"
+// (never allow-same-origin). srcdoc/blob inherit the parent CSP and cannot
+// run author JS — these must be real URLs.
+function isValidWidgetName(name) {
+  return typeof name === 'string' && /^[a-z0-9][a-z0-9-]{0,63}$/.test(name);
+}
+function widgetCspHeader() {
+  return "default-src 'none'; script-src 'unsafe-inline'; style-src 'unsafe-inline'; object-src 'none'; base-uri 'none'; frame-ancestors 'self'; worker-src 'none'; form-action 'none'";
+}
+function isWidgetFrameRequest(dest) {
+  const d = String(dest || '').toLowerCase();
+  return d === 'iframe' || d === 'embed' || d === 'frame';
+}
+function forceWidgetSandbox(html) {
+  if (typeof html !== 'string') return html;
+  return html.replace(/<iframe\b([^>]*?)>/gi, (full, attrs) => {
+    const srcM = /\bsrc\s*=\s*(?:"([^"]*)"|'([^']*)'|([^\s>]+))/i.exec(attrs);
+    if (!srcM) return full;
+    const src = srcM[1] || srcM[2] || srcM[3] || '';
+    if (!/\/widget\/[a-z0-9][a-z0-9-]{0,63}\/?$/i.test(src.split('?')[0])) return full;
+    const stripped = attrs.replace(/\s*sandbox\s*=\s*(?:"[^"]*"|'[^']*'|[^\s>]+)/gi, '');
+    return '<iframe sandbox="allow-scripts"' + stripped + '>';
+  });
+}
+
 function injectOverlay(html, slug, version, nonce) {
+  html = forceWidgetSandbox(html);
   const overlay = fs.readFileSync(OVERLAY_PATH, 'utf8');
   // Hand the overlay the full version list so the bar can offer a version
   // picker. Read straight from meta.json; ignore failures and fall back to
@@ -484,6 +511,22 @@ const server = http.createServer(async (req, res) => {
   }
 
   if (p === '/') return send(res, 200, indexPage(), { 'Content-Type': 'text/html; charset=utf-8' });
+
+  const widgetMatch = p.match(/^\/d\/([^/]+)\/v\/(\d+)\/widget\/([^/]+)\/?$/);
+  if (widgetMatch) {
+    const [, rawSlug, vStr, rawName] = widgetMatch;
+    const slug = safeSlug(rawSlug);
+    if (!slug || !isValidWidgetName(rawName)) return send(res, 400, 'invalid slug or widget');
+    const dest = req.headers['sec-fetch-dest'];
+    if (!isWidgetFrameRequest(dest)) return send(res, 403, 'widget must be framed');
+    const file = path.join(ROOT, slug, `v${vStr}`, 'widgets', `${rawName}.html`);
+    if (!fs.existsSync(file)) return send(res, 404, `Not found: ${slug} v${vStr} widget ${rawName}`);
+    return send(res, 200, fs.readFileSync(file, 'utf8'), {
+      'Content-Type': 'text/html; charset=utf-8',
+      'Content-Security-Policy': widgetCspHeader(),
+      'X-Content-Type-Options': 'nosniff',
+    });
+  }
 
   const docMatch = p.match(/^\/d\/([^/]+)\/v\/(\d+)\/?$/);
   if (docMatch) {

--- a/server/server.js
+++ b/server/server.js
@@ -256,7 +256,7 @@ function forceWidgetSandbox(html) {
     const srcM = /\bsrc\s*=\s*(?:"([^"]*)"|'([^']*)'|([^\s>]+))/i.exec(attrs);
     if (!srcM) return full;
     const src = srcM[1] || srcM[2] || srcM[3] || '';
-    if (!/\/widget\/[a-z0-9][a-z0-9-]{0,63}\/?$/i.test(src.split('?')[0])) return full;
+    if (!/\/d\/[a-z0-9][a-z0-9-]{0,63}\/v\/\d+\/widget\/[a-z0-9][a-z0-9-]{0,63}\/?$/i.test(src.split('?')[0])) return full;
     const stripped = attrs.replace(/\s*sandbox\s*=\s*(?:"[^"]*"|'[^']*'|[^\s>]+)/gi, '');
     return '<iframe sandbox="allow-scripts"' + stripped + '>';
   });
@@ -514,6 +514,9 @@ const server = http.createServer(async (req, res) => {
 
   const widgetMatch = p.match(/^\/d\/([^/]+)\/v\/(\d+)\/widget\/([^/]+)\/?$/);
   if (widgetMatch) {
+    if (req.method !== 'GET' && req.method !== 'HEAD') {
+      return send(res, 405, 'method not allowed', { Allow: 'GET, HEAD' });
+    }
     const [, rawSlug, vStr, rawName] = widgetMatch;
     const slug = safeSlug(rawSlug);
     if (!slug || !isValidWidgetName(rawName)) return send(res, 400, 'invalid slug or widget');
@@ -521,7 +524,8 @@ const server = http.createServer(async (req, res) => {
     if (!isWidgetFrameRequest(dest)) return send(res, 403, 'widget must be framed');
     const file = path.join(ROOT, slug, `v${vStr}`, 'widgets', `${rawName}.html`);
     if (!fs.existsSync(file)) return send(res, 404, `Not found: ${slug} v${vStr} widget ${rawName}`);
-    return send(res, 200, fs.readFileSync(file, 'utf8'), {
+    const body = req.method === 'HEAD' ? '' : fs.readFileSync(file, 'utf8');
+    return send(res, 200, body, {
       'Content-Type': 'text/html; charset=utf-8',
       'Content-Security-Policy': widgetCspHeader(),
       'X-Content-Type-Options': 'nosniff',

--- a/skills/tdoc/SKILL.md
+++ b/skills/tdoc/SKILL.md
@@ -168,6 +168,7 @@ sharing, with GitHub auth gating comments.
   <slug>/
     meta.json          # { title, created, versions: [...] }
     v1/index.html
+    v1/widgets/<name>.html  # optional; sandboxed JS island, served at /widget/<name>
     v2/index.html
     comments.json      # [{ id, version, anchor, text, status }]
 ```
@@ -175,6 +176,7 @@ sharing, with GitHub auth gating comments.
 Server runs at `http://localhost:7878` (override with `TDOC_PORT`) and serves:
 - `/` — index of all docs
 - `/d/<slug>/v/<n>` — a specific version (injects comment overlay)
+- `/d/<slug>/v/<n>/widget/<name>` — sandboxed interactive island (no overlay)
 - `/api/comments` GET/POST — comment persistence
 - `/api/ping` — health check; responds `{"ok":true,"service":"tdoc"}`. The
   `service` field is the identity marker — a foreign service answering 200 on
@@ -228,7 +230,7 @@ sleep 1
    - All CSS inline in `<style>`. **No JavaScript** — author `<script>` tags do not execute (CSP; see "Interactivity: CSS only" under HTML generation rules).
    - No external CDNs unless requested. No build step.
    - Clean reading-typography (system font stack, generous line-height, max-width ~720px for prose) UNLESS the doc is primarily a diagram, in which case go full-bleed.
-   - Interactive: if the prompt implies a model or diagram, build it with the CSS-only techniques in "Interactivity: CSS only" — `:checked` toggles, CSS keyframes, `<style>` inside the `<svg>`. If the idea genuinely needs computation, follow the fallbacks in that section; do NOT emit JavaScript, which fails silently and leaves the reader an empty box.
+   - Interactive: if the prompt implies a model or diagram, build it with the CSS-only techniques in "Interactivity: CSS only" — `:checked` toggles, CSS keyframes, `<style>` inside the `<svg>`. If the idea genuinely needs computation, emit a sandboxed widget island (see that section); do NOT put `<script>` in the host document.
 3. Write `meta.json`:
    ```json
    { "title": "...", "slug": "...", "created": "<iso>", "versions": [{ "n": 1, "created": "<iso>", "prompt": "..." }] }
@@ -619,17 +621,40 @@ Give each SVG its own class names and `@keyframes` names (`flow-a` / `flowdash-a
 
 **When the prompt wants something CSS can't express**
 
-Game of Life, a Monte Carlo model, a parameter sweep. Don't write the JS anyway: it
-fails silently and the reader gets an empty rectangle where the point of the doc was.
-Pick one:
+Game of Life, a live calculator, a parameter sweep. Do **not** put `<script>` in
+the host document — it is inert under CSP. Two options:
 
-- Pre-compute the interesting states and switch between them with `:checked`.
-- Render the outcome as a static SVG chart or diagram with the numbers baked in.
-- Show a short CSS-animated loop of the phenomenon.
+1. **Sandboxed island (preferred when it must compute).** Write a second HTML
+   file and embed it as an iframe. Overlay comments on the iframe as one
+   artifact (`iframe[src]` is already commentable). Do not walk into the frame.
 
-Then note in the doc what was simplified, so the reader isn't misled about what
-they're looking at. Do not invent a `/widget/` iframe or a sandboxed island —
-that route does not exist yet (issue #138).
+   ```
+   ~/tdocs/<slug>/v1/index.html
+   ~/tdocs/<slug>/v1/widgets/compound-interest.html
+   ```
+
+   Host document:
+
+   ```html
+   <iframe
+     sandbox="allow-scripts"
+     src="/d/<slug>/v/1/widget/compound-interest"
+     title="Compound interest"
+     style="width:100%;height:320px;border:0">
+   </iframe>
+   ```
+
+   The `sandbox` attribute must be `allow-scripts` only — never add
+   `allow-same-origin`. The server rewrites matching widget iframes to that
+   value even if the author HTML forgets or adds extra flags. Widget HTML is a
+   full document; inline `<script>` there **does** run. Do not use `srcdoc`,
+   `data:`, or `blob:` — those inherit the host CSP and the script stays dead.
+
+2. **Precompute** if an island is overkill: `:checked` panels, a static SVG, or
+   a CSS loop, and note in the doc what was simplified.
+
+Fork/export of a doc with islands is not supported in v1 (the downloaded file
+cannot fetch `/widget/` URLs).
 
 ### Default styling — DO NOT re-style the doc
 

--- a/skills/tdoc/SKILL.md
+++ b/skills/tdoc/SKILL.md
@@ -226,9 +226,9 @@ sleep 1
 ### `/tdoc new <prompt>` — create a new doc
 
 1. Pick a slug from the prompt (kebab-case, ≤4 words).
-2. Create `~/tdocs/<slug>/v1/index.html` — a **fully self-contained** HTML file:
-   - All CSS inline in `<style>`. **No JavaScript** — author `<script>` tags do not execute (CSP; see "Interactivity: CSS only" under HTML generation rules).
-   - No external CDNs unless requested. No build step.
+2. Create `~/tdocs/<slug>/v1/index.html` — the host document:
+   - All host CSS inline in `<style>`. **No JavaScript in the host** — those tags do not execute (CSP; see HTML generation rules). If the idea needs computation, also write `v1/widgets/<name>.html` and iframe it.
+   - No external CDNs in the host unless requested. No build step.
    - Clean reading-typography (system font stack, generous line-height, max-width ~720px for prose) UNLESS the doc is primarily a diagram, in which case go full-bleed.
    - Interactive: if the prompt implies a model or diagram, build it with the CSS-only techniques in "Interactivity: CSS only" — `:checked` toggles, CSS keyframes, `<style>` inside the `<svg>`. If the idea genuinely needs computation, emit a sandboxed widget island (see that section); do NOT put `<script>` in the host document.
 3. Write `meta.json`:
@@ -537,20 +537,22 @@ When the user reports a problem, check these first:
 
 ## HTML generation rules
 
-- **Author JavaScript does not run — write none.** Every doc is served under a nonce-based CSP (`script-src 'nonce-<n>' 'strict-dynamic'; object-src 'none'; base-uri 'none';`) and the nonce is stamped onto the two injected overlay scripts *only*. Author `<script>` tags (inline or `src`), `onclick=`/`onchange=` attributes, and `javascript:` URLs have no nonce, so the browser refuses them: no error in the page, no visible failure — just a widget that never does anything. This is true on **both** the local server (`server/server.js` → `cspHeader`, `injectOverlay`) and published docs (`worker/worker.js` → `cspHeader`, `injectOverlayCfg`). Build interactivity with CSS instead — see "Interactivity: CSS only" below.
-- Self-contained: one HTML file. No imports. External `<script src>` is blocked by the same CSP, so a CDN library (D3, Chart.js, …) will not load even if the user asks for one — say so rather than shipping a dead reference.
+- **Host HTML does not run author JavaScript.** Every host document is served under a nonce-based CSP (`script-src 'nonce-<n>' 'strict-dynamic'; object-src 'none'; base-uri 'none';`) and the nonce is stamped onto the two injected overlay scripts *only*. Host `<script>` tags (inline or `src`), `onclick=`/`onchange=` attributes, and `javascript:` URLs have no nonce, so the browser refuses them: no error in the page, no visible failure — just a control that never does anything. This is true on **both** the local server (`server/server.js` → `cspHeader`, `injectOverlay`) and published docs (`worker/worker.js` → `cspHeader`, `injectOverlayCfg`).
+  **Exception — sandboxed island:** if the doc needs computation, write `v<n>/widgets/<name>.html` and embed `<iframe sandbox="allow-scripts" src="/d/<slug>/v/<n>/widget/<name>">`. Inline `<script>` in that widget file **does** run. Never put author JS in the host document. See "When the prompt wants something CSS can't express" below.
+- Host document is one HTML file (no imports). Optional islands are extra files under `v<n>/widgets/`. External `<script src>` in the host is blocked by the same CSP, so a CDN library (D3, Chart.js, …) will not load in the host — put it in a widget island or say so rather than shipping a dead reference.
 - Sandboxed-safe: the server serves docs inside an iframe overlay-host, so don't rely on top-level navigation or parent-frame access.
 - The comment overlay is injected by the server — **don't** add commenting UI yourself.
 - Don't add a "made with tdoc" footer, version selector, or share button. The shell handles those.
-- Use SVG for diagrams (commentable text, and CSS can animate it). **Don't use `<canvas>`** — nothing can draw to it without JS, so it renders as a blank box.
+- Use SVG for diagrams (commentable text, and CSS can animate it). **Don't use `<canvas>` in the host** — nothing can draw to it without JS. Draw inside a widget island if needed.
 - Default font stack: `system-ui, -apple-system, "Segoe UI", Roboto, sans-serif`. Mono: `ui-monospace, "SF Mono", Menlo, monospace`.
 
 ### Interactivity: CSS only
 
-Author `<script>` never executes (see above), so every moving or switchable part
-of a doc has to be declarative. The patterns below are verified on this runtime;
-a working reference doc using all three is at
-`~/tdocs/agent-gui-integration/v1/index.html`.
+Author `<script>` in the **host** document never executes (see above), so every
+moving or switchable part of the host has to be declarative. The patterns below
+are verified on this runtime; a working reference doc using all three is at
+`~/tdocs/agent-gui-integration/v1/index.html`. Computed state belongs in a
+sandboxed island, not in the host.
 
 **1. Toggles and mode switches — `:checked` + sibling selectors**
 
@@ -609,15 +611,16 @@ fully self-contained:
 Give each SVG its own class names and `@keyframes` names (`flow-a` / `flowdash-a`,
 `flow-b` / `flowdash-b`) so two figures on one page don't collide.
 
-**What does NOT work**
+**What does NOT work in the host document**
 
-- `<script>` of any kind, `on*=` handler attributes, `javascript:` URLs — all inert.
+- `<script>` of any kind, `on*=` handler attributes, `javascript:` URLs — all inert
+  in the host. The same tags **do** run inside `v<n>/widgets/<name>.html`.
 - **SMIL** (`<animate>`, `<animateMotion>`, `<animateTransform>`): verified not to
   run here — the SVG timeline stays frozen at `getCurrentTime() === 0`. Use CSS
   animation instead.
-- `<canvas>`: a blank box without JS.
-- Anything with computed state — simulations, a slider that recalculates a model,
-  live data, sorting or filtering a table, form validation.
+- `<canvas>` in the host: a blank box without JS. Draw inside a widget island if needed.
+- Computed state in the host — simulations, a slider that recalculates a model,
+  live data, sorting or filtering a table, form validation. Use a sandboxed island.
 
 **When the prompt wants something CSS can't express**
 
@@ -685,8 +688,8 @@ What to write:
     <h1>{title}</h1>
     <p class="meta">{subtitle or attribution}</p>
     <!-- content here using plain <h2>, <h3>, <p>, <ul>, <pre>, <table>, etc. -->
-    <!-- interactivity goes in <style>, not <script>: author scripts are
-         blocked by CSP. See "Interactivity: CSS only" above. -->
+    <!-- host interactivity goes in <style>, not <script>. Computation
+         belongs in v1/widgets/<name>.html. See HTML generation rules. -->
   </div>
 </body></html>
 ```

--- a/test/no-drift.test.js
+++ b/test/no-drift.test.js
@@ -66,7 +66,7 @@ t('cyrb53 algorithm body is identical in worker.js and overlay.js (modulo indent
   assert(a === b, `cyrb53 has DRIFTED between worker.js and overlay.js:\n      worker: ${a}\n      overlay: ${b}`);
 });
 
-for (const name of ['isAnthropicCompanyMark', 'logoForAgentLogin', 'isGenericAgentLogin', 'detectAgentRuntime', 'agentIdentity']) {
+for (const name of ['isAnthropicCompanyMark', 'logoForAgentLogin', 'isGenericAgentLogin', 'detectAgentRuntime', 'agentIdentity', 'isValidWidgetName', 'widgetCspHeader', 'isWidgetFrameRequest', 'forceWidgetSandbox']) {
   t(`${name} is identical in worker.js and server.js`, () => {
     const a = norm(fnBody(worker, name));
     const b = norm(fnBody(server, name));

--- a/test/run.js
+++ b/test/run.js
@@ -41,6 +41,7 @@ const OFFLINE = [
   'notifications.test.js',    // inbox aggregation + Reddit recipients
   'p3-hardening.test.js',     // #33 safeParseList + escapeHtml
   'csp-headers.test.js',      // CSP header + nonce plumbing (hermetic, no browser)
+  'widget-island.test.js',    // #138 sandboxed widget route + host iframe rewrite
   'stampaids.test.js',        // aid-stamp regex hardening (equivalence + edges)
   'vercel-shim.test.js',      // vercel storage shims (KV/R2 contract, rewrite URL)
   'api.test.js',              // hermetic: spawns its own server in a temp dir

--- a/test/widget-island.test.js
+++ b/test/widget-island.test.js
@@ -66,7 +66,7 @@ function get(port, p, headers = {}) {
     '<!doctype html><html><head><title>Island fixture</title></head><body>' +
     '<p>Host copy.</p>' +
     '<iframe src="/d/island-fixture/v/1/widget/compound-interest" sandbox="allow-scripts allow-same-origin"></iframe>' +
-    '<iframe src="https://example.com/chart" sandbox="allow-scripts"></iframe>' +
+    '<iframe id="third-party-chart" src="https://example.com/chart" sandbox="allow-scripts"></iframe>' +
     '</body></html>');
   fs.writeFileSync(path.join(docDir, 'v1', 'widgets', 'compound-interest.html'),
     '<!doctype html><html><body><script>window.__WIDGET__=1;</script><p>widget</p></body></html>');
@@ -118,20 +118,13 @@ function get(port, p, headers = {}) {
 
   await t('host doc rewrites widget iframe sandbox to allow-scripts only', async () => {
     const res = await get(PORT, `/d/${SLUG}/v/1`);
-    const widgetTag = (res.body.match(/<iframe[^>]*compound-interest[^>]*>/i) || [])[0]
-      || (res.body.match(/<iframe[^>]*sandbox="allow-scripts"[^>]*compound-interest[^>]*>/i) || [])[0];
-    // Attribute order may put sandbox first after rewrite.
     const iframes = [...res.body.matchAll(/<iframe\b([^>]*)>/gi)].map(m => m[0]);
     const widgetIframe = iframes.find(t => t.includes('compound-interest'));
     if (!widgetIframe) throw new Error(`widget iframe missing from host doc: ${iframes.join(' | ')}`);
     if (!/sandbox="allow-scripts"/.test(widgetIframe)) throw new Error(`sandbox not forced: ${widgetIframe}`);
     if (/allow-same-origin/.test(widgetIframe)) throw new Error(`allow-same-origin survived: ${widgetIframe}`);
-    const other = iframes.find(t => t.includes('example.com'));
+    const other = iframes.find(t => t.includes('id="third-party-chart"'));
     if (!other) throw new Error('non-widget iframe missing');
-    if (!other.includes('example.com')) throw new Error('rewrote the wrong iframe');
-    if (!other.includes('sandbox="allow-scripts"') || other.includes('allow-same-origin')) {
-      // third-party iframe is left as authored
-    }
     if (other.includes('compound-interest')) throw new Error('confused widget with third-party iframe');
   });
 

--- a/test/widget-island.test.js
+++ b/test/widget-island.test.js
@@ -1,0 +1,175 @@
+// Interactive islands (#138): host CSP stays strict; computation is a
+// separately served widget HTML resource that must be framed.
+//
+// Hermetic: boots the local server. Worker wiring is checked from source
+// (same pattern as csp-headers.test.js) because the offline suite cannot
+// boot Cloudflare.
+
+const fs = require('fs');
+const path = require('path');
+const os = require('os');
+const net = require('net');
+const http = require('http');
+const { spawn } = require('child_process');
+
+let pass = 0, fail = 0;
+function ok(name) { console.log(`  ✓ ${name}`); pass++; }
+function bad(name, err) { console.log(`  ✗ ${name}\n    ${err}`); fail++; }
+async function t(name, fn) { try { await fn(); ok(name); } catch (e) { bad(name, e.message); } }
+
+function freePort() {
+  return new Promise((resolve, reject) => {
+    const s = net.createServer();
+    s.listen(0, '127.0.0.1', () => { const p = s.address().port; s.close(() => resolve(p)); });
+    s.on('error', reject);
+  });
+}
+function waitReady(port, ms = 5000) {
+  const deadline = Date.now() + ms;
+  return new Promise((resolve, reject) => {
+    (function probe() {
+      const r = http.get({ host: '127.0.0.1', port, path: '/api/ping' }, (res) => { res.resume(); resolve(); });
+      r.on('error', () => { if (Date.now() > deadline) reject(new Error('server not ready')); else setTimeout(probe, 100); });
+    })();
+  });
+}
+function get(port, p, headers = {}) {
+  return new Promise((resolve, reject) => {
+    http.get({ host: '127.0.0.1', port, path: p, headers }, (res) => {
+      let buf = '';
+      res.on('data', d => buf += d);
+      res.on('end', () => resolve({ status: res.statusCode, headers: res.headers, body: buf }));
+    }).on('error', reject);
+  });
+}
+
+(async () => {
+  const TMP_DIR = fs.mkdtempSync(path.join(os.tmpdir(), 'tdoc-widget-'));
+  const PORT = await freePort();
+  const serverPath = path.join(__dirname, '..', 'server', 'server.js');
+  const srv = spawn(process.execPath, [serverPath], {
+    env: { ...process.env, TDOC_DIR: TMP_DIR, TDOC_PORT: String(PORT), TDOC_HOST: '127.0.0.1' },
+    stdio: 'ignore',
+  });
+  const shutdown = () => {
+    try { srv.kill('SIGKILL'); } catch {}
+    try { fs.rmSync(TMP_DIR, { recursive: true, force: true }); } catch {}
+  };
+  process.on('exit', shutdown);
+  await waitReady(PORT);
+  console.log(`widget-island (hermetic, TDOC_DIR=${TMP_DIR})\n`);
+
+  const SLUG = 'island-fixture';
+  const docDir = path.join(TMP_DIR, SLUG);
+  fs.mkdirSync(path.join(docDir, 'v1', 'widgets'), { recursive: true });
+  fs.writeFileSync(path.join(docDir, 'v1', 'index.html'),
+    '<!doctype html><html><head><title>Island fixture</title></head><body>' +
+    '<p>Host copy.</p>' +
+    '<iframe src="/d/island-fixture/v/1/widget/compound-interest" sandbox="allow-scripts allow-same-origin"></iframe>' +
+    '<iframe src="https://example.com/chart" sandbox="allow-scripts"></iframe>' +
+    '</body></html>');
+  fs.writeFileSync(path.join(docDir, 'v1', 'widgets', 'compound-interest.html'),
+    '<!doctype html><html><body><script>window.__WIDGET__=1;</script><p>widget</p></body></html>');
+  fs.writeFileSync(path.join(docDir, 'meta.json'), JSON.stringify({ title: 'Island fixture', versions: [{ n: 1 }] }));
+  fs.writeFileSync(path.join(docDir, 'comments.json'), '[]');
+
+  const widgetPath = `/d/${SLUG}/v/1/widget/compound-interest`;
+
+  await t('top-level widget GET is 403 (no Sec-Fetch-Dest)', async () => {
+    const res = await get(PORT, widgetPath);
+    if (res.status !== 403) throw new Error(`status ${res.status}, expected 403`);
+  });
+
+  await t('top-level widget GET with Dest=document is 403', async () => {
+    const res = await get(PORT, widgetPath, { 'Sec-Fetch-Dest': 'document' });
+    if (res.status !== 403) throw new Error(`status ${res.status}, expected 403`);
+  });
+
+  let framed;
+  await t('framed widget GET returns the author HTML (no overlay)', async () => {
+    framed = await get(PORT, widgetPath, { 'Sec-Fetch-Dest': 'iframe' });
+    if (framed.status !== 200) throw new Error(`status ${framed.status}`);
+    if (!framed.body.includes('window.__WIDGET__=1')) throw new Error('widget script missing');
+    if (framed.body.includes('window.__TDOC__') || framed.body.includes('tdoc-bar')) {
+      throw new Error('overlay leaked into widget response');
+    }
+  });
+
+  await t('framed widget CSP allows inline script and forbids framing by others', async () => {
+    const csp = framed.headers['content-security-policy'] || '';
+    if (!csp.includes("script-src 'unsafe-inline'")) throw new Error(`missing script-src unsafe-inline: ${csp}`);
+    if (!csp.includes("default-src 'none'")) throw new Error(`missing default-src none: ${csp}`);
+    if (!csp.includes("frame-ancestors 'self'")) throw new Error(`missing frame-ancestors: ${csp}`);
+    if (!csp.includes("worker-src 'none'")) throw new Error(`missing worker-src none: ${csp}`);
+    if (csp.includes('strict-dynamic') || csp.includes('nonce-')) {
+      throw new Error(`widget must not use the host nonce CSP: ${csp}`);
+    }
+  });
+
+  await t('host doc CSP is still the nonce policy (no unsafe-inline)', async () => {
+    const res = await get(PORT, `/d/${SLUG}/v/1`);
+    if (res.status !== 200) throw new Error(`status ${res.status}`);
+    const csp = res.headers['content-security-policy'] || '';
+    if (!/script-src 'nonce-[a-f0-9]+' 'strict-dynamic'/.test(csp)) {
+      throw new Error(`host CSP lost nonce policy: ${csp}`);
+    }
+    if (csp.includes('unsafe-inline')) throw new Error(`host CSP gained unsafe-inline: ${csp}`);
+  });
+
+  await t('host doc rewrites widget iframe sandbox to allow-scripts only', async () => {
+    const res = await get(PORT, `/d/${SLUG}/v/1`);
+    const widgetTag = (res.body.match(/<iframe[^>]*compound-interest[^>]*>/i) || [])[0]
+      || (res.body.match(/<iframe[^>]*sandbox="allow-scripts"[^>]*compound-interest[^>]*>/i) || [])[0];
+    // Attribute order may put sandbox first after rewrite.
+    const iframes = [...res.body.matchAll(/<iframe\b([^>]*)>/gi)].map(m => m[0]);
+    const widgetIframe = iframes.find(t => t.includes('compound-interest'));
+    if (!widgetIframe) throw new Error(`widget iframe missing from host doc: ${iframes.join(' | ')}`);
+    if (!/sandbox="allow-scripts"/.test(widgetIframe)) throw new Error(`sandbox not forced: ${widgetIframe}`);
+    if (/allow-same-origin/.test(widgetIframe)) throw new Error(`allow-same-origin survived: ${widgetIframe}`);
+    const other = iframes.find(t => t.includes('example.com'));
+    if (!other) throw new Error('non-widget iframe missing');
+    if (!other.includes('example.com')) throw new Error('rewrote the wrong iframe');
+    if (!other.includes('sandbox="allow-scripts"') || other.includes('allow-same-origin')) {
+      // third-party iframe is left as authored
+    }
+    if (other.includes('compound-interest')) throw new Error('confused widget with third-party iframe');
+  });
+
+  await t('invalid widget name is 400', async () => {
+    const res = await get(PORT, `/d/${SLUG}/v/1/widget/not_ok`, { 'Sec-Fetch-Dest': 'iframe' });
+    if (res.status !== 400) throw new Error(`status ${res.status}, expected 400`);
+  });
+
+  const workerSrc = fs.readFileSync(path.join(__dirname, '..', 'worker', 'worker.js'), 'utf8');
+
+  await t('worker widget route uses widgetCspHeader and does not inject overlay', async () => {
+    const s = workerSrc.indexOf('// ---- interactive island');
+    if (s < 0) throw new Error('worker widget route comment missing');
+    const e = workerSrc.indexOf('// ---- doc view ----', s);
+    const body = workerSrc.slice(s, e > s ? e : s + 2500);
+    if (!body.includes('widgetCspHeader()')) throw new Error('widget route must set widgetCspHeader()');
+    if (body.includes('injectOverlay')) throw new Error('widget route must not inject overlay');
+    if (!body.includes('isWidgetFrameRequest')) throw new Error('widget route must reject non-frame Dest');
+  });
+
+  await t('worker upload writes docs/<slug>/v<n>/widgets/<name>.html', async () => {
+    const s = workerSrc.indexOf('const widgets = body.widgets');
+    if (s < 0) throw new Error('upload widgets handling missing');
+    const body = workerSrc.slice(s, s + 1200);
+    if (!body.includes('widgets/${wname}.html') && !body.includes('widgets/${wname}.html')) {
+      if (!body.includes('/widgets/')) throw new Error(`upload does not put widget R2 keys: ${body.slice(0, 400)}`);
+    }
+  });
+
+  await t('worker injectOverlayCfg runs forceWidgetSandbox', async () => {
+    const s = workerSrc.indexOf('function injectOverlayCfg');
+    const body = workerSrc.slice(s, s + 400);
+    if (!body.includes('forceWidgetSandbox(rawHtml)')) {
+      throw new Error('injectOverlayCfg must rewrite widget iframes');
+    }
+  });
+
+  console.log(`\n${pass} passed, ${fail} failed`);
+  shutdown();
+  process.exit(fail ? 1 : 0);
+})().catch((e) => { console.error(e); process.exit(1); });

--- a/test/widget-island.test.js
+++ b/test/widget-island.test.js
@@ -71,8 +71,11 @@ function get(port, p, headers = {}) {
     '<!doctype html><html><head><title>Island fixture</title></head><body>' +
     '<p>Host copy.</p>' +
     '<iframe src="/d/island-fixture/v/1/widget/compound-interest" sandbox="allow-scripts allow-same-origin"></iframe>' +
+    '<iframe id="widget-hash" src="/d/island-fixture/v/1/widget/compound-interest#frag" sandbox="allow-scripts allow-same-origin"></iframe>' +
+    '<iframe id="widget-trail" src="/d/island-fixture/v/1/widget/compound-interest " sandbox="allow-scripts allow-same-origin"></iframe>' +
     '<iframe id="third-party-chart" src="https://example.com/chart" sandbox="allow-scripts"></iframe>' +
     '<iframe id="foreign-widget-path" src="https://cdn.invalid/widget/compound-interest" sandbox="allow-scripts allow-same-origin"></iframe>' +
+    '<iframe id="cross-origin-widget-path" src="https://cdn.invalid/d/island-fixture/v/1/widget/compound-interest" sandbox="allow-scripts allow-same-origin"></iframe>' +
     '</body></html>');
   fs.writeFileSync(path.join(docDir, 'v1', 'widgets', 'compound-interest.html'),
     '<!doctype html><html><body><script>window.__WIDGET__=1;</script><p>widget</p></body></html>');
@@ -88,6 +91,16 @@ function get(port, p, headers = {}) {
 
   await t('top-level widget GET with Dest=document is 403', async () => {
     const res = await get(PORT, widgetPath, { 'Sec-Fetch-Dest': 'document' });
+    if (res.status !== 403) throw new Error(`status ${res.status}, expected 403`);
+  });
+
+  await t('widget GET with Dest=embed is 403', async () => {
+    const res = await get(PORT, widgetPath, { 'Sec-Fetch-Dest': 'embed' });
+    if (res.status !== 403) throw new Error(`status ${res.status}, expected 403`);
+  });
+
+  await t('widget GET with Dest=frame is 403', async () => {
+    const res = await get(PORT, widgetPath, { 'Sec-Fetch-Dest': 'frame' });
     if (res.status !== 403) throw new Error(`status ${res.status}, expected 403`);
   });
 
@@ -107,9 +120,18 @@ function get(port, p, headers = {}) {
     if (!csp.includes("default-src 'none'")) throw new Error(`missing default-src none: ${csp}`);
     if (!csp.includes("frame-ancestors 'self'")) throw new Error(`missing frame-ancestors: ${csp}`);
     if (!csp.includes("worker-src 'none'")) throw new Error(`missing worker-src none: ${csp}`);
+    if (!csp.includes('sandbox allow-scripts')) throw new Error(`missing CSP sandbox allow-scripts: ${csp}`);
+    if (/sandbox[^;]*allow-same-origin/.test(csp)) throw new Error(`CSP sandbox must not allow-same-origin: ${csp}`);
     if (csp.includes('strict-dynamic') || csp.includes('nonce-')) {
       throw new Error(`widget must not use the host nonce CSP: ${csp}`);
     }
+  });
+
+  await t('framed widget is not stored and varies on Sec-Fetch-Dest', async () => {
+    const cc = framed.headers['cache-control'] || '';
+    if (!/\bno-store\b/.test(cc)) throw new Error(`Cache-Control missing no-store: ${cc}`);
+    const vary = framed.headers['vary'] || '';
+    if (!/Sec-Fetch-Dest/i.test(vary)) throw new Error(`Vary missing Sec-Fetch-Dest: ${vary}`);
   });
 
   await t('host doc CSP is still the nonce policy (no unsafe-inline)', async () => {
@@ -135,6 +157,16 @@ function get(port, p, headers = {}) {
     const foreign = iframes.find(t => t.includes('id="foreign-widget-path"'));
     if (!foreign) throw new Error('foreign /widget/ iframe missing');
     if (!/allow-same-origin/.test(foreign)) throw new Error(`foreign iframe sandbox was rewritten: ${foreign}`);
+    const hashed = iframes.find(t => t.includes('id="widget-hash"'));
+    if (!hashed) throw new Error('hash widget iframe missing');
+    if (!/sandbox="allow-scripts"/.test(hashed)) throw new Error(`hash src sandbox not forced: ${hashed}`);
+    if (/allow-same-origin/.test(hashed)) throw new Error(`hash src allow-same-origin survived: ${hashed}`);
+    const trailed = iframes.find(t => t.includes('id="widget-trail"'));
+    if (!trailed) throw new Error('trailing-space widget iframe missing');
+    if (/allow-same-origin/.test(trailed)) throw new Error(`trailing-space src allow-same-origin survived: ${trailed}`);
+    const cross = iframes.find(t => t.includes('id="cross-origin-widget-path"'));
+    if (!cross) throw new Error('cross-origin widget-path iframe missing');
+    if (!/allow-same-origin/.test(cross)) throw new Error(`cross-origin iframe sandbox was rewritten: ${cross}`);
   });
 
   await t('widget POST is 405; HEAD is framed-only with empty body', async () => {
@@ -162,6 +194,17 @@ function get(port, p, headers = {}) {
     if (!body.includes('widgetCspHeader()')) throw new Error('widget route must set widgetCspHeader()');
     if (body.includes('injectOverlay')) throw new Error('widget route must not inject overlay');
     if (!body.includes('isWidgetFrameRequest')) throw new Error('widget route must reject non-frame Dest');
+    if (!body.includes('enforceDocAccess')) throw new Error('widget route must use enforceDocAccess');
+    if (!body.includes("'Cache-Control': 'no-store'")) throw new Error('widget route must set Cache-Control no-store');
+    if (!body.includes("'Vary': 'Sec-Fetch-Dest'")) throw new Error('widget route must Vary on Sec-Fetch-Dest');
+  });
+
+  await t('worker widgetCspHeader unique-origins the widget document', async () => {
+    const s = workerSrc.indexOf('function widgetCspHeader');
+    if (s < 0) throw new Error('widgetCspHeader missing');
+    const body = workerSrc.slice(s, s + 400);
+    if (!body.includes('sandbox allow-scripts')) throw new Error('widgetCspHeader must include sandbox allow-scripts');
+    if (/sandbox[^"]*allow-same-origin/.test(body)) throw new Error('widget CSP sandbox must not allow-same-origin');
   });
 
   await t('worker upload writes docs/<slug>/v<n>/widgets/<name>.html', async () => {

--- a/test/widget-island.test.js
+++ b/test/widget-island.test.js
@@ -33,14 +33,19 @@ function waitReady(port, ms = 5000) {
     })();
   });
 }
-function get(port, p, headers = {}) {
+function request(port, p, { method = 'GET', headers = {} } = {}) {
   return new Promise((resolve, reject) => {
-    http.get({ host: '127.0.0.1', port, path: p, headers }, (res) => {
+    const req = http.request({ host: '127.0.0.1', port, path: p, method, headers }, (res) => {
       let buf = '';
       res.on('data', d => buf += d);
       res.on('end', () => resolve({ status: res.statusCode, headers: res.headers, body: buf }));
-    }).on('error', reject);
+    });
+    req.on('error', reject);
+    req.end();
   });
+}
+function get(port, p, headers = {}) {
+  return request(port, p, { headers });
 }
 
 (async () => {
@@ -67,6 +72,7 @@ function get(port, p, headers = {}) {
     '<p>Host copy.</p>' +
     '<iframe src="/d/island-fixture/v/1/widget/compound-interest" sandbox="allow-scripts allow-same-origin"></iframe>' +
     '<iframe id="third-party-chart" src="https://example.com/chart" sandbox="allow-scripts"></iframe>' +
+    '<iframe id="foreign-widget-path" src="https://cdn.invalid/widget/compound-interest" sandbox="allow-scripts allow-same-origin"></iframe>' +
     '</body></html>');
   fs.writeFileSync(path.join(docDir, 'v1', 'widgets', 'compound-interest.html'),
     '<!doctype html><html><body><script>window.__WIDGET__=1;</script><p>widget</p></body></html>');
@@ -119,13 +125,26 @@ function get(port, p, headers = {}) {
   await t('host doc rewrites widget iframe sandbox to allow-scripts only', async () => {
     const res = await get(PORT, `/d/${SLUG}/v/1`);
     const iframes = [...res.body.matchAll(/<iframe\b([^>]*)>/gi)].map(m => m[0]);
-    const widgetIframe = iframes.find(t => t.includes('compound-interest'));
+    const widgetIframe = iframes.find(t => t.includes('/d/island-fixture/v/1/widget/'));
     if (!widgetIframe) throw new Error(`widget iframe missing from host doc: ${iframes.join(' | ')}`);
     if (!/sandbox="allow-scripts"/.test(widgetIframe)) throw new Error(`sandbox not forced: ${widgetIframe}`);
     if (/allow-same-origin/.test(widgetIframe)) throw new Error(`allow-same-origin survived: ${widgetIframe}`);
     const other = iframes.find(t => t.includes('id="third-party-chart"'));
     if (!other) throw new Error('non-widget iframe missing');
-    if (other.includes('compound-interest')) throw new Error('confused widget with third-party iframe');
+    if (other.includes('/d/island-fixture/')) throw new Error('confused widget with third-party iframe');
+    const foreign = iframes.find(t => t.includes('id="foreign-widget-path"'));
+    if (!foreign) throw new Error('foreign /widget/ iframe missing');
+    if (!/allow-same-origin/.test(foreign)) throw new Error(`foreign iframe sandbox was rewritten: ${foreign}`);
+  });
+
+  await t('widget POST is 405; HEAD is framed-only with empty body', async () => {
+    const post = await request(PORT, widgetPath, { method: 'POST', headers: { 'Sec-Fetch-Dest': 'iframe' } });
+    if (post.status !== 405) throw new Error(`POST status ${post.status}, expected 405`);
+    const headBare = await request(PORT, widgetPath, { method: 'HEAD' });
+    if (headBare.status !== 403) throw new Error(`HEAD without dest ${headBare.status}, expected 403`);
+    const head = await request(PORT, widgetPath, { method: 'HEAD', headers: { 'Sec-Fetch-Dest': 'iframe' } });
+    if (head.status !== 200) throw new Error(`HEAD status ${head.status}`);
+    if (head.body) throw new Error('HEAD must not send a body');
   });
 
   await t('invalid widget name is 400', async () => {

--- a/worker/worker.js
+++ b/worker/worker.js
@@ -947,19 +947,26 @@ function isValidWidgetName(name) {
   return typeof name === 'string' && /^[a-z0-9][a-z0-9-]{0,63}$/.test(name);
 }
 function widgetCspHeader() {
-  return "default-src 'none'; script-src 'unsafe-inline'; style-src 'unsafe-inline'; object-src 'none'; base-uri 'none'; frame-ancestors 'self'; worker-src 'none'; form-action 'none'";
+  return "default-src 'none'; script-src 'unsafe-inline'; style-src 'unsafe-inline'; object-src 'none'; base-uri 'none'; frame-ancestors 'self'; worker-src 'none'; form-action 'none'; sandbox allow-scripts";
 }
 function isWidgetFrameRequest(dest) {
-  const d = String(dest || '').toLowerCase();
-  return d === 'iframe' || d === 'embed' || d === 'frame';
+  return String(dest || '').toLowerCase() === 'iframe';
 }
 function forceWidgetSandbox(html) {
   if (typeof html !== 'string') return html;
   return html.replace(/<iframe\b([^>]*?)>/gi, (full, attrs) => {
     const srcM = /\bsrc\s*=\s*(?:"([^"]*)"|'([^']*)'|([^\s>]+))/i.exec(attrs);
     if (!srcM) return full;
-    const src = srcM[1] || srcM[2] || srcM[3] || '';
-    if (!/\/d\/[a-z0-9][a-z0-9-]{0,63}\/v\/\d+\/widget\/[a-z0-9][a-z0-9-]{0,63}\/?$/i.test(src.split('?')[0])) return full;
+    const src = String(srcM[1] || srcM[2] || srcM[3] || '').trim();
+    let path;
+    try {
+      const u = new URL(src, 'https://tdoc-widget-src.invalid');
+      if (u.hostname !== 'tdoc-widget-src.invalid') return full;
+      path = u.pathname;
+    } catch {
+      return full;
+    }
+    if (!/^\/d\/[a-z0-9][a-z0-9-]{0,63}\/v\/\d+\/widget\/[a-z0-9][a-z0-9-]{0,63}\/?$/i.test(path)) return full;
     const stripped = attrs.replace(/\s*sandbox\s*=\s*(?:"[^"]*"|'[^']*'|[^\s>]+)/gi, '');
     return '<iframe sandbox="allow-scripts"' + stripped + '>';
   });
@@ -2223,8 +2230,9 @@ export default {
 
     // ---- interactive island (sandboxed widget) ----
     // Separate HTML resource so author JS can run without inheriting the host
-    // document CSP (srcdoc/blob cannot). Must be framed: top-level loads are
-    // 403 so this URL cannot become a same-origin script gadget. No overlay.
+    // document CSP (srcdoc/blob cannot). Must be Dest=iframe: top-level,
+    // embed, and frame loads are 403 so this URL cannot become a same-origin
+    // script gadget. Unique origin is also on the widget CSP (sandbox). No overlay.
     const widgetMatch = p.match(/^\/d\/([^/]+)\/v\/(\d+)\/widget\/([^/]+)\/?$/);
     if (widgetMatch && (method === 'GET' || method === 'HEAD')) {
       const [, slug, vStr, name] = widgetMatch;
@@ -2244,6 +2252,8 @@ export default {
         headers: {
           'Content-Security-Policy': widgetCspHeader(),
           'X-Content-Type-Options': 'nosniff',
+          'Cache-Control': 'no-store',
+          'Vary': 'Sec-Fetch-Dest',
         },
       });
     }

--- a/worker/worker.js
+++ b/worker/worker.js
@@ -939,6 +939,32 @@ function cspHeader(nonce) {
   return `script-src 'nonce-${nonce}' 'strict-dynamic'; object-src 'none'; base-uri 'none';`;
 }
 
+// Interactive islands (#138). Host documents keep cspHeader(); computation
+// lives in a separately served HTML resource framed with sandbox="allow-scripts"
+// (never allow-same-origin). srcdoc/blob inherit the parent CSP and cannot
+// run author JS — these must be real URLs.
+function isValidWidgetName(name) {
+  return typeof name === 'string' && /^[a-z0-9][a-z0-9-]{0,63}$/.test(name);
+}
+function widgetCspHeader() {
+  return "default-src 'none'; script-src 'unsafe-inline'; style-src 'unsafe-inline'; object-src 'none'; base-uri 'none'; frame-ancestors 'self'; worker-src 'none'; form-action 'none'";
+}
+function isWidgetFrameRequest(dest) {
+  const d = String(dest || '').toLowerCase();
+  return d === 'iframe' || d === 'embed' || d === 'frame';
+}
+function forceWidgetSandbox(html) {
+  if (typeof html !== 'string') return html;
+  return html.replace(/<iframe\b([^>]*?)>/gi, (full, attrs) => {
+    const srcM = /\bsrc\s*=\s*(?:"([^"]*)"|'([^']*)'|([^\s>]+))/i.exec(attrs);
+    if (!srcM) return full;
+    const src = srcM[1] || srcM[2] || srcM[3] || '';
+    if (!/\/widget\/[a-z0-9][a-z0-9-]{0,63}\/?$/i.test(src.split('?')[0])) return full;
+    const stripped = attrs.replace(/\s*sandbox\s*=\s*(?:"[^"]*"|'[^']*'|[^\s>]+)/gi, '');
+    return '<iframe sandbox="allow-scripts"' + stripped + '>';
+  });
+}
+
 // Inject the overlay boot + an arbitrary cfg into a document. Single source of
 // truth for "put window.__TDOC__ + overlay.js before </body>" — used by both
 // the published view and the /fork view (which previously re-implemented this
@@ -951,6 +977,7 @@ function cspHeader(nonce) {
 // choice) get unnonced tags, which simply won't execute under a nonce-based
 // CSP — fail closed, not fail open.
 function injectOverlayCfg(rawHtml, cfg, nonce) {
+  rawHtml = forceWidgetSandbox(rawHtml);
   const bootCfg = { ...cfg, runtime: cfg.runtime || runtimeInfo() };
   const nonceAttr = nonce ? ` nonce="${nonce}"` : '';
   const inject =
@@ -2194,6 +2221,33 @@ export default {
       return html(await indexHtml(env, s));
     }
 
+    // ---- interactive island (sandboxed widget) ----
+    // Separate HTML resource so author JS can run without inheriting the host
+    // document CSP (srcdoc/blob cannot). Must be framed: top-level loads are
+    // 403 so this URL cannot become a same-origin script gadget. No overlay.
+    const widgetMatch = p.match(/^\/d\/([^/]+)\/v\/(\d+)\/widget\/([^/]+)\/?$/);
+    if (widgetMatch && (method === 'GET' || method === 'HEAD')) {
+      const [, slug, vStr, name] = widgetMatch;
+      if (!isValidSlug(slug) || !isValidWidgetName(name)) {
+        return text('invalid slug or widget', { status: 400 });
+      }
+      const dest = req.headers.get('sec-fetch-dest');
+      if (!isWidgetFrameRequest(dest)) {
+        return text('widget must be framed', { status: 403 });
+      }
+      const gate = await enforceDocAccess(env, req, slug, Number(vStr));
+      if (!gate.ok) return gate.response;
+      const obj = await env.DOCS.get(`docs/${slug}/v${vStr}/widgets/${name}.html`);
+      if (!obj) return text(`Not found: ${slug} v${vStr} widget ${name}`, { status: 404 });
+      const raw = method === 'HEAD' ? '' : await obj.text();
+      return html(raw, {
+        headers: {
+          'Content-Security-Policy': widgetCspHeader(),
+          'X-Content-Type-Options': 'nosniff',
+        },
+      });
+    }
+
     // ---- doc view ----
     const docMatch = p.match(/^\/d\/([^/]+)\/v\/(\d+)\/?$/);
     if (docMatch && (method === 'GET' || method === 'HEAD')) {
@@ -2787,6 +2841,29 @@ export default {
       if (!verify) {
         console.error('[upload] R2 write did not persist:', r2Key);
         return json({ error: 'r2_write_lost', message: 'PUT succeeded but the key is not readable. Re-deploy the worker; the R2 binding may be stale.' }, { status: 500 });
+      }
+      const widgets = body.widgets;
+      if (widgets != null) {
+        if (typeof widgets !== 'object' || Array.isArray(widgets)) {
+          return json({ error: 'widgets must be an object of name → html' }, { status: 400 });
+        }
+        const names = Object.keys(widgets);
+        if (names.length > 32) return json({ error: 'too many widgets' }, { status: 400 });
+        for (const wname of names) {
+          if (!isValidWidgetName(wname)) return json({ error: 'invalid_widget_name', name: wname }, { status: 400 });
+          const whtml = widgets[wname];
+          if (typeof whtml !== 'string') return json({ error: 'widget html must be a string', name: wname }, { status: 400 });
+          if (whtml.length > 512 * 1024) return json({ error: 'widget too large', name: wname }, { status: 400 });
+          const wKey = `docs/${slug}/v${verNum}/widgets/${wname}.html`;
+          try {
+            await env.DOCS.put(wKey, whtml, {
+              httpMetadata: { contentType: 'text/html; charset=utf-8' },
+            });
+          } catch (e) {
+            console.error('[upload] R2 widget put failed:', e.message);
+            return json({ error: 'r2_put_failed', message: e.message }, { status: 500 });
+          }
+        }
       }
       if (incoming) {
         await env.META.put(`meta:${slug}`, JSON.stringify(incoming));

--- a/worker/worker.js
+++ b/worker/worker.js
@@ -959,7 +959,7 @@ function forceWidgetSandbox(html) {
     const srcM = /\bsrc\s*=\s*(?:"([^"]*)"|'([^']*)'|([^\s>]+))/i.exec(attrs);
     if (!srcM) return full;
     const src = srcM[1] || srcM[2] || srcM[3] || '';
-    if (!/\/widget\/[a-z0-9][a-z0-9-]{0,63}\/?$/i.test(src.split('?')[0])) return full;
+    if (!/\/d\/[a-z0-9][a-z0-9-]{0,63}\/v\/\d+\/widget\/[a-z0-9][a-z0-9-]{0,63}\/?$/i.test(src.split('?')[0])) return full;
     const stripped = attrs.replace(/\s*sandbox\s*=\s*(?:"[^"]*"|'[^']*'|[^\s>]+)/gi, '');
     return '<iframe sandbox="allow-scripts"' + stripped + '>';
   });


### PR DESCRIPTION
## Summary
- Implements #138 as **embedded artifacts**, not document JS. Host `/d/:slug/v/:n` keeps today's nonce CSP; computation is a separate HTML file framed with `sandbox="allow-scripts"` (never `allow-same-origin`).
- Provider-enforced: widget URLs 403 unless `Sec-Fetch-Dest` is `iframe`/`embed`/`frame`; host HTML rewrite forces that sandbox on matching `<iframe src="…/widget/…">`. No overlay in the widget response. No postMessage, no Share toggle, no whole-doc iframe.
- Publish: `vN/widgets/*.html` rides along in `/api/upload` as `widgets`. Fork/export of island docs is out of scope for v1.

Closes #138

## Test plan
- [x] `npm test` (offline, 30/30) including new `widget-island.test.js`
- [ ] Local: put a widget under `~/tdocs/<slug>/v1/widgets/foo.html`, iframe it from `index.html`, confirm the slider/script runs in the frame and host `<script>` still does not
- [ ] Open `/d/<slug>/v/1/widget/foo` in a top-level tab → 403
- [ ] Author iframe missing `sandbox` or with `allow-same-origin` → served host HTML has `sandbox="allow-scripts"` only
- [ ] Comment on the iframe as one artifact
- [ ] `/tdoc publish` of a doc with a widgets folder; framed widget still loads on the worker


Made with [Cursor](https://cursor.com)