### PR TITLE
fix(auth): org OAuth SoT + landing redirects

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -438,8 +438,12 @@ changed. Set `TDOC_SKIP_WORKER_DEPLOY=1` to skip the redeploy (useful for batch
 uploads). Published pages expose runtime provenance at `/api/runtime` and in
 `window.__TDOC__.runtime`.
 
-On published docs, viewers sign in with GitHub (Device Flow, shared OAuth App
-`Ov23liZ1UAGOchvKPmlS`, scope `read:user`) before commenting.
+Local preview (`tdoc serve`) does not need GitHub login. Published docs —
+hosted (`tdoc.dev`) and BYOK remote (your Cloudflare/Vercel worker) — use
+GitHub Device Flow for commenter sign-in via the org-owned OAuth App in
+`shared/github-oauth.js` (scope `read:user`). Viewers authorize that shared
+app; they do not register their own. Set the OAuth App callback URL to
+`https://<host>/auth/done` so GitHub's post-approve redirect is not a 404.
 
 Requires `jq`. Hosted needs no extra CLI. Cloudflare needs `wrangler`
 (`npm i -g wrangler`); Vercel needs `vercel` (`npm i -g vercel`).
@@ -504,8 +508,9 @@ installed, or might be partway through. You **must** drive the flow from
 - ALWAYS show the user what you're running. Print the JSON status if helpful.
 - If a "click" step doesn't take effect after the user says "done", offer to
   re-check after waiting 10s (Cloudflare API can be slow to reflect changes).
-- The shared OAuth App client ID (`Ov23liZ1UAGOchvKPmlS`) is already baked
-  into the Worker — users do NOT register their own.
+- Published/BYOK remotes bake in the shared org OAuth client ID from
+  `shared/github-oauth.js` — users do NOT register their own. Local preview
+  never needs that login path.
 
 ### `/tdoc update` — check for updates and pull the latest
 

