### PR TITLE
ci: sync tdoc.dev upload token so the homepage can publish

### DIFF
--- a/.github/workflows/publish-landing.yml
+++ b/.github/workflows/publish-landing.yml
@@ -27,6 +27,15 @@ on:
     workflows: ['deploy tdoc.dev']
     types: [completed]
   workflow_dispatch:
+    inputs:
+      sync_upload_token:
+        description: >
+          Overwrite the Worker TDOC_UPLOAD_TOKEN with GitHub's
+          TDOC_DEV_UPLOAD_TOKEN. Use when /api/upload returns 401 because
+          the GitHub secret was never written onto the Worker. Automatic
+          workflow_run publishes never rotate the secret.
+        type: boolean
+        default: false
 
 permissions:
   contents: read
@@ -72,6 +81,41 @@ jobs:
 
       - name: Build the release payload
         run: node bin/tdoc-landing-release
+
+      # First ship (#129): TDOC_DEV_UPLOAD_TOKEN was present in GitHub and
+      # still 401'd, because nothing had ever `wrangler secret put` that
+      # value onto the Worker. deploy-tdoc-dev.yml must not rotate the
+      # secret on every CD. This step is dispatch-only and opt-in.
+      - name: Align Worker TDOC_UPLOAD_TOKEN with the GitHub secret
+        if: github.event_name == 'workflow_dispatch' && inputs.sync_upload_token
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          TDOC_DEV_KV_ID: ${{ secrets.TDOC_DEV_KV_ID }}
+          TDOC_DEV_OWNER: ${{ secrets.TDOC_DEV_OWNER }}
+          TDOC_DEV_UPLOAD_TOKEN: ${{ secrets.TDOC_DEV_UPLOAD_TOKEN }}
+        run: |
+          set -euo pipefail
+          missing=
+          [ -n "$CLOUDFLARE_API_TOKEN" ] || missing="$missing CLOUDFLARE_API_TOKEN"
+          [ -n "$CLOUDFLARE_ACCOUNT_ID" ] || missing="$missing CLOUDFLARE_ACCOUNT_ID"
+          [ -n "$TDOC_DEV_KV_ID" ] || missing="$missing TDOC_DEV_KV_ID"
+          [ -n "$TDOC_DEV_OWNER" ] || missing="$missing TDOC_DEV_OWNER"
+          [ -n "$TDOC_DEV_UPLOAD_TOKEN" ] || missing="$missing TDOC_DEV_UPLOAD_TOKEN"
+          if [ -n "$missing" ]; then
+            echo "token sync is missing GitHub secrets:$missing" >&2
+            exit 1
+          fi
+          sed \
+            -e "s/PLACEHOLDER_KV_ID/${TDOC_DEV_KV_ID}/g" \
+            -e "s/PLACEHOLDER_OWNER/${TDOC_DEV_OWNER}/g" \
+            worker/wrangler.toml.template > worker/wrangler.toml
+          # stdin is the secret. Do not echo it. Do not print wrangler
+          # debug that might replay env.
+          # CLOUDFLARE_API_TOKEN + CLOUDFLARE_ACCOUNT_ID come from env.
+          # --cwd is the worker dir so name=tdoc is read from wrangler.toml.
+          printf '%s' "$TDOC_DEV_UPLOAD_TOKEN" | npx --yes wrangler@4.90.1 secret put TDOC_UPLOAD_TOKEN \
+            --cwd worker
 
       - name: Upload v1 to tdoc.dev
         env:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,12 @@ file and `.claude-plugin/plugin.json`.
 
 ### Fixed
 
+- **tdoc.dev homepage publish no longer dies on a present-but-unwritten token.**
+  `#129` merged and deployed the Worker, then `publish-landing.yml` got
+  `401 unauthorized` because `TDOC_DEV_UPLOAD_TOKEN` existed in GitHub
+  Actions and had never been `wrangler secret put` onto the Worker.
+  Re-running that workflow with `sync_upload_token` writes the secret
+  once. Automatic publishes still do not rotate it.
 - **`DELETE /api/doc` fails closed when hosted `release_owner` fails** and the
   Durable Object binding is present, so a 200 cannot leave the slug parked.
   Vercel (no `COMMENTS`) still returns 200 — there was never a reservation.

--- a/test/tornado-doc-landing.test.js
+++ b/test/tornado-doc-landing.test.js
@@ -526,6 +526,17 @@ t('shipping the homepage ships content, not just worker code', () => {
     'a push trigger races deploy-tdoc-dev.yml on the first merge to main');
   assert(/workflow_run\.head_sha/.test(content),
     'publish must check out the commit the Worker deploy just shipped');
+  // First ship 401'd because TDOC_DEV_UPLOAD_TOKEN lived only in GitHub.
+  // Token rotation is a manual dispatch input, never the automatic path.
+  assert(/sync_upload_token/.test(content),
+    'publish workflow must expose a manual token-sync input');
+  assert(/github.event_name == 'workflow_dispatch' && inputs.sync_upload_token/.test(content),
+    'token sync must be dispatch-only and opt-in');
+  assert(/wrangler@4\.90\.1 secret put TDOC_UPLOAD_TOKEN/.test(content),
+    'token sync must write TDOC_UPLOAD_TOKEN onto the Worker');
+  const autoPath = content.split("if: github.event_name == 'workflow_dispatch' && inputs.sync_upload_token")[0];
+  assert(!/secret put TDOC_UPLOAD_TOKEN/.test(autoPath),
+    'the automatic workflow_run path must not rotate TDOC_UPLOAD_TOKEN');
 });
 
 console.log(`\n${pass} passed, ${fail} failed.`);


### PR DESCRIPTION
Follow-up to #129.

## Why

#129 merged. `deploy tdoc.dev` went green. `publish tdoc.dev homepage` died on the first upload:

```
HTTP 401
{"error":"unauthorized"}
```

`TDOC_DEV_UPLOAD_TOKEN` is set (the workflow's presence check passed). `/api/upload` still rejected it. The GitHub secret was stored on 2026-08-15 at the same second as `~/.tdoc/published.tdoc-dev.json` and never `wrangler secret put` onto the Worker. `deploy-tdoc-dev.yml` correctly refuses to rotate `TDOC_UPLOAD_TOKEN` on every CD, so the mismatch survived the merge.

`tdoc.dev/` is still the #145 sign-in landing. The Worker code from #129 is live (`/api/runtime` reports `source_sha` `7f47e28`).

## What

A `workflow_dispatch` input `sync_upload_token` writes GitHub's `TDOC_DEV_UPLOAD_TOKEN` onto the Worker, then the existing upload + homepage verify steps run. Automatic `workflow_run` publishes do **not** rotate the secret.

After this lands I will dispatch:

```
gh workflow run "publish tdoc.dev homepage" -f sync_upload_token=true
```

That rotation will break any laptop still holding the *original* Worker token. Hosted account tokens are unaffected.

## Test plan

- [x] Offline suite 33/33
- [ ] CI green
- [ ] Dispatch with `sync_upload_token=true`
- [ ] `tdoc.dev/` serves the landing doc (`isLanding: true`, headline present)
- [ ] `/?notice=me` still shows the sign-in landing