### PR TITLE
ci: homepage verify must not SIGPIPE a live tdoc.dev

### DIFF
--- a/.github/workflows/publish-landing.yml
+++ b/.github/workflows/publish-landing.yml
@@ -160,10 +160,13 @@ jobs:
           # landingHtml() is the neutral page. If it comes back, the route is
           # deployed but the doc is not readable, and the run must not be green.
           # KV is eventually consistent; retry so a one-second lag is not red.
+          # Do not pipe the body into a quiet grep under pipefail: quiet
+          # grep closes the pipe on the first match, the writer gets SIGPIPE,
+          # and a successful homepage looks like a miss. Bash [[ ]] does not.
           for i in 1 2 3 4 5 6 7 8 9 10; do
             body=$(curl -sS https://tdoc.dev/)
-            if echo "$body" | grep -q 'A doc that answers its own comments' \
-              && echo "$body" | grep -q '"isLanding":true'; then
+            if [[ "$body" == *'A doc that answers its own comments'* \
+              && "$body" == *'"isLanding":true'* ]]; then
               echo "tdoc.dev/ is serving the landing doc."
               exit 0
             fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,10 @@ file and `.claude-plugin/plugin.json`.
   Actions and had never been `wrangler secret put` onto the Worker.
   Re-running that workflow with `sync_upload_token` writes the secret
   once. Automatic publishes still do not rotate it.
+- **Homepage verify no longer fails a live landing page.** `set -o pipefail`
+  plus `echo "$body" | grep -q` SIGPIPEs on the 300kB homepage, so a
+  successful ship looked like the fallback. The check now uses bash
+  `[[ ]]`.
 - **`DELETE /api/doc` fails closed when hosted `release_owner` fails** and the
   Durable Object binding is present, so a 200 cannot leave the slug parked.
   Vercel (no `COMMENTS`) still returns 200 — there was never a reservation.

--- a/test/tornado-doc-landing.test.js
+++ b/test/tornado-doc-landing.test.js
@@ -515,6 +515,10 @@ t('shipping the homepage ships content, not just worker code', () => {
   // gate, wrong slug). Green must mean the homepage actually renders.
   assert(/is still serving the neutral fallback/.test(content),
     'publish workflow must fail when tdoc.dev/ falls back to the neutral page');
+  assert(/\[\[ "\$body" == \*'A doc that answers its own comments'\*/.test(content),
+    'homepage verify must use bash [[ ]], not echo|grep -q under pipefail');
+  assert(!/echo "\$body" \| grep -q/.test(content),
+    'echo|grep -q SIGPIPEs on a 300kB landing page and fails a successful ship');
   // First merge: the live worker does not yet have landingResponse. A
   // push-triggered publish would GET tdoc.dev/ against that old worker
   // and fail the isLanding check. Wait for deploy tdoc.dev instead.


### PR DESCRIPTION
Follow-up to #129 / #151.

Token sync + upload in https://github.com/tornado-doc/tdoc/actions/runs/32002319102 succeeded. The verify step then failed 10 times with `echo: write error: Broken pipe` while `tdoc.dev/` was already serving the landing doc.

Cause: `set -o pipefail` + `echo \"\$body\" | grep -q`. Quiet grep exits on the first match and closes the pipe; echo dies with SIGPIPE; the `if` is false even though both needles are present.

Fix: bash `[[ ]]` substring match. Live check after the upload: `tdoc.dev/` has `isLanding: true` and the headline.

## Test plan

- [x] Offline landing suite
- [ ] CI green
- [x] Live `tdoc.dev/` already serves the doc (this PR does not need another publish)