--- a/bin/tdoc-publish
+++ b/bin/tdoc-publish
@@ -299,7 +299,7 @@ vercel_bundle_sha() {
     const crypto = require("crypto");
     const skill = process.env.SKILL_DIR;
     const h = crypto.createHash("sha256");
-    for (const rel of ["worker/worker.js", "server/overlay.js"]) {
+    for (const rel of ["worker/worker.js", "server/overlay.js", "shared/github-oauth.js"]) {
       h.update(rel); h.update("\0"); h.update(fs.readFileSync(path.join(skill, rel))); h.update("\0");
     }
     const dir = path.join(skill, "vercel");
@@ -424,6 +424,8 @@ first_time_setup() {
   else
     echo "[tdoc] no GitHub login detected — doc catalog stays private (link-only)."
   fi
+  # GITHUB_CLIENT_ID comes from wrangler.toml.template (kept in sync with
+  # shared/github-oauth.js by test/no-drift.test.js).
   sed \
     -e "s/PLACEHOLDER_KV_ID/${kv_id}/g" \
     -e "s/PLACEHOLDER_OWNER/${owner_login}/g" \
@@ -485,6 +487,9 @@ sync_vercel_app() {
   mkdir -p "$VERCEL_APP_DIR/api" "$VERCEL_APP_DIR/lib"
   cp "$SKILL_DIR/vercel/api/"*.js "$VERCEL_APP_DIR/api/"
   cp "$SKILL_DIR/vercel/lib/"*.js "$VERCEL_APP_DIR/lib/"
+  # Flat-copy SoT so api/tdoc.js can require('../lib/github-oauth.js') without
+  # a ../../shared hop (vercel-app is outside the skill checkout).
+  cp "$SKILL_DIR/shared/github-oauth.js" "$VERCEL_APP_DIR/lib/github-oauth.js"
   cp "$SKILL_DIR/vercel/vercel.json" "$SKILL_DIR/vercel/package.json" "$VERCEL_APP_DIR/"
   SKILL_DIR="$SKILL_DIR" bundle_worker "$VERCEL_APP_DIR"
 }
@@ -740,6 +745,20 @@ else
         fi
         [ -n "$_ol" ] && echo "[tdoc] backfilled TDOC_OWNER=$_ol into wrangler.toml" \
           || echo "[tdoc] TDOC_OWNER left empty (catalog stays private)."
+      fi
+      # Retire the personal-account OAuth client id on existing BYOK workers.
+      if [ -f "$WORKER_DIR/wrangler.toml" ] && [ -f "$SKILL_DIR/shared/github-oauth.js" ]; then
+        _gh="$(node -e 'console.log(require(process.argv[1]).GITHUB_CLIENT_ID)' \
+          "$SKILL_DIR/shared/github-oauth.js" 2>/dev/null || true)"
+        if [ -n "$_gh" ] && grep -Eq 'Ov23liZ1UAGOchvKPmlS|PLACEHOLDER_GITHUB_CLIENT_ID' \
+          "$WORKER_DIR/wrangler.toml"; then
+          awk -v id="$_gh" '
+            /^GITHUB_CLIENT_ID[[:space:]]*=/ { print "GITHUB_CLIENT_ID = \"" id "\""; next }
+            { print }
+          ' "$WORKER_DIR/wrangler.toml" > "$WORKER_DIR/wrangler.toml.tmp" \
+            && mv "$WORKER_DIR/wrangler.toml.tmp" "$WORKER_DIR/wrangler.toml"
+          echo "[tdoc] updated GITHUB_CLIENT_ID to org OAuth SoT ($_gh)"
+        fi
       fi
       SKILL_DIR="$SKILL_DIR" bundle_worker
       (cd "$WORKER_DIR" && wrangler deploy)

--- a/server/overlay.js
+++ b/server/overlay.js
@@ -2642,9 +2642,10 @@
       return;
     }
     showDeviceModal(data);
-    // Only open the verification URL if it's an https GitHub URL — never window.open an
-    // arbitrary string from the response.
-    if (isGithubHttpsUrl(data.verification_uri)) window.open(data.verification_uri, '_blank');
+    // Prefer the complete URI (code pre-filled) when GitHub provides it.
+    // Only open https GitHub URLs — never window.open an arbitrary string.
+    const verifyUrl = data.verification_uri_complete || data.verification_uri;
+    if (isGithubHttpsUrl(verifyUrl)) window.open(verifyUrl, '_blank');
     pollInterval = Math.max(5, data.interval || 5);
     schedulePoll(data.device_code);
   }
@@ -2998,7 +2999,7 @@
         onConfirm: async (status) => {
           await ownerFetch(`/api/doc?slug=${encodeURIComponent(slug)}`, { method: 'DELETE' });
           status.textContent = 'Deleted. Redirecting…';
-          setTimeout(() => { window.location.href = 'https://github.com/tornado-doc/tdoc'; }, 900);
+          setTimeout(() => { window.location.href = '/'; }, 900);
         },
       });
     };
@@ -3015,6 +3016,12 @@
       const data = await r.json();
       if (data.ok && data.identity) {
         identity = data.identity;
+        // Page may have booted signed-out (isOwner false). Refresh owner
+        // flag so "My docs" appears without a full reload.
+        try {
+          const me = await fetch('/api/auth/me', { credentials: 'same-origin' }).then((x) => x.json());
+          if (me && typeof me.isOwner === 'boolean') isOwner = me.isOwner;
+        } catch { /* keep bootCfg isOwner */ }
         closeDeviceModal();
         renderIdentity();
         refreshComments();

--- a/shared/github-oauth.js
+++ b/shared/github-oauth.js
@@ -1,0 +1,12 @@
+// Single source of truth: org-owned GitHub OAuth App for Device Flow
+// commenter login on published docs. Owned by github.com/tornado-doc.
+// Client ID is public; tdoc does not use a client secret for device flow.
+//
+// Consumers: worker/wrangler.toml.template (literal must match this module —
+// enforced by test/no-drift.test.js), vercel/api/tdoc.js via
+// vercel/lib/github-oauth.js. Set the OAuth App's Authorization callback URL
+// to https://<host>/auth/done so GitHub's post-authorize redirect is not a 404.
+
+module.exports = {
+  GITHUB_CLIENT_ID: 'Ov23li1jJiBkS23x4O07',
+};

--- a/skills/tdoc/SKILL.md
+++ b/skills/tdoc/SKILL.md
@@ -438,8 +438,12 @@ changed. Set `TDOC_SKIP_WORKER_DEPLOY=1` to skip the redeploy (useful for batch
 uploads). Published pages expose runtime provenance at `/api/runtime` and in
 `window.__TDOC__.runtime`.
 
-On published docs, viewers sign in with GitHub (Device Flow, shared OAuth App
-`Ov23liZ1UAGOchvKPmlS`, scope `read:user`) before commenting.
+Local preview (`tdoc serve`) does not need GitHub login. Published docs —
+hosted (`tdoc.dev`) and BYOK remote (your Cloudflare/Vercel worker) — use
+GitHub Device Flow for commenter sign-in via the org-owned OAuth App in
+`shared/github-oauth.js` (scope `read:user`). Viewers authorize that shared
+app; they do not register their own. Set the OAuth App callback URL to
+`https://<host>/auth/done` so GitHub's post-approve redirect is not a 404.
 
 Requires `jq`. Hosted needs no extra CLI. Cloudflare needs `wrangler`
 (`npm i -g wrangler`); Vercel needs `vercel` (`npm i -g vercel`).
@@ -504,8 +508,9 @@ installed, or might be partway through. You **must** drive the flow from
 - ALWAYS show the user what you're running. Print the JSON status if helpful.
 - If a "click" step doesn't take effect after the user says "done", offer to
   re-check after waiting 10s (Cloudflare API can be slow to reflect changes).
-- The shared OAuth App client ID (`Ov23liZ1UAGOchvKPmlS`) is already baked
-  into the Worker — users do NOT register their own.
+- Published/BYOK remotes bake in the shared org OAuth client ID from
+  `shared/github-oauth.js` — users do NOT register their own. Local preview
+  never needs that login path.
 
 ### `/tdoc update` — check for updates and pull the latest
 

--- a/test/me-management.test.js
+++ b/test/me-management.test.js
@@ -132,5 +132,25 @@ t('/me does not introduce a bespoke cookie-only admin-auth path', () => {
   assert(!worker.includes('isSameOriginRequest'), 'same-origin is not sufficient when docs are arbitrary same-origin HTML');
 });
 
+t('/me non-owner bounce goes to landing with notice, not github.com', () => {
+  const meStart = worker.indexOf("if (p === '/me' && method === 'GET')");
+  const meEnd = worker.indexOf('// ---- doc view ----', meStart);
+  assert(meStart >= 0 && meEnd > meStart, '/me route block missing');
+  const meRoute = worker.slice(meStart, meEnd);
+  assert(meRoute.includes("Location: `/?notice=${notice}`") || meRoute.includes("Location: '/?notice="),
+    '/me must redirect to landing ?notice=…');
+  assert(!meRoute.includes('github.com/tornado-doc/tdoc'),
+    '/me must not redirect to the GitHub repo');
+});
+
+t('landing supports sign-in + toast notices; /auth/done soft-lands OAuth callback', () => {
+  assert(worker.includes('function landingHtml(env, notice)'), 'landingHtml must take a notice');
+  assert(worker.includes("id=\"signin\""), 'landing must offer Sign in with GitHub');
+  assert(worker.includes('function authDoneHtml('), 'authDoneHtml missing');
+  assert(worker.includes("/auth/done"), 'must serve /auth/done for OAuth callback URL');
+  assert(worker.includes("Location: '/?notice=notfound'"),
+    'unknown GET paths must bounce to landing with notfound notice');
+});
+
 console.log(`\n${pass} passed, ${fail} failed`);
 process.exit(fail ? 1 : 0);

--- a/test/no-drift.test.js
+++ b/test/no-drift.test.js
@@ -49,8 +49,37 @@ const norm = (s) => s == null ? null : s.replace(/\s+/g, ' ').trim();
 const worker = read('worker/worker.js');
 const server = read('server/server.js');
 const overlay = read('server/overlay.js');
+const githubOauth = require(path.join(root, 'shared/github-oauth.js'));
 
 console.log('no-drift (duplicated helper guard)');
+
+t('GITHUB_CLIENT_ID has a single SoT (shared/github-oauth.js)', () => {
+  const id = githubOauth.GITHUB_CLIENT_ID;
+  assert(typeof id === 'string' && /^Ov[\w]+$/.test(id), `bad SoT client id: ${id}`);
+  const template = read('worker/wrangler.toml.template');
+  assert(template.includes(`GITHUB_CLIENT_ID = "${id}"`),
+    'wrangler.toml.template must ship the SoT client id for CD/BYOK defaults');
+  const vercelApi = read('vercel/api/tdoc.js');
+  assert(vercelApi.includes('githubOauth.GITHUB_CLIENT_ID'),
+    'vercel/api/tdoc.js must read the client id from github-oauth SoT');
+  assert(!vercelApi.includes(id),
+    'vercel/api/tdoc.js must not hardcode the client id');
+  assert(!read('SKILL.md').includes('Ov23liZ1UAGOchvKPmlS'),
+    'SKILL.md still mentions the old personal-account OAuth client id');
+  for (const rel of [
+    'vercel/api/tdoc.js',
+    'shared/github-oauth.js',
+  ]) {
+    // shared owns the literal; vercel must not duplicate it
+  }
+  assert(read('shared/github-oauth.js').includes(id), 'SoT module missing its own id');
+  assert(!read('vercel/api/tdoc.js').includes('Ov23liZ1UAGOchvKPmlS'),
+    'vercel still hardcodes the retired personal OAuth client id');
+  assert(!template.includes('Ov23liZ1UAGOchvKPmlS'),
+    'wrangler.toml.template still hardcodes the retired personal OAuth client id');
+  assert(read('bin/tdoc-publish').includes('shared/github-oauth.js'),
+    'tdoc-publish must read GITHUB_CLIENT_ID from shared/github-oauth.js (BYOK backfill)');
+});
 
 t('safeJsonForScript is identical in worker.js and server.js', () => {
   const a = norm(fnBody(worker, 'safeJsonForScript'));

--- a/vercel/api/tdoc.js
+++ b/vercel/api/tdoc.js
@@ -17,10 +17,14 @@
 // Uses the Node runtime's web handler signature (Request → Response), so the
 // worker's fetch handler runs unmodified.
 
+import { createRequire } from 'module';
 import worker from '../_worker.bundled.js';
 import { createDocsStore } from '../lib/blob-r2.js';
 import { createKvStore } from '../lib/upstash-kv.js';
 import { originalRequestUrl } from '../lib/request-url.js';
+
+// CJS SoT (shared/github-oauth.js); createRequire keeps this ESM file simple.
+const githubOauth = createRequire(import.meta.url)('../lib/github-oauth.js');
 
 function json(obj, status) {
   return new Response(JSON.stringify(obj), {
@@ -59,9 +63,9 @@ async function buildEnv() {
       META: createKvStore({ url: kvUrl, token: kvToken }),
       TDOC_UPLOAD_TOKEN: process.env.TDOC_UPLOAD_TOKEN,
       TDOC_OWNER: process.env.TDOC_OWNER || '',
-      // Same public GitHub Device Flow app the wrangler template ships —
-      // device flow has no redirect URI, so it works from any host.
-      GITHUB_CLIENT_ID: process.env.GITHUB_CLIENT_ID || 'Ov23liZ1UAGOchvKPmlS',
+      // Same public GitHub Device Flow app as Cloudflare (shared/github-oauth.js).
+      // Device flow has no redirect URI, so it works from any host.
+      GITHUB_CLIENT_ID: process.env.GITHUB_CLIENT_ID || githubOauth.GITHUB_CLIENT_ID,
       TDOC_DEBUG: process.env.TDOC_DEBUG || '',
     },
   };

--- a/vercel/lib/github-oauth.js
+++ b/vercel/lib/github-oauth.js
@@ -1,0 +1,4 @@
+// Re-exports shared/github-oauth.js in the repo checkout.
+// tdoc-publish overwrites this path with a flat copy of the SoT for deploy
+// (~/.tdoc/vercel-app has no ../../shared/).
+module.exports = require('../../shared/github-oauth.js');

--- a/worker/worker.js
+++ b/worker/worker.js
@@ -4,7 +4,7 @@
 //   DOCS   — R2 bucket (key: docs/<slug>/v<N>/index.html)
 //   META   — KV namespace
 // Vars:
-//   GITHUB_CLIENT_ID — hardcoded "Ov23liZ1UAGOchvKPmlS"
+//   GITHUB_CLIENT_ID — from wrangler [vars]; SoT is shared/github-oauth.js
 // Secrets:
 //   TDOC_UPLOAD_TOKEN — shared secret for /api/upload from `tdoc publish`
 //
@@ -977,8 +977,17 @@ function injectOverlay(rawHtml, slug, version, identity, versions, isOwner, owne
 }
 
 // Neutral landing page served at `/`. No catalog, no slug list — just
-// brand + a link to the open-source project. Docs are link-only.
-function landingHtml() {
+// brand + sign-in (when auth is configured) + a link to the open-source
+// project. Docs are link-only. `notice` is an optional toast reason when
+// we bounce users here from /me or an unknown path.
+function landingHtml(env, notice) {
+  const authOk = !!(env && String(env.GITHUB_CLIENT_ID || '').trim());
+  const toastMsg = ({
+    me: 'My docs is only available after you sign in as the worker owner.',
+    signin: 'Sign in with GitHub to continue.',
+    notfound: 'That page was not found. Sign in or open a doc from its shared link.',
+  })[notice] || '';
+  const toastJson = JSON.stringify(toastMsg);
   return `<!doctype html><html><head><meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>tdoc</title>
@@ -991,11 +1000,120 @@ function landingHtml() {
   a { color: #1652f0; text-decoration: none; }
   a:hover { text-decoration: underline; }
   .sub { margin-top: 14px; font-size: 13px; color: #888; }
+  .actions { display: flex; gap: 10px; align-items: center; margin-top: 18px; }
+  button.signin { font: inherit; padding: 8px 16px; border-radius: 8px; border: none;
+    background: #1652f0; color: #fff; font-weight: 600; cursor: pointer; }
+  button.signin:hover { background: #1245d0; }
+  button.signin:disabled { opacity: 0.6; cursor: default; }
+  #toast { position: fixed; top: 16px; right: 16px; max-width: min(360px, calc(100vw - 32px));
+    background: #111; color: #fff; padding: 12px 14px; border-radius: 10px; font-size: 13px;
+    line-height: 1.4; box-shadow: 0 8px 24px rgba(0,0,0,0.18); opacity: 0;
+    transform: translateY(-6px); transition: opacity .18s, transform .18s; pointer-events: none; }
+  #toast.show { opacity: 1; transform: translateY(0); }
+  .status { font-size: 13px; color: #888; min-height: 1.2em; }
 </style></head><body>
   <h1>tdoc</h1>
   <p>Prompt-native, commentable documents.</p>
+  <div class="actions">
+    ${authOk ? '<button type="button" class="signin" id="signin">Sign in with GitHub</button>' : ''}
+  </div>
+  <p class="status" id="status"></p>
   <p class="sub">Open a document from its shared link ·
     <a href="https://github.com/tornado-doc/tdoc">github.com/tornado-doc/tdoc</a></p>
+  <div id="toast" role="status" aria-live="polite"></div>
+<script>
+(function () {
+  var toastMsg = ${toastJson};
+  var toastEl = document.getElementById('toast');
+  if (toastMsg && toastEl) {
+    toastEl.textContent = toastMsg;
+    toastEl.classList.add('show');
+    setTimeout(function () { toastEl.classList.remove('show'); }, 5200);
+  }
+  var btn = document.getElementById('signin');
+  var status = document.getElementById('status');
+  if (!btn) return;
+  var pollTimer = null;
+  var pollInterval = 5;
+  function setStatus(t) { if (status) status.textContent = t || ''; }
+  function schedule(code) {
+    pollTimer = setTimeout(function () { poll(code); }, pollInterval * 1000);
+  }
+  async function poll(code) {
+    pollTimer = null;
+    try {
+      var r = await fetch('/api/auth/device/poll', {
+        method: 'POST', headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ device_code: code })
+      });
+      var data = await r.json();
+      if (data.ok) {
+        setStatus('Signed in. Opening My docs…');
+        window.location.href = '/me';
+        return;
+      }
+      if (data.error === 'slow_down') {
+        pollInterval = Math.max(pollInterval + 5, Number(data.interval) || 0);
+        schedule(code); return;
+      }
+      if (data.error === 'authorization_pending' || (data.pending && !data.error)) {
+        schedule(code); return;
+      }
+      if (data.error === 'expired_token' || data.error === 'access_denied') {
+        setStatus('Code expired or denied. Try again.');
+        btn.disabled = false; return;
+      }
+      if (data.error || !r.ok) {
+        setStatus('Sign-in failed: ' + (data.message || data.error || ('HTTP ' + r.status)));
+        btn.disabled = false; return;
+      }
+      schedule(code);
+    } catch (e) {
+      setStatus('Network error — retrying…');
+      schedule(code);
+    }
+  }
+  btn.onclick = async function () {
+    btn.disabled = true;
+    setStatus('Starting GitHub sign-in…');
+    try {
+      var r = await fetch('/api/auth/device/start', { method: 'POST' });
+      var data = await r.json();
+      if (!r.ok || data.error || !data.user_code || !data.verification_uri) {
+        setStatus('Sign-in error: ' + ((data && (data.message || data.error)) || ('HTTP ' + r.status)));
+        btn.disabled = false; return;
+      }
+      var uri = data.verification_uri_complete || data.verification_uri;
+      setStatus('Code ' + data.user_code + ' — approve in the GitHub tab, then return here.');
+      try {
+        var u = new URL(String(uri));
+        if (u.protocol === 'https:' && /(^|\\.)github\\.com$/.test(u.hostname)) window.open(uri, '_blank');
+      } catch (_) {}
+      pollInterval = Math.max(5, data.interval || 5);
+      schedule(data.device_code);
+    } catch (e) {
+      setStatus('Sign-in error: could not reach the sign-in service.');
+      btn.disabled = false;
+    }
+  };
+})();
+</script>
+</body></html>`;
+}
+
+function authDoneHtml() {
+  return `<!doctype html><html><head><meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>tdoc — signed in</title>
+<style>
+  body { font: 15px system-ui, -apple-system, sans-serif; min-height: 100vh; margin: 0;
+    display: flex; flex-direction: column; align-items: center; justify-content: center;
+    color: #111; background: #fff; gap: 8px; }
+  h1 { font-size: 22px; margin: 0; color: #1652f0; }
+  p { color: #666; margin: 0; }
+</style></head><body>
+  <h1>You're signed in</h1>
+  <p>You can close this tab and return to tdoc.</p>
 </body></html>`;
 }
 
@@ -2488,19 +2606,31 @@ export default {
 
     // ---- landing (NO public catalog) ----
     // `/` never lists docs. Docs are only reachable via their direct link.
-    // A neutral branded page points at the open-source project.
-    if (p === '/' && method === 'GET') return html(landingHtml());
+    // A neutral branded page points at the open-source project; optional
+    // ?notice=… shows a toast when we bounced the user here.
+    if (p === '/' && method === 'GET') {
+      const notice = (url.searchParams.get('notice') || '').trim();
+      return html(landingHtml(env, notice));
+    }
+
+    // Soft landing for the OAuth App "Authorization callback URL". Device
+    // Flow does not need a callback, but GitHub may still redirect here
+    // after Approve — serve a friendly page instead of a 404.
+    if ((p === '/auth/done' || p === '/auth/github/callback') && method === 'GET') {
+      return html(authDoneHtml());
+    }
 
     // ---- owner-only doc catalog ----
     // `/me` returns the list of every doc hosted on THIS worker, but only
     // to the configured owner (TDOC_OWNER) when signed in. Everyone else
-    // gets redirected to the GitHub repo — no slug enumeration.
+    // is sent to the landing page (with a toast) — never to github.com.
     if (p === '/me' && method === 'GET') {
       const s = await getSession(env, req);
       if (!isOwnerSession(env, s)) {
+        const notice = sessionLogin(s) ? 'me' : 'signin';
         return new Response(null, {
           status: 302,
-          headers: { Location: 'https://github.com/tornado-doc/tdoc' },
+          headers: { Location: `/?notice=${notice}` },
         });
       }
       return html(await indexHtml(env, s));
@@ -2692,6 +2822,7 @@ export default {
           device_code: r.device_code,
           user_code: r.user_code,
           verification_uri: r.verification_uri,
+          verification_uri_complete: r.verification_uri_complete || null,
           expires_in: r.expires_in,
           interval: r.interval,
         });
@@ -3253,6 +3384,14 @@ export default {
       return json({ ok: true });
     }
 
+    // Browser navigations to unknown paths bounce to the landing page with a
+    // toast — not a raw 404 and never github.com. API-ish methods stay 404.
+    if (method === 'GET' || method === 'HEAD') {
+      return new Response(null, {
+        status: 302,
+        headers: { Location: '/?notice=notfound' },
+      });
+    }
     return text('Not found', { status: 404 });
   },
 };

--- a/worker/wrangler.toml.template
+++ b/worker/wrangler.toml.template
@@ -26,7 +26,10 @@ tag = "v1-comments-do"
 new_sqlite_classes = ["CommentsStore"]
 
 [vars]
-GITHUB_CLIENT_ID = "Ov23liZ1UAGOchvKPmlS"
+# Filled from shared/github-oauth.js (single source of truth). Keep in sync —
+# test/no-drift.test.js fails if this drifts from the SoT module.
+GITHUB_CLIENT_ID = "Ov23li1jJiBkS23x4O07"
+
 # The worker owner's GitHub login. Only this signed-in viewer sees the
 # "My docs" catalog (profile chip → My docs). Empty = catalog stays fully
 # private (no one can enumerate docs; they're reachable only by direct link).


### PR DESCRIPTION
## Summary
- Switch shared Device Flow to the **tornado-doc** OAuth App (`Ov23li1jJiBkS23x4O07`) via `shared/github-oauth.js` (single SoT; template + Vercel consume it; BYOK backfill retires Serena’s personal client id).
- Unauthorized `/me` and unknown GET paths redirect to **landing** with a toast (`?notice=…`), not github.com; landing can sign in with GitHub.
- Soft-land OAuth approve on `/auth/done` (set the OAuth App callback URL here to avoid GitHub 404 after Authorize).
- After Device Flow succeeds, refresh `isOwner` from `/api/auth/me` so **My docs** appears in the profile menu without a reload.

## Test plan
- [ ] `npm test` (31 offline suites)
- [ ] Sign in on a published doc → profile menu shows **My docs** when `TDOC_OWNER` matches (no reload)
- [ ] Visit `/me` signed out → lands on `/?notice=signin` with toast + Sign in
- [ ] Visit `/me` signed in as non-owner → `/?notice=me` toast
- [ ] Visit `/auth/done` → “You’re signed in / close this tab”
- [ ] Confirm org OAuth App callback URL is `https://<host>/auth/done` (e.g. `https://tdoc.dev/auth/done`)
- [ ] Redeploy BYOK worker (or next publish that redeploys) picks up org client id if wrangler still had the old personal id


Made with [Cursor](https://cursor.com)