### PR TITLE
feat: per-user /me and GitHub-gated hosted publish

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ file and `.claude-plugin/plugin.json`.
 
 ### Added
 
+- **Hosted tdoc.dev is multi-tenant.** GitHub sign-in mints a recoverable
+  account-scoped upload token (`POST /api/hosted/token`). `/me` lists that
+  user's slugs (`meta.hosted.github_login`), not the Worker operator's dump.
+  Per-account doc quota (default 50) and upload-size cap (default 2 MB).
+  tdoc.dev enables signup by hostname; BYOK Workers stay single-owner unless
+  `TDOC_HOSTED_REGISTRATION` is set. `#131` `#154`.
 - **Sandboxed interactive widgets.** Author JS still does not run in the host
   document. Computation lives in `/d/:slug/v/:n/widget/:name`, loaded only as
   `Sec-Fetch-Dest: iframe`, with `sandbox="allow-scripts"` on the iframe and
@@ -18,8 +24,9 @@ file and `.claude-plugin/plugin.json`.
 ### Changed
 
 - **Default `/tdoc publish` target is hosted tdoc.dev** (Cloudflare/Vercel via
-  `--platform`). Closed signup fails clearly and points at self-host flags;
-  onboarding’s sample publish uses `--platform cloudflare`.
+  `--platform`). First hosted publish runs GitHub Device Flow, then mints a
+  token bound to that login. Closed signup on a host that left registration
+  unset still fails clearly and points at self-host flags.
 - **`--platform` after first setup switches for real.** A conflicting flag
   rewrites `~/.tdoc/published.json` via full re-setup (previous config kept as
   `published.json.bak.switch` and restored if setup fails). Cloudflare setup

--- a/ONBOARDING.md
+++ b/ONBOARDING.md
@@ -7,7 +7,7 @@
 `tdoc` is a Claude Code skill that gives the user prompt-native HTML documents with text- and artifact-anchored comments. After install + onboarding, the user can:
 
 - `/tdoc new <prompt>` → generate a commentable HTML doc
-- `/tdoc publish <slug>` → publish (default target is hosted tdoc.dev; signup may be closed, so onboarding uses `--platform cloudflare` below)
+- `/tdoc publish <slug>` → publish (default target is hosted tdoc.dev; first publish signs in with GitHub)
 - Share the live URL; commenters sign in with GitHub
 
 Install + onboarding takes ~3 minutes on a clean machine. Most steps are automatic. The user only has to click ~2 things in a browser.
@@ -139,10 +139,10 @@ cat > ~/tdocs/$SLUG/meta.json <<EOF
 {"title":"Hello tdoc","slug":"$SLUG","versions":[{"n":1,"created":"$(date -Iseconds)"}]}
 EOF
 echo '[]' > ~/tdocs/$SLUG/comments.json
-# Publish to the user's own Cloudflare Worker. Hosted tdoc.dev is the
-# default for `/tdoc publish`, but self-serve signup is closed — use an
-# explicit self-host flag here.
-~/.claude/skills/tdoc/bin/tdoc-publish --platform cloudflare $SLUG
+# Publish to hosted tdoc.dev. First run signs in with GitHub Device Flow
+# (open the printed URL and enter the code), then uploads.
+# To self-host instead: --platform cloudflare or --platform vercel.
+~/.claude/skills/tdoc/bin/tdoc-publish $SLUG
 ```
 
 The script prints the live URL. Show it to the user.

--- a/README.md
+++ b/README.md
@@ -107,10 +107,11 @@ switch — the CLI rewrites the config via full re-setup (previous file kept as
 Worker are two hostnames, not two platforms.
 
 - **Hosted (default)** — `/tdoc publish <slug>` uploads to a tdoc-managed host
-  such as `tdoc.dev`. This path skips user deploy setup. On first use, the
-  hosted service issues an account-scoped upload token and the CLI stores it in
-  `~/.tdoc/published.json`; that token can only mutate docs it owns. If hosted
-  signup is not open, the CLI says so and points at `--platform cloudflare` or
+  such as `tdoc.dev`. First use signs in with GitHub (Device Flow); the host
+  issues an account-scoped upload token bound to that login and stores it in
+  `~/.tdoc/published.json`. That token can only mutate docs it owns. `/me` on
+  the hosted worker lists that GitHub user's docs. If hosted signup is not
+  open, the CLI says so and points at `--platform cloudflare` or
   `--platform vercel`.
 - **Cloudflare** — `/tdoc publish --platform cloudflare <slug>` deploys a
   Worker + R2 + KV you own, with a Durable Object serializing concurrent

--- a/SKILL.md
+++ b/SKILL.md
@@ -409,11 +409,12 @@ pkill -f "$SKILL_DIR/server/server.js"
 
 Publishes the latest version of `<slug>` to a public URL.
 
-Default target is **hosted** (`https://tdoc.dev`). First run asks the host for
-an account-scoped upload token and stores it in `~/.tdoc/published.json`. That
-token can only mutate docs it owns. If hosted signup is not open, the CLI fails
-with a clear prompt to self-host instead — do **not** tell the user to flip a
-Worker env flag.
+Default target is **hosted** (`https://tdoc.dev`). First run signs in with
+GitHub (Device Flow), then asks the host for an account-scoped upload token
+bound to that login and stores it in `~/.tdoc/published.json`. That token can
+only mutate docs it owns. `/me` on tdoc.dev lists that GitHub user's docs. If
+hosted signup is not open on the target, the CLI fails with a clear prompt to
+self-host instead — do **not** tell the user to flip a Worker env flag.
 
 **Self-host — Cloudflare**: `tdoc-publish --platform cloudflare <slug>`.
 First run (or an explicit switch onto cloudflare) prompts `wrangler login`,
@@ -783,13 +784,13 @@ Remote storage holds optional `meta.access`:
 }
 ```
 
-- **public / unlisted**: link-readable without login. Unlisted is not catalog-discovery; `/me` still lists owner docs.
-- **private**: `TDOC_OWNER` + `allowed_users` only. Gates `/d/.../v/N`, export, fork, `GET /api/comments`.
+- **public / unlisted**: link-readable without login. Unlisted is not catalog-discovery; `/me` still lists the signed-in publisher's docs.
+- **private**: the doc publisher (hosted `github_login`, or `TDOC_OWNER` on BYOK/legacy) + `allowed_users`. Gates `/d/.../v/N`, export, fork, `GET /api/comments`.
 - **history_visibility**: version picker visibility (new policies default owner-only / pure-publish).
 - Legacy meta without `access` stays world-readable + full history (back-compat).
 - Initial publish can set access via `tdoc-publish --visibility|--history|--commenting|--allow-user`.
 - After publish, access must be mutable directly on remote storage (`PATCH /api/doc/access` with the upload token) without local `meta.json` or full HTML re-upload.
-- `/me` may list docs through the owner GitHub session, but remote write actions still use the upload token; do not authorize destructive/access changes from the owner cookie while arbitrary published docs share the same origin.
+- `/me` on hosted tdoc.dev lists the signed-in GitHub user's docs. On BYOK it lists the worker operator's docs. Remote write actions still use the upload token for CLI; the publisher's session cookie may mutate their own docs (CSP on every response).
 
 
 ### Comment anchor stability (important for `/tdoc edit`)

--- a/bin/tdoc-publish
+++ b/bin/tdoc-publish
@@ -210,6 +210,74 @@ require_vercel() {
   fi
 }
 
+# GitHub Device Flow against the hosted Worker. Writes the session cookie into
+# $2 (curl cookie jar) so /api/hosted/token can bind the upload token to the
+# signed-in login. Same shape as the overlay sign-in, for the CLI.
+hosted_github_signin() {
+  local base="$1" cookiejar="$2"
+  local resp http payload
+  resp="$(curl -sS --connect-timeout 10 --max-time 30 -w $'\n%{http_code}' \
+    -X POST "$base/api/auth/device/start" -H "Content-Type: application/json" -d '{}')" || {
+      fail_with_agent_prompt "hosted GitHub sign-in is unreachable" \
+        "The hosted tdoc service at $base did not start GitHub sign-in. Retry '/tdoc publish $SLUG' later, or self-host with '/tdoc publish --platform cloudflare $SLUG' or '/tdoc publish --platform vercel $SLUG'."
+    }
+  http="${resp##*$'\n'}"
+  payload="${resp%$'\n'*}"
+  if ! printf '%s' "$http" | grep -qE '^2[0-9][0-9]$'; then
+    echo "[tdoc] GitHub device-flow start returned HTTP $http" >&2
+    printf '%s\n' "$payload" | head -c 400 >&2; echo >&2
+    exit 1
+  fi
+  local user_code device_code uri interval expires
+  user_code="$(printf '%s' "$payload" | jq -r '.user_code // empty')"
+  device_code="$(printf '%s' "$payload" | jq -r '.device_code // empty')"
+  uri="$(printf '%s' "$payload" | jq -r '.verification_uri_complete // .verification_uri // empty')"
+  interval="$(printf '%s' "$payload" | jq -r '.interval // 5')"
+  expires="$(printf '%s' "$payload" | jq -r '.expires_in // 900')"
+  if [ -z "$user_code" ] || [ -z "$device_code" ] || [ -z "$uri" ]; then
+    echo "[tdoc] GitHub device-flow start was missing user_code/device_code." >&2
+    printf '%s\n' "$payload" | head -c 400 >&2; echo >&2
+    exit 1
+  fi
+  case "$interval" in ''|*[!0-9]*) interval=5 ;; esac
+  [ "$interval" -lt 5 ] && interval=5
+  case "$expires" in ''|*[!0-9]*) expires=900 ;; esac
+  echo "[tdoc] Sign in with GitHub to publish on $base" >&2
+  echo "[tdoc] Open: $uri" >&2
+  echo "[tdoc] Code: $user_code" >&2
+  echo "[tdoc] Waiting for GitHub approval…" >&2
+  local waited=0 err
+  while [ "$waited" -lt "$expires" ]; do
+    sleep "$interval"
+    waited=$((waited + interval))
+    resp="$(curl -sS --connect-timeout 10 --max-time 30 -c "$cookiejar" -b "$cookiejar" -w $'\n%{http_code}' \
+      -X POST "$base/api/auth/device/poll" -H "Content-Type: application/json" \
+      -d "{\"device_code\":\"$(printf '%s' "$device_code" | sed 's/"/\\"/g')\"}")" || continue
+    http="${resp##*$'\n'}"
+    payload="${resp%$'\n'*}"
+    if printf '%s' "$payload" | jq -e '.ok == true' >/dev/null 2>&1; then
+      echo "[tdoc] Signed in as $(printf '%s' "$payload" | jq -r '.identity.login // "github user"')" >&2
+      return 0
+    fi
+    err="$(printf '%s' "$payload" | jq -r '.error // empty')"
+    case "$err" in
+      authorization_pending|'') ;;
+      slow_down) interval=$((interval + 5)) ;;
+      expired_token|access_denied)
+        fail_with_agent_prompt "GitHub sign-in expired or was denied" \
+          "Retry '/tdoc publish $SLUG' and approve the GitHub device code shown in the terminal."
+        ;;
+      *)
+        echo "[tdoc] GitHub sign-in error: ${err:-HTTP $http}" >&2
+        printf '%s\n' "$payload" | head -c 400 >&2; echo >&2
+        exit 1
+        ;;
+    esac
+  done
+  fail_with_agent_prompt "GitHub sign-in timed out" \
+    "Retry '/tdoc publish $SLUG' and approve the GitHub device code before it expires. To self-host instead, run '/tdoc publish --platform cloudflare $SLUG' or '/tdoc publish --platform vercel $SLUG'."
+}
+
 first_time_setup_hosted() {
   local base="${TDOC_HOSTED_BASE:-https://tdoc.dev}"
   base="${base%/}"
@@ -217,13 +285,17 @@ first_time_setup_hosted() {
     http://*|https://*) ;;
     *) echo "[tdoc] TDOC_HOSTED_BASE must start with http:// or https:// (got '$base')." >&2; exit 1 ;;
   esac
-  local resp http payload token account_id
-  resp="$(curl -sS --connect-timeout 10 --max-time 30 -w $'\n%{http_code}' \
+  local cookiejar resp http payload token account_id github_login
+  cookiejar="$(mktemp -t tdoc-hosted-cookie.XXXXXX)"
+  hosted_github_signin "$base" "$cookiejar"
+  resp="$(curl -sS --connect-timeout 10 --max-time 30 -b "$cookiejar" -w $'\n%{http_code}' \
     -X POST "$base/api/hosted/token" -H "Content-Type: application/json" \
     -d "{\"label\":\"$(printf '%s' "$SLUG" | sed 's/"/\\"/g')\"}" 2>&1)" || {
+      rm -f "$cookiejar"
       fail_with_agent_prompt "hosted service is unreachable" \
         "The hosted tdoc service at $base did not respond. Retry '/tdoc publish $SLUG' later, or set TDOC_HOSTED_BASE to the correct hosted URL. To self-host instead, run '/tdoc publish --platform cloudflare $SLUG' or '/tdoc publish --platform vercel $SLUG'."
     }
+  rm -f "$cookiejar"
   http="${resp##*$'\n'}"
   payload="${resp%$'\n'*}"
   if ! printf '%s' "$http" | grep -qE '^2[0-9][0-9]$'; then
@@ -231,12 +303,17 @@ first_time_setup_hosted() {
       fail_with_agent_prompt "hosted signup is not open on $base" \
         "The default publish target is hosted tdoc ($base), but self-serve signup is not enabled there. Publish to your own account instead: '/tdoc publish --platform cloudflare $SLUG' or '/tdoc publish --platform vercel $SLUG'."
     fi
+    if printf '%s' "$payload" | grep -q 'sign_in_required'; then
+      fail_with_agent_prompt "hosted publish requires GitHub sign-in" \
+        "Retry '/tdoc publish $SLUG' and complete the GitHub device-flow prompt. To self-host instead, run '/tdoc publish --platform cloudflare $SLUG' or '/tdoc publish --platform vercel $SLUG'."
+    fi
     echo "[tdoc] hosted token request returned HTTP $http" >&2
     printf '%s\n' "$payload" | head -c 400 >&2; echo >&2
     exit 1
   fi
   token="$(printf '%s' "$payload" | jq -r '.token // empty')"
   account_id="$(printf '%s' "$payload" | jq -r '.account_id // empty')"
+  github_login="$(printf '%s' "$payload" | jq -r '.github_login // empty')"
   if [ -z "$token" ] || [ -z "$account_id" ]; then
     echo "[tdoc] hosted token response was missing token/account_id." >&2
     printf '%s\n' "$payload" | head -c 400 >&2; echo >&2
@@ -251,7 +328,8 @@ first_time_setup_hosted() {
       --arg base "$base" \
       --arg host "$public_host" \
       --arg acct "$account_id" \
-      '{platform:"hosted", upload_token:$tok, base:$base, public_host:$host, account_id:$acct, created: now | todate}' \
+      --arg gh "$github_login" \
+      '{platform:"hosted", upload_token:$tok, base:$base, public_host:$host, account_id:$acct, github_login:$gh, created: now | todate}' \
       > "$CONFIG_FILE"
   )
   chmod 600 "$CONFIG_FILE"

--- a/server/overlay.js
+++ b/server/overlay.js
@@ -31,7 +31,8 @@
   // embedded #tdoc-fork-comments JSON. No /api calls, no auth, no publish.
   // The original published slug is in cfg.originalSlug so we can label it.
   let identity = cfg.identity || null;
-  let isOwner = !!cfg.isOwner; // true only for the configured TDOC_OWNER
+  let isOwner = !!cfg.isOwner; // true when this session owns THIS doc
+  let canSeeMyDocs = !!(cfg.canSeeMyDocs || cfg.isOwner);
   if (!slug) return;
 
   const HIGHLIGHT_API = typeof CSS !== 'undefined' && CSS.highlights && typeof Highlight === 'function';
@@ -1202,7 +1203,7 @@
           </button>
           <div class="tdoc-menu" id="tdoc-me-menu" role="menu">
             <button id="tdoc-inbox-open" role="menuitem">${escapeHtml(inboxMenuLabel(inboxUnreadN))}</button>
-            ${isOwner ? `<button id="tdoc-my-docs" role="menuitem">My docs</button>` : ''}
+            ${canSeeMyDocs ? `<button id="tdoc-my-docs" role="menuitem">My docs</button>` : ''}
             <button id="tdoc-signout" role="menuitem">Sign out</button>
           </div>
         </div>`;
@@ -1214,7 +1215,7 @@
         meBtn.setAttribute('aria-expanded', open ? 'true' : 'false');
       };
       document.getElementById('tdoc-inbox-open').onclick = () => { meMenu.classList.remove('open'); showInboxPanel(); };
-      if (isOwner) {
+      if (canSeeMyDocs) {
         document.getElementById('tdoc-my-docs').onclick = () => {
           window.open('/me', '_blank', 'noopener');
         };
@@ -1223,6 +1224,7 @@
         await fetch('/api/auth/logout', { method: 'POST' });
         identity = null;
         isOwner = false;
+        canSeeMyDocs = false;
         inboxUnreadN = 0;
         inboxSig = '';
         stopInboxPoll();
@@ -3032,12 +3034,14 @@
       const data = await r.json();
       if (data.ok && data.identity) {
         identity = data.identity;
-        // Page may have booted signed-out (isOwner false). Refresh owner
-        // flag so "My docs" appears without a full reload.
+        // Page may have booted signed-out (canSeeMyDocs false). Refresh so
+        // "My docs" appears without a full reload on hosted tdoc.dev.
         try {
           const me = await fetch('/api/auth/me', { credentials: 'same-origin' }).then((x) => x.json());
           if (me && typeof me.isOwner === 'boolean') isOwner = me.isOwner;
-        } catch { /* keep bootCfg isOwner */ }
+          if (me && typeof me.canSeeMyDocs === 'boolean') canSeeMyDocs = me.canSeeMyDocs;
+          else if (me && me.isOwner) canSeeMyDocs = true;
+        } catch { /* keep bootCfg flags */ }
         closeDeviceModal();
         renderIdentity();
         refreshComments();

--- a/server/overlay.js
+++ b/server/overlay.js
@@ -32,7 +32,9 @@
   // The original published slug is in cfg.originalSlug so we can label it.
   let identity = cfg.identity || null;
   let isOwner = !!cfg.isOwner; // true when this session owns THIS doc
-  let canSeeMyDocs = !!(cfg.canSeeMyDocs || cfg.isOwner);
+  // Worker sends this explicitly. Do not infer from isOwner — on hosted
+  // tdoc.dev a signed-in reader may not own the current doc and still has /me.
+  let canSeeMyDocs = !!cfg.canSeeMyDocs;
   if (!slug) return;
 
   const HIGHLIGHT_API = typeof CSS !== 'undefined' && CSS.highlights && typeof Highlight === 'function';
@@ -3309,7 +3311,6 @@
           const me = await fetch('/api/auth/me', { credentials: 'same-origin' }).then((x) => x.json());
           if (me && typeof me.isOwner === 'boolean') isOwner = me.isOwner;
           if (me && typeof me.canSeeMyDocs === 'boolean') canSeeMyDocs = me.canSeeMyDocs;
-          else if (me && me.isOwner) canSeeMyDocs = true;
         } catch { /* keep bootCfg flags */ }
         closeDeviceModal();
         renderIdentity();

--- a/server/overlay.js
+++ b/server/overlay.js
@@ -3062,7 +3062,7 @@
   // the single Share button (showShareModal dispatches here when
   // cfg.ownerManage is set). Gated on cfg.ownerManage, which the worker only
   // populates in the per-request boot config when THIS request's session
-  // passed isOwnerSession() server-side (worker.js's /d/ route). A
+  // passed isDocOwnerSession() server-side (worker.js's /d/ route). A
   // non-owner's config carries cfg.ownerManage === null — every function
   // below bails before creating any DOM, so there is no hidden button, just
   // nothing rendered for them.
@@ -3309,7 +3309,6 @@
         // "My docs" appears without a full reload on hosted tdoc.dev.
         try {
           const me = await fetch('/api/auth/me', { credentials: 'same-origin' }).then((x) => x.json());
-          if (me && typeof me.isOwner === 'boolean') isOwner = me.isOwner;
           if (me && typeof me.canSeeMyDocs === 'boolean') canSeeMyDocs = me.canSeeMyDocs;
         } catch { /* keep bootCfg flags */ }
         closeDeviceModal();

--- a/skills/tdoc/SKILL.md
+++ b/skills/tdoc/SKILL.md
@@ -409,11 +409,12 @@ pkill -f "$SKILL_DIR/server/server.js"
 
 Publishes the latest version of `<slug>` to a public URL.
 
-Default target is **hosted** (`https://tdoc.dev`). First run asks the host for
-an account-scoped upload token and stores it in `~/.tdoc/published.json`. That
-token can only mutate docs it owns. If hosted signup is not open, the CLI fails
-with a clear prompt to self-host instead — do **not** tell the user to flip a
-Worker env flag.
+Default target is **hosted** (`https://tdoc.dev`). First run signs in with
+GitHub (Device Flow), then asks the host for an account-scoped upload token
+bound to that login and stores it in `~/.tdoc/published.json`. That token can
+only mutate docs it owns. `/me` on tdoc.dev lists that GitHub user's docs. If
+hosted signup is not open on the target, the CLI fails with a clear prompt to
+self-host instead — do **not** tell the user to flip a Worker env flag.
 
 **Self-host — Cloudflare**: `tdoc-publish --platform cloudflare <slug>`.
 First run (or an explicit switch onto cloudflare) prompts `wrangler login`,
@@ -783,13 +784,13 @@ Remote storage holds optional `meta.access`:
 }
 ```
 
-- **public / unlisted**: link-readable without login. Unlisted is not catalog-discovery; `/me` still lists owner docs.
-- **private**: `TDOC_OWNER` + `allowed_users` only. Gates `/d/.../v/N`, export, fork, `GET /api/comments`.
+- **public / unlisted**: link-readable without login. Unlisted is not catalog-discovery; `/me` still lists the signed-in publisher's docs.
+- **private**: the doc publisher (hosted `github_login`, or `TDOC_OWNER` on BYOK/legacy) + `allowed_users`. Gates `/d/.../v/N`, export, fork, `GET /api/comments`.
 - **history_visibility**: version picker visibility (new policies default owner-only / pure-publish).
 - Legacy meta without `access` stays world-readable + full history (back-compat).
 - Initial publish can set access via `tdoc-publish --visibility|--history|--commenting|--allow-user`.
 - After publish, access must be mutable directly on remote storage (`PATCH /api/doc/access` with the upload token) without local `meta.json` or full HTML re-upload.
-- `/me` may list docs through the owner GitHub session, but remote write actions still use the upload token; do not authorize destructive/access changes from the owner cookie while arbitrary published docs share the same origin.
+- `/me` on hosted tdoc.dev lists the signed-in GitHub user's docs. On BYOK it lists the worker operator's docs. Remote write actions still use the upload token for CLI; the publisher's session cookie may mutate their own docs (CSP on every response).
 
 
 ### Comment anchor stability (important for `/tdoc edit`)

--- a/test/access.test.js
+++ b/test/access.test.js
@@ -83,6 +83,24 @@ t('history_visibility owner hides picker from allowlisted non-owner', () => {
   assert(box.canSeeHistory(a, null, ENV) === false);
 });
 
+t('hosted publisher is the doc owner; TDOC_OWNER is not', () => {
+  const a = box.normalizeAccess({
+    visibility: 'private',
+    history_visibility: 'owner',
+    commenting: 'owner',
+    allowed_users: [],
+  });
+  const hosted = { hosted: { github_login: 'alice', account_id: 'acct_1' } };
+  assert(box.isDocOwnerSession(ENV, alice, hosted) === true);
+  assert(box.isDocOwnerSession(ENV, owner, hosted) === false);
+  assert(box.canSeeHistory(a, alice, ENV, hosted) === true);
+  assert(box.canSeeHistory(a, owner, ENV, hosted) === false);
+  assert(box.canReadDoc(a, alice, ENV, hosted) === true);
+  assert(box.canReadDoc(a, owner, ENV, hosted) === false);
+  assert(box.canCommentOnDoc(a, alice, ENV, hosted) === true);
+  assert(box.canCommentOnDoc(a, owner, ENV, hosted) === false);
+});
+
 t('history_visibility invited allows allowlist', () => {
   const a = box.normalizeAccess({
     visibility: 'private',

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -61,9 +61,12 @@ t('tdoc-publish defaults to hosted and treats Cloudflare/Vercel as self-host fla
   assert(/PLATFORM_FLAG:-hosted/.test(src), 'first publish must default to hosted');
   assert(/first_time_setup_hosted\(\)/.test(src), 'hosted setup function missing');
   assert(/\/api\/hosted\/token/.test(src), 'hosted setup does not request a provider-issued token');
+  assert(/\/api\/auth\/device\/start/.test(src), 'hosted setup must GitHub-device-flow before minting a token');
+  assert(/sign_in_required/.test(src), 'hosted setup must handle a missing GitHub session');
   assert(!/TDOC_HOSTED_UPLOAD_TOKEN/.test(src), 'hosted setup must not require an out-of-band upload token');
   assert(/TDOC_HOSTED_BASE:-https:\/\/tdoc\.dev/.test(src), 'hosted setup does not default to tdoc.dev');
   assert(/platform:"hosted"/.test(src), 'hosted setup does not persist hosted platform');
+  assert(/github_login:\$gh/.test(src), 'hosted setup does not persist github_login');
   assert(/account_id:\$acct/.test(src), 'hosted setup does not persist account_id');
   assert(/if \[ "\$PLATFORM" = "hosted" \]/.test(src), 'hosted platform branch missing');
   assert(/UPLOAD_BASE="\$BASE"/.test(src), 'hosted branch should upload to configured base');

--- a/test/duplicate-download.test.js
+++ b/test/duplicate-download.test.js
@@ -82,7 +82,9 @@ t('POST /api/doc/duplicate is session-gated, snapshot-only, no comment copy', ()
   assert(!dupRoute.includes('mutateComments'), 'v1 duplicate must not copy comment threads');
   assert(!dupRoute.includes('readComments'), 'v1 duplicate must not snapshot comments');
   assert(dupRoute.includes('stampAids'), 'copied HTML must be aid-stamped');
-  assert(dupRoute.includes('nextDuplicateSlug'), 'must allocate a -copy slug');
+  assert(dupRoute.includes('hostedAccountForGithub'), 'duplicate must reuse the hosted account registry');
+  assert(dupRoute.includes('quota_docs'), 'duplicate must share the hosted doc quota');
+  assert(dupRoute.includes('quota_upload_bytes'), 'duplicate must share the hosted upload-size cap');
 });
 
 t('export attachment filename is slug-vN.html, not -fork.html', () => {

--- a/test/hosted-oob-behavior.test.js
+++ b/test/hosted-oob-behavior.test.js
@@ -539,6 +539,27 @@ async function issue(worker, env, login = 'alice', label = login) {
     assert(body.error === 'quota_upload_bytes', `expected quota_upload_bytes, got ${JSON.stringify(body)}`);
   });
 
+  await t('hosted upload quota counts UTF-8 bytes, not JS string length', async () => {
+    const env = makeEnv(mod.CommentsStore, { TDOC_HOSTED_MAX_UPLOAD_BYTES: '20' });
+    const alice = await issue(worker, env, 'alice');
+    const cjk = '<p>' + '文'.repeat(7) + '</p>'; // 14 UTF-16 units, 28 UTF-8 bytes
+    assert(cjk.length <= 20, 'fixture must sit under the JS length cap');
+    const over = await worker.fetch(req('/api/upload', {
+      method: 'POST', token: alice.token,
+      body: { slug: 'cjk', version: 1, html: cjk },
+    }), env, {});
+    assert(over.status === 413, `expected 413 for CJK over the byte cap, got ${over.status}`);
+    const overBody = await over.json();
+    assert(overBody.error === 'quota_upload_bytes', `unexpected ${JSON.stringify(overBody)}`);
+    assert(overBody.size === new TextEncoder().encode(cjk).byteLength,
+      `size should be UTF-8 bytes, got ${overBody.size}`);
+    const okUp = await worker.fetch(req('/api/upload', {
+      method: 'POST', token: alice.token,
+      body: { slug: 'ok', version: 1, html: '<p>hi</p>' },
+    }), env, {});
+    assert(okUp.status === 200, `ASCII under the cap should upload, got ${okUp.status}: ${await okUp.text()}`);
+  });
+
   await t('duplicate requires a signed-in session', async () => {
     const env = makeEnv(mod.CommentsStore, { TDOC_OWNER: 'julie' });
     await env.DOCS.put('docs/src-doc/v1/index.html', '<h1>Src</h1>');

--- a/test/hosted-oob-behavior.test.js
+++ b/test/hosted-oob-behavior.test.js
@@ -132,22 +132,38 @@ function makeEnv(StoreClass, extra = {}) {
   return env;
 }
 
-function req(pathname, { method = 'GET', token = '', body = null } = {}) {
+function req(pathname, { method = 'GET', token = '', body = null, cookie = '' } = {}) {
   return new Request(`https://tdoc.dev${pathname}`, {
     method,
     headers: {
       ...(token ? { Authorization: `Bearer ${token}` } : {}),
+      ...(cookie ? { Cookie: `tdoc_sid=${cookie}` } : {}),
       ...(body ? { 'Content-Type': 'application/json' } : {}),
     },
     body: body ? JSON.stringify(body) : undefined,
   });
 }
 
-async function issue(worker, env, label = 'test') {
-  const r = await worker.fetch(req('/api/hosted/token', { method: 'POST', body: { label } }), env, {});
+async function putSession(env, login) {
+  // Worker parseCookie only accepts hex tdoc_sid values.
+  const sid = [...crypto.getRandomValues(new Uint8Array(16))]
+    .map((b) => b.toString(16).padStart(2, '0')).join('');
+  await env.META.put(`session:${sid}`, JSON.stringify({
+    login, name: login, avatar_url: '', created: new Date().toISOString(),
+  }));
+  return sid;
+}
+
+async function issue(worker, env, login = 'alice', label = login) {
+  const cookie = await putSession(env, login);
+  const r = await worker.fetch(req('/api/hosted/token', {
+    method: 'POST', cookie, body: { label },
+  }), env, {});
   const data = await r.json();
-  assert(r.status === 200 && data.token && data.account_id, `token issue failed ${r.status}: ${JSON.stringify(data)}`);
-  return data;
+  assert(r.status === 200 && data.token && data.account_id,
+    `token issue failed ${r.status}: ${JSON.stringify(data)}`);
+  assert(data.github_login === login, `expected github_login ${login}, got ${data.github_login}`);
+  return { ...data, cookie, login };
 }
 
 (async () => {
@@ -156,13 +172,31 @@ async function issue(worker, env, label = 'test') {
   console.log('hosted OOB behavior');
 
   await t('hosted token mint is closed unless registration is explicitly enabled', async () => {
-    const env = makeEnv(mod.CommentsStore, { TDOC_HOSTED_REGISTRATION: '' });
+    const env = makeEnv(mod.CommentsStore, { TDOC_HOSTED_REGISTRATION: '0' });
     const r = await worker.fetch(req('/api/hosted/token', { method: 'POST', body: { label: 'closed' } }), env, {});
     const data = await r.json();
     assert(r.status === 403, `expected 403, got ${r.status}`);
     assert(data.error === 'hosted_registration_disabled', `unexpected error ${JSON.stringify(data)}`);
     assert([...env.META.map.keys()].every(k => !k.startsWith('hosted-token:')),
       'disabled registration must not persist a token record');
+  });
+
+  await t('unset registration enables on tdoc.dev and stays closed on BYOK hosts', async () => {
+    const env = makeEnv(mod.CommentsStore);
+    delete env.TDOC_HOSTED_REGISTRATION;
+    const cookie = await putSession(env, 'alice');
+    const onDev = await worker.fetch(req('/api/hosted/token', {
+      method: 'POST', cookie, body: { label: 'dev' },
+    }), env, {});
+    assert(onDev.status === 200, `tdoc.dev should mint, got ${onDev.status}: ${await onDev.clone().text()}`);
+    const byok = await worker.fetch(new Request('https://example.workers.dev/api/hosted/token', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', Cookie: `tdoc_sid=${cookie}` },
+      body: JSON.stringify({ label: 'byok' }),
+    }), env, {});
+    assert(byok.status === 403, `BYOK host should stay closed, got ${byok.status}`);
+    const byokBody = await byok.json();
+    assert(byokBody.error === 'hosted_registration_disabled', `unexpected ${JSON.stringify(byokBody)}`);
   });
 
   await t('missing-meta hosted upload still persists owner; second token cannot overwrite', async () => {
@@ -391,6 +425,112 @@ async function issue(worker, env, label = 'test') {
     }), env, {});
     assert(r.status !== 200, `agent reply should fail closed, got ${r.status}`);
     assert(state.get('list')[0].events.length === 1, 'agent reply mutated comments');
+  });
+
+  await t('hosted token mint requires a GitHub session even when registration is open', async () => {
+    const env = makeEnv(mod.CommentsStore);
+    const r = await worker.fetch(req('/api/hosted/token', { method: 'POST', body: { label: 'anon' } }), env, {});
+    const data = await r.json();
+    assert(r.status === 401, `expected 401, got ${r.status}`);
+    assert(data.error === 'sign_in_required', `unexpected error ${JSON.stringify(data)}`);
+    assert([...env.META.map.keys()].every(k => !k.startsWith('hosted-token:')),
+      'anonymous mint must not persist a token record');
+  });
+
+  await t('same GitHub login remints the same account_id; a second login cannot overwrite that slug', async () => {
+    const env = makeEnv(mod.CommentsStore);
+    const first = await issue(worker, env, 'alice', 'laptop');
+    const remint = await issue(worker, env, 'alice', 'phone');
+    assert(first.account_id === remint.account_id, 'remint must reuse account_id');
+    assert(first.token !== remint.token, 'remint must issue a new token');
+
+    const up = await worker.fetch(req('/api/upload', {
+      method: 'POST', token: first.token,
+      body: { slug: 'alice-doc', version: 1, html: '<h1>A</h1>' },
+    }), env, {});
+    assert(up.status === 200, `alice upload ${up.status}: ${await up.text()}`);
+    const meta = JSON.parse(await env.META.get('meta:alice-doc'));
+    assert(meta.hosted.github_login === 'alice', 'upload must stamp github_login');
+
+    const bob = await issue(worker, env, 'bob');
+    const steal = await worker.fetch(req('/api/upload', {
+      method: 'POST', token: bob.token,
+      body: { slug: 'alice-doc', version: 1, html: '<h1>stolen</h1>' },
+    }), env, {});
+    assert(steal.status === 403, `bob should be denied, got ${steal.status}`);
+  });
+
+  await t('/me lists only the signed-in GitHub user docs; operator keeps legacy unhosted', async () => {
+    const env = makeEnv(mod.CommentsStore, { TDOC_OWNER: 'julie' });
+    const alice = await issue(worker, env, 'alice');
+    const bob = await issue(worker, env, 'bob');
+    const aUp = await worker.fetch(req('/api/upload', {
+      method: 'POST', token: alice.token,
+      body: { slug: 'alice-doc', version: 1, html: '<h1>A</h1>', meta: { title: 'Alice Doc' } },
+    }), env, {});
+    assert(aUp.status === 200, `alice upload ${aUp.status}`);
+    const bUp = await worker.fetch(req('/api/upload', {
+      method: 'POST', token: bob.token,
+      body: { slug: 'bob-doc', version: 1, html: '<h1>B</h1>', meta: { title: 'Bob Doc' } },
+    }), env, {});
+    assert(bUp.status === 200, `bob upload ${bUp.status}`);
+    await env.META.put('meta:legacy', JSON.stringify({
+      title: 'Legacy', slug: 'legacy', versions: [{ n: 1 }],
+    }));
+
+    const aliceMe = await worker.fetch(req('/me', { cookie: alice.cookie }), env, {});
+    assert(aliceMe.status === 200, `/me alice ${aliceMe.status}`);
+    const aliceHtml = await aliceMe.text();
+    assert(aliceHtml.includes('alice-doc'), 'alice must see her slug');
+    assert(!aliceHtml.includes('bob-doc'), 'alice must not see bob');
+    assert(!aliceHtml.includes('legacy'), 'alice must not see operator legacy docs');
+
+    const bobMe = await worker.fetch(req('/me', { cookie: bob.cookie }), env, {});
+    const bobHtml = await bobMe.text();
+    assert(bobHtml.includes('bob-doc'), 'bob must see his slug');
+    assert(!bobHtml.includes('alice-doc'), 'bob must not see alice');
+
+    const julieSid = await putSession(env, 'julie');
+    const julieMe = await worker.fetch(req('/me', { cookie: julieSid }), env, {});
+    assert(julieMe.status === 200, `/me julie ${julieMe.status}`);
+    const julieHtml = await julieMe.text();
+    assert(julieHtml.includes('legacy'), 'operator must still see unhosted legacy docs');
+    assert(!julieHtml.includes('alice-doc'), 'operator /me must not list other tenants');
+    assert(!julieHtml.includes('bob-doc'), 'operator /me must not list other tenants');
+  });
+
+  await t('hosted create enforces per-account doc quota; retry of same slug does not consume another slot', async () => {
+    const env = makeEnv(mod.CommentsStore, { TDOC_HOSTED_MAX_DOCS: '1' });
+    const alice = await issue(worker, env, 'alice');
+    const first = await worker.fetch(req('/api/upload', {
+      method: 'POST', token: alice.token,
+      body: { slug: 'one', version: 1, html: '<h1>1</h1>' },
+    }), env, {});
+    assert(first.status === 200, `first upload ${first.status}`);
+    const second = await worker.fetch(req('/api/upload', {
+      method: 'POST', token: alice.token,
+      body: { slug: 'two', version: 1, html: '<h1>2</h1>' },
+    }), env, {});
+    assert(second.status === 403, `quota should 403, got ${second.status}`);
+    const body = await second.json();
+    assert(body.error === 'quota_docs', `expected quota_docs, got ${JSON.stringify(body)}`);
+    const retry = await worker.fetch(req('/api/upload', {
+      method: 'POST', token: alice.token,
+      body: { slug: 'one', version: 2, html: '<h1>1b</h1>' },
+    }), env, {});
+    assert(retry.status === 200, `same-slug retry should not count as a new doc, got ${retry.status}: ${await retry.text()}`);
+  });
+
+  await t('hosted upload rejects oversize html', async () => {
+    const env = makeEnv(mod.CommentsStore, { TDOC_HOSTED_MAX_UPLOAD_BYTES: '20' });
+    const alice = await issue(worker, env, 'alice');
+    const r = await worker.fetch(req('/api/upload', {
+      method: 'POST', token: alice.token,
+      body: { slug: 'big', version: 1, html: '<h1>this is more than twenty bytes of html</h1>' },
+    }), env, {});
+    assert(r.status === 413, `expected 413, got ${r.status}`);
+    const body = await r.json();
+    assert(body.error === 'quota_upload_bytes', `expected quota_upload_bytes, got ${JSON.stringify(body)}`);
   });
 
   console.log(`\n${pass} passed, ${fail} failed`);

--- a/test/hosted-oob-behavior.test.js
+++ b/test/hosted-oob-behavior.test.js
@@ -622,6 +622,14 @@ async function issue(worker, env, login = 'alice', label = login) {
     assert(meta.versions.length === 1 && meta.versions[0].n === 1, 'must be a v1 snapshot');
     assert(meta.access && meta.access.visibility === 'unlisted', 'copy should default unlisted');
     assert(meta.hosted && meta.hosted.github_login === 'alice', 'copy must bind alice');
+    const tok = await issue(worker, env, 'alice');
+    assert(tok.account_id === meta.hosted.account_id,
+      'CLI mint and Duplicate must share account_id');
+    const up = await worker.fetch(req('/api/upload', {
+      method: 'POST', token: tok.token,
+      body: { slug: firstBody.slug, version: 2, html: '<h1>Essay v2</h1>' },
+    }), env, {});
+    assert(up.status === 200, `CLI token should update the copy, got ${up.status}: ${await up.text()}`);
     assert(!(await env.META.get('comments:public-essay-copy')), 'comments must not come along');
 
     const second = await worker.fetch(req('/api/doc/duplicate', {
@@ -638,6 +646,35 @@ async function issue(worker, env, login = 'alice', label = login) {
     assert(me.status === 200, `/me ${me.status}`);
     assert(meHtml.includes('public-essay') && !meHtml.includes('public-essay-copy'),
       'operator /me must not list alice\'s account copies');
+  });
+
+  await t('duplicate consumes the same hosted doc quota as publish', async () => {
+    const env = makeEnv(mod.CommentsStore, { TDOC_HOSTED_MAX_DOCS: '1' });
+    await env.DOCS.put('docs/src-doc/v1/index.html', '<h1>Src</h1>');
+    await env.META.put('meta:src-doc', JSON.stringify({ title: 'Src', slug: 'src-doc', versions: [{ n: 1 }] }));
+    const alice = await issue(worker, env, 'alice');
+    const up = await worker.fetch(req('/api/upload', {
+      method: 'POST', token: alice.token,
+      body: { slug: 'one', version: 1, html: '<h1>1</h1>' },
+    }), env, {});
+    assert(up.status === 200, `seed upload ${up.status}`);
+    const dup = await worker.fetch(req('/api/doc/duplicate', {
+      method: 'POST', cookie: alice.cookie,
+      body: { slug: 'src-doc', version: 1 },
+    }), env, {});
+    assert(dup.status === 403, `duplicate should hit quota, got ${dup.status}`);
+    assert((await dup.json()).error === 'quota_docs', 'duplicate must return quota_docs');
+  });
+
+  await t('legacy hosted-github account_id is reused by mint', async () => {
+    const env = makeEnv(mod.CommentsStore);
+    await env.META.put('hosted-github:alice', JSON.stringify({
+      account_id: 'acct_legacyalice', github_login: 'alice', created: '2026-01-01T00:00:00.000Z',
+    }));
+    const tok = await issue(worker, env, 'alice');
+    assert(tok.account_id === 'acct_legacyalice', `expected migrated account_id, got ${tok.account_id}`);
+    const rec = JSON.parse(await env.META.get('hosted-account:alice'));
+    assert(rec.account_id === 'acct_legacyalice', 'must copy the leftover record onto hosted-account');
   });
 
   await t('duplicate refuses island-bearing docs', async () => {

--- a/test/hosted-oob.test.js
+++ b/test/hosted-oob.test.js
@@ -39,17 +39,22 @@ const authorizeSrc = worker.slice(authorizeStart, authorizeEnd);
 console.log('hosted out-of-box publish');
 
 t('Worker exposes provider-gated hosted token bootstrap', () => {
-  assert(hostedRoute.includes('hostedRegistrationEnabled(env)'), 'hosted route must be registration-gated');
-  assert(hostedRoute.includes('issueHostedToken(env, body)'), 'hosted route must mint a token server-side');
+  assert(hostedRoute.includes('hostedRegistrationEnabled(env, url.origin)'), 'hosted route must be registration-gated');
+  assert(hostedRoute.includes('issueHostedToken(env,'), 'hosted route must mint a token server-side');
   assert(hostedRoute.includes("hosted_registration_disabled"), 'hosted route must return disabled registration error');
+  assert(hostedRoute.includes("sign_in_required"), 'hosted mint must require a GitHub session');
   assert(hostedRoute.includes('account_id'), 'hosted route must return account_id');
+  assert(hostedRoute.includes('github_login'), 'hosted route must return github_login');
 });
 
-t('tdoc.dev must not enable hosted registration', () => {
-  assert(!/TDOC_HOSTED_REGISTRATION\s*=\s*"?1"?/.test(wranglerTpl),
-    'wrangler template must not set TDOC_HOSTED_REGISTRATION=1');
+t('tdoc.dev opens hosted registration by hostname; BYOK template does not', () => {
+  const uncommented = wranglerTpl.split('\n').filter(l => !l.trim().startsWith('#')).join('\n');
+  assert(!/TDOC_HOSTED_REGISTRATION\s*=\s*"?1"?/.test(uncommented),
+    'wrangler template must not set TDOC_HOSTED_REGISTRATION=1 (BYOK stays single-owner /me)');
   assert(!/TDOC_HOSTED_REGISTRATION\s*=\s*"?1"?/.test(deployWf),
-    'tdoc.dev CD must not set TDOC_HOSTED_REGISTRATION=1');
+    'tdoc.dev CD must not set TDOC_HOSTED_REGISTRATION=1 (hostname opens it)');
+  assert(worker.includes("origin === 'https://tdoc.dev'"),
+    'unset registration must enable on the tdoc.dev origin');
 });
 
 t('Hosted tokens are stored hashed, not in cleartext', () => {
@@ -65,7 +70,7 @@ t('Upload auth accepts either provider admin token or hosted account token', () 
 });
 
 t('Combined owner-mutation gate is session OR admin token OR (hosted token + slug ACL)', () => {
-  assert(authorizeSrc.includes('isOwnerSession(env, session)'), 'session path missing');
+  assert(authorizeSrc.includes('isDocOwnerSession(env, session, meta)'), 'session path missing');
   assert(authorizeSrc.includes('requireUploadAuth(req, env)'), 'token fallback missing');
   assert(authorizeSrc.includes("auth.actor.kind === 'admin'"), 'admin token must skip slug ACL');
   assert(authorizeSrc.includes('requireDocWriteAccess(env, auth.actor, slug)'),
@@ -75,6 +80,8 @@ t('Combined owner-mutation gate is session OR admin token OR (hosted token + slu
 t('Hosted upload stamps remote meta ownership before writing', () => {
   assert(uploadRoute.includes('requireDocWriteAccess(env, auth.actor, slug, { create: true })'), 'upload must enforce create/claim write access');
   assert(uploadRoute.includes('stampHostedOwnership(incoming, auth.actor)'), 'upload must stamp hosted owner');
+  assert(uploadRoute.includes('quota_docs'), 'hosted create must enforce a per-account doc quota');
+  assert(uploadRoute.includes('quota_upload_bytes'), 'hosted upload must cap payload bytes');
   const gate = uploadRoute.indexOf('requireDocWriteAccess(env, auth.actor, slug, { create: true })');
   const validate = uploadRoute.indexOf('validateAccessWrite');
   const claim = uploadRoute.indexOf("kind: 'claim_owner'");

--- a/test/hosted-oob.test.js
+++ b/test/hosted-oob.test.js
@@ -47,6 +47,21 @@ t('Worker exposes provider-gated hosted token bootstrap', () => {
   assert(hostedRoute.includes('github_login'), 'hosted route must return github_login');
 });
 
+t('CLI mint and Duplicate share one hosted-account registry', () => {
+  const acctStart = worker.indexOf('async function hostedAccountForGithub');
+  const acct = worker.slice(acctStart, worker.indexOf('async function sourceHasWidgets'));
+  const issue = worker.slice(
+    worker.indexOf('async function issueHostedToken'),
+    worker.indexOf('async function hostedTokenActor'),
+  );
+  assert(acct.includes('hosted-account:'), 'canonical account key is hosted-account:<login>');
+  assert(acct.includes('hosted-github:'), 'must still read leftover hosted-github records');
+  assert(!acct.includes("source: 'duplicate'"), 'must not mint a second registry just for Duplicate');
+  assert(issue.includes('hostedAccountForGithub(env, github_login)'),
+    'token mint must reuse hostedAccountForGithub');
+  assert(!issue.includes('hosted-github:'), 'token mint must not write a second registry');
+});
+
 t('tdoc.dev opens hosted registration by hostname; BYOK template does not', () => {
   const uncommented = wranglerTpl.split('\n').filter(l => !l.trim().startsWith('#')).join('\n');
   assert(!/TDOC_HOSTED_REGISTRATION\s*=\s*"?1"?/.test(uncommented),

--- a/test/hosted-oob.test.js
+++ b/test/hosted-oob.test.js
@@ -82,6 +82,8 @@ t('Hosted upload stamps remote meta ownership before writing', () => {
   assert(uploadRoute.includes('stampHostedOwnership(incoming, auth.actor)'), 'upload must stamp hosted owner');
   assert(uploadRoute.includes('quota_docs'), 'hosted create must enforce a per-account doc quota');
   assert(uploadRoute.includes('quota_upload_bytes'), 'hosted upload must cap payload bytes');
+  assert(uploadRoute.includes('utf8ByteLength(doc)'), 'upload quota must count UTF-8 bytes');
+  assert(!uploadRoute.includes('doc.length > maxBytes'), 'upload quota must not use JS string length');
   const gate = uploadRoute.indexOf('requireDocWriteAccess(env, auth.actor, slug, { create: true })');
   const validate = uploadRoute.indexOf('validateAccessWrite');
   const claim = uploadRoute.indexOf("kind: 'claim_owner'");

--- a/test/jul36-owner-manage.test.js
+++ b/test/jul36-owner-manage.test.js
@@ -48,8 +48,8 @@ if (docViewStart < 0 || docViewEnd < 0) throw new Error('serveDocVersion block m
 const docViewRoute = worker.slice(docViewStart, docViewEnd);
 
 t('doc-view route computes isOwner server-side from the session, not the client', () => {
-  assert(docViewRoute.includes('const isOwner = isOwnerSession(env, session);'),
-    'isOwner must be derived from isOwnerSession(env, session) on THIS request');
+  assert(docViewRoute.includes('const isOwner = isDocOwnerSession(env, session, gate.meta);'),
+    'isOwner must be derived from isDocOwnerSession(env, session, meta) on THIS request');
 });
 
 t('doc-view route only builds ownerManage data inside an isOwner guard', () => {
@@ -133,11 +133,17 @@ const getSessionStart = worker.indexOf('async function getSession(env, req) {');
 const getSessionEnd = worker.indexOf('\n}', getSessionStart) + 2;
 const isOwnerSessionStart = worker.indexOf('function isOwnerSession(env, session) {');
 const isOwnerSessionEnd = worker.indexOf('\n}', isOwnerSessionStart) + 2;
+const sessionLoginStart = worker.indexOf('function sessionLogin(session) {');
+const isDocOwnerStart = worker.indexOf('function isDocOwnerSession(env, session, meta) {');
+const isDocOwnerEnd = worker.indexOf('\n}', isDocOwnerStart) + 2;
+const loadDocMetaStart = worker.indexOf('async function loadDocMeta(env, slug) {');
+const loadDocMetaEnd = worker.indexOf('\n}', loadDocMetaStart) + 2;
 const hostedHelpersStart = worker.indexOf('async function sha256Hex(s) {');
 const authorizeStart = worker.indexOf('async function authorizeOwnerMutation(req, env, slug) {');
 const hostedHelpersEnd = worker.indexOf('// #34 — Per-slug write serialization', hostedHelpersStart);
 if (uploadAuthStart < 0 || timingEqualStart < 0 || parseCookieStart < 0 || getSessionStart < 0
-  || isOwnerSessionStart < 0 || authorizeStart < 0 || hostedHelpersStart < 0 || hostedHelpersEnd < 0) {
+  || isOwnerSessionStart < 0 || sessionLoginStart < 0 || isDocOwnerStart < 0 || loadDocMetaStart < 0
+  || authorizeStart < 0 || hostedHelpersStart < 0 || hostedHelpersEnd < 0) {
   throw new Error('auth helpers not found');
 }
 const authSrc = [
@@ -145,6 +151,8 @@ const authSrc = [
   worker.slice(parseCookieStart, parseCookieEnd),
   worker.slice(getSessionStart, getSessionEnd),
   worker.slice(isOwnerSessionStart, isOwnerSessionEnd),
+  worker.slice(sessionLoginStart, isDocOwnerEnd),
+  worker.slice(loadDocMetaStart, loadDocMetaEnd),
   worker.slice(hostedHelpersStart, hostedHelpersEnd),
 ].join('\n');
 
@@ -165,13 +173,13 @@ t('DELETE /api/doc and PATCH /api/doc/access both go through the shared authoriz
   assert(!worker.includes('isSameOriginRequest'), 'same-origin is not sufficient — docs are arbitrary same-origin HTML');
 });
 
-t('authorizeOwnerMutation gate itself calls isOwnerSession, then falls back to requireUploadAuth', () => {
+t('authorizeOwnerMutation gate itself calls isDocOwnerSession, then falls back to requireUploadAuth', () => {
   const fnSrc = worker.slice(authorizeStart, hostedHelpersEnd);
-  const ownerCheck = fnSrc.indexOf('isOwnerSession(env, session)');
+  const ownerCheck = fnSrc.indexOf('isDocOwnerSession(env, session, meta)');
   const tokenCheck = fnSrc.indexOf('requireUploadAuth(req, env)');
-  assert(ownerCheck >= 0, 'must check isOwnerSession');
+  assert(ownerCheck >= 0, 'must check isDocOwnerSession');
   assert(tokenCheck >= 0, 'must fall back to requireUploadAuth');
-  assert(ownerCheck < tokenCheck, 'owner-session check must come before the token fallback');
+  assert(ownerCheck < tokenCheck, 'doc-owner session check must come before the token fallback');
   assert(fnSrc.includes('requireDocWriteAccess(env, auth.actor, slug)'),
     'hosted tokens must be slug-scoped inside the shared gate, not treated as global owners');
 });
@@ -284,7 +292,7 @@ async function main() {
   }
 
   t('worker /me page no longer uses window.confirm() for delete', () => {
-    const idxStart = worker.indexOf('async function indexHtml(env, session)');
+    const idxStart = worker.indexOf('async function indexHtml(env, session');
     const idxEnd = worker.indexOf('// ─────────────────────────────────────────────────────────────────────────', idxStart);
     const indexHtmlSrc = worker.slice(idxStart, idxEnd);
     assert(!nativeConfirmCall.test(stripLineComments(indexHtmlSrc)), '/me must not call the native confirm()');

--- a/test/me-management.test.js
+++ b/test/me-management.test.js
@@ -7,8 +7,8 @@
 // controls moved to the doc-page Share panel (overlay.js showManageModal,
 // see jul36-owner-manage.test.js), and Delete now authorizes off the owner's
 // session cookie instead of a pasted token (safe only because of the CSP on
-// every doc response — see csp.test.js). /me is reachable only by the
-// signed-in owner (route-level isOwnerSession redirect), so its own
+// every doc response — see csp.test.js). /me is gated by canSeeMyDocs
+// (hosted: any signed-in GitHub user; BYOK: TDOC_OWNER), so its own
 // same-origin fetches are already cookied.
 //
 // Gate (小cc review #2): the /me HTML response must not contain access data
@@ -25,6 +25,7 @@ function t(n, fn) { try { fn(); ok(n); } catch (e) { bad(n, e.message); } }
 function assert(c, m) { if (!c) throw new Error(m || 'assertion failed'); }
 
 const worker = fs.readFileSync(path.join(__dirname, '..', 'worker', 'worker.js'), 'utf8');
+const overlay = fs.readFileSync(path.join(__dirname, '..', 'server', 'overlay.js'), 'utf8');
 const start = worker.indexOf('async function indexHtml(env, session');
 const end = worker.indexOf('// ─────────────────────────────────────────────────────────────────────────', start);
 if (start < 0 || end < 0 || end <= start) throw new Error('indexHtml block missing');
@@ -139,6 +140,12 @@ t('/me non-owner bounce goes to landing with notice, not github.com', () => {
   const meRoute = worker.slice(meStart, meEnd);
   assert(meRoute.includes('canSeeMyDocs(env, s, url.origin)'),
     '/me must gate on canSeeMyDocs (hosted per-user or BYOK TDOC_OWNER)');
+  assert(!worker.includes('isOwnerSession gate in the'),
+    '/me must not document the retired owner-only gate');
+  assert(!overlay.includes('cfg.canSeeMyDocs || cfg.isOwner'),
+    'My docs must not fall back to this-doc isOwner');
+  assert(!overlay.includes('else if (me && me.isOwner) canSeeMyDocs'),
+    'device-flow must not treat isOwner as canSeeMyDocs');
   assert(meRoute.includes("Location: `/?notice=${notice}`") || meRoute.includes("Location: '/?notice="),
     '/me must redirect to landing ?notice=…');
   assert(!meRoute.includes('github.com/tornado-doc/tdoc'),

--- a/test/me-management.test.js
+++ b/test/me-management.test.js
@@ -146,6 +146,8 @@ t('/me non-owner bounce goes to landing with notice, not github.com', () => {
     'My docs must not fall back to this-doc isOwner');
   assert(!overlay.includes('else if (me && me.isOwner) canSeeMyDocs'),
     'device-flow must not treat isOwner as canSeeMyDocs');
+  assert(!overlay.includes("typeof me.isOwner === 'boolean') isOwner"),
+    'device-flow must not clobber per-doc isOwner from /api/auth/me');
   assert(meRoute.includes("Location: `/?notice=${notice}`") || meRoute.includes("Location: '/?notice="),
     '/me must redirect to landing ?notice=…');
   assert(!meRoute.includes('github.com/tornado-doc/tdoc'),

--- a/test/me-management.test.js
+++ b/test/me-management.test.js
@@ -25,7 +25,7 @@ function t(n, fn) { try { fn(); ok(n); } catch (e) { bad(n, e.message); } }
 function assert(c, m) { if (!c) throw new Error(m || 'assertion failed'); }
 
 const worker = fs.readFileSync(path.join(__dirname, '..', 'worker', 'worker.js'), 'utf8');
-const start = worker.indexOf('async function indexHtml(env, session)');
+const start = worker.indexOf('async function indexHtml(env, session');
 const end = worker.indexOf('// ─────────────────────────────────────────────────────────────────────────', start);
 if (start < 0 || end < 0 || end <= start) throw new Error('indexHtml block missing');
 const index = worker.slice(start, end);
@@ -137,6 +137,8 @@ t('/me non-owner bounce goes to landing with notice, not github.com', () => {
   const meEnd = worker.indexOf('// ---- doc view ----', meStart);
   assert(meStart >= 0 && meEnd > meStart, '/me route block missing');
   const meRoute = worker.slice(meStart, meEnd);
+  assert(meRoute.includes('canSeeMyDocs(env, s, url.origin)'),
+    '/me must gate on canSeeMyDocs (hosted per-user or BYOK TDOC_OWNER)');
   assert(meRoute.includes("Location: `/?notice=${notice}`") || meRoute.includes("Location: '/?notice="),
     '/me must redirect to landing ?notice=…');
   assert(!meRoute.includes('github.com/tornado-doc/tdoc'),

--- a/test/security.test.js
+++ b/test/security.test.js
@@ -40,7 +40,11 @@ const box = { URL }; // isLocalMutation uses the URL global
 vm.createContext(box);
 vm.runInContext([
   sliceFn(workerSrc, 'forHtmlComment'),
+  sliceFn(workerSrc, 'sessionLogin'),
+  sliceFn(workerSrc, 'normalizeGithubLogin'),
+  sliceFn(workerSrc, 'hostedGithubLogin'),
   sliceFn(workerSrc, 'isOwnerSession'),
+  sliceFn(workerSrc, 'isDocOwnerSession'),
   sliceFn(workerSrc, 'canMutate'),
   sliceFn(serverSrc, 'safeSlug'),
   sliceFn(serverSrc, 'isLocalMutation'),
@@ -76,9 +80,15 @@ t('canMutate DENIES a stranger on someone else’s record', () => {
 t('canMutate ALLOWS the author of the record', () => {
   assert(box.canMutate({ author: { login: 'alice' } }, { login: 'alice' }, ENV) === true);
 });
-t('canMutate ALLOWS the doc owner regardless of author', () => {
+t('canMutate ALLOWS the unhosted worker owner regardless of author', () => {
   assert(box.canMutate({ author: { login: 'alice' } }, { login: 'owner' }, ENV) === true);
   assert(box.canMutate({ author: null }, { login: 'owner' }, ENV) === true, 'owner can clean up legacy null-author records');
+});
+t('canMutate ALLOWS the hosted publisher, not TDOC_OWNER, on a hosted doc', () => {
+  const meta = { hosted: { github_login: 'alice' } };
+  assert(box.canMutate({ author: { login: 'bob' } }, { login: 'alice' }, ENV, meta) === true);
+  assert(box.canMutate({ author: { login: 'bob' } }, { login: 'owner' }, ENV, meta) === false,
+    'operator must not moderate comments on another tenant\'s hosted doc');
 });
 t('canMutate DENIES when session is null/anonymous', () => {
   assert(box.canMutate({ author: { login: 'alice' } }, null, ENV) === false);

--- a/worker/worker.js
+++ b/worker/worker.js
@@ -73,10 +73,11 @@ async function getSession(env, req) {
     return { id: sid, ...data };
   } catch { return null; }
 }
-// The worker owner = the GitHub login configured in TDOC_OWNER at deploy.
-// Only that signed-in viewer may see the catalog of hosted docs. Case-
-// insensitive; if TDOC_OWNER is unset, nobody is owner (catalog stays
-// fully private — safe default).
+// The worker operator = the GitHub login configured in TDOC_OWNER at deploy.
+// On BYOK (hosted registration off) only that signed-in viewer sees /me.
+// On hosted tdoc.dev, /me is per signed-in GitHub user; TDOC_OWNER still
+// owns legacy docs with no hosted.github_login. Case-insensitive; if
+// TDOC_OWNER is unset, nobody is operator.
 function isOwnerSession(env, session) {
   const owner = (env.TDOC_OWNER || '').trim().toLowerCase();
   if (!owner || !session || !session.login) return false;
@@ -127,6 +128,23 @@ function normalizeGithubLogin(v) {
   // GitHub logins: alphanumeric + hyphen
   if (!/^[a-z0-9](?:[a-z0-9-]{0,37}[a-z0-9])?$/.test(s)) return null;
   return s;
+}
+
+// Publisher GitHub login stamped on hosted-tenant meta. Empty on BYOK / legacy
+// docs — those still belong to TDOC_OWNER.
+function hostedGithubLogin(meta) {
+  return meta && meta.hosted ? normalizeGithubLogin(meta.hosted.github_login) : null;
+}
+
+// True when this session owns this document:
+//   - hosted: meta.hosted.github_login matches the session
+//   - unhosted / legacy: the Worker operator (TDOC_OWNER)
+function isDocOwnerSession(env, session, meta) {
+  const login = sessionLogin(session);
+  if (!login) return false;
+  const hostedLogin = hostedGithubLogin(meta);
+  if (hostedLogin) return hostedLogin === login;
+  return isOwnerSession(env, session);
 }
 
 // Normalize meta.access. `legacy` chooses defaults when the field is absent:
@@ -227,31 +245,31 @@ function applyAccessPatch(meta, patch) {
   return { meta: { ...meta, access: next }, access: next };
 }
 
-function isAllowlisted(access, session, env) {
-  if (isOwnerSession(env, session)) return true;
+function isAllowlisted(access, session, env, meta) {
+  if (isDocOwnerSession(env, session, meta)) return true;
   const login = sessionLogin(session);
   if (!login) return false;
   return (access.allowed_users || []).includes(login);
 }
 
-function canReadDoc(access, session, env) {
+function canReadDoc(access, session, env, meta) {
   if (access.visibility === 'public' || access.visibility === 'unlisted') return true;
-  return isAllowlisted(access, session, env);
+  return isAllowlisted(access, session, env, meta);
 }
 
-function canSeeHistory(access, session, env) {
+function canSeeHistory(access, session, env, meta) {
   if (access.history_visibility === 'public') return true;
-  if (access.history_visibility === 'invited') return isAllowlisted(access, session, env);
-  // owner — TDOC_OWNER only (not every allowlisted reviewer)
-  return isOwnerSession(env, session);
+  if (access.history_visibility === 'invited') return isAllowlisted(access, session, env, meta);
+  // owner — the doc publisher (hosted GitHub login) or TDOC_OWNER on legacy docs
+  return isDocOwnerSession(env, session, meta);
 }
 
-function canCommentOnDoc(access, session, env) {
+function canCommentOnDoc(access, session, env, meta) {
   if (access.commenting === 'off') return false;
   if (!sessionLogin(session)) return false;
   if (access.commenting === 'signed_in') return true;
-  if (access.commenting === 'owner') return isOwnerSession(env, session);
-  if (access.commenting === 'invited') return isAllowlisted(access, session, env);
+  if (access.commenting === 'owner') return isDocOwnerSession(env, session, meta);
+  if (access.commenting === 'invited') return isAllowlisted(access, session, env, meta);
   return false;
 }
 
@@ -292,7 +310,7 @@ async function enforceDocAccess(env, req, slug, version) {
   // No meta yet (orphan R2 object) — treat as public so legacy uploads still work.
   const access = accessFromMeta(meta || {});
   const session = await getSession(env, req);
-  if (canReadDoc(access, session, env)) {
+  if (canReadDoc(access, session, env, meta)) {
     return { ok: true, access, session, meta };
   }
   if (!sessionLogin(session)) {
@@ -996,11 +1014,13 @@ function injectOverlayCfg(rawHtml, cfg, nonce) {
   return rawHtml + inject;
 }
 
-function injectOverlay(rawHtml, slug, version, identity, versions, isOwner, ownerManage, nonce, isLanding) {
+function injectOverlay(rawHtml, slug, version, identity, versions, isOwner, ownerManage, nonce, isLanding, canSeeMyDocsFlag) {
   return injectOverlayCfg(rawHtml, {
     slug, version,
     identity: identity || null,
     isOwner: !!isOwner,
+    // Hosted tdoc.dev: any signed-in GitHub user. BYOK: TDOC_OWNER only.
+    canSeeMyDocs: canSeeMyDocsFlag != null ? !!canSeeMyDocsFlag : !!isOwner,
     // `/` is the site itself, not a doc someone published. The slug and the
     // version number are storage detail; printing them in the bar tells a
     // first-time visitor they are looking at somebody's document.
@@ -1039,14 +1059,14 @@ async function serveDocVersion(env, req, slug, version, isLanding) {
   let versions = [{ n: version, created: null }];
   try {
     const meta = gate.meta;
-    if (meta && Array.isArray(meta.versions) && canSeeHistory(gate.access, session, env)) {
+    if (meta && Array.isArray(meta.versions) && canSeeHistory(gate.access, session, env, meta)) {
       versions = meta.versions.map(v => ({ n: v.n, created: v.created || null }));
     } else if (meta && Array.isArray(meta.versions)) {
       const hit = meta.versions.find(v => Number(v.n) === version);
       versions = [{ n: version, created: (hit && hit.created) || null }];
     }
   } catch {}
-  const isOwner = isOwnerSession(env, session);
+  const isOwner = isDocOwnerSession(env, session, gate.meta);
   // JUL-36: owner-only manage data (Delete / Unpublish / visibility switch),
   // computed fresh on THIS request and embedded only for the owner. A
   // non-owner's bootCfg carries `ownerManage: null` — the overlay's manage
@@ -1068,7 +1088,7 @@ async function serveDocVersion(env, req, slug, version, isLanding) {
   const nonce = rand(16);
   return {
     ok: true,
-    response: html(injectOverlay(raw, slug, version, identity, versions, isOwner, ownerManage, nonce, isLanding), {
+    response: html(injectOverlay(raw, slug, version, identity, versions, isOwner, ownerManage, nonce, isLanding, canSeeMyDocs(env, session, requestOrigin(req))), {
       headers: { 'Content-Security-Policy': cspHeader(nonce) },
     }),
   };
@@ -1253,7 +1273,7 @@ function authDoneHtml() {
 // a quiet ⋯ Delete. No access data of any kind is computed or emitted here
 // (gate: response HTML must not contain `allowed_users` — there is nothing
 // here that could).
-async function indexHtml(env, session) {
+async function indexHtml(env, session, origin) {
   // Catalog is title/slug/version from KV meta only. Do NOT HEAD R2 or fold
   // comment logs here — that was N serial Durable-Object + R2 round trips
   // per page load. Search + batch select are client-side over the rendered
@@ -1268,14 +1288,18 @@ async function indexHtml(env, session) {
     if (r.list_complete) break;
   } while (cursor);
 
-  const docs = await Promise.all(list.map(async (k) => {
+  const hosted = hostedRegistrationEnabled(env, origin);
+  const docs = (await Promise.all(list.map(async (k) => {
     const slug = k.name.slice('meta:'.length);
     const metaRaw = await env.META.get(k.name);
     let meta = {};
     try { meta = JSON.parse(metaRaw || '{}'); } catch {}
     const latest = meta.versions?.[meta.versions.length - 1]?.n || 1;
-    return { slug, title: meta.title || slug, latest };
-  }));
+    return { slug, title: meta.title || slug, latest, meta };
+  }))).filter((row) => {
+    if (!hosted) return true;
+    return isDocOwnerSession(env, session, row.meta);
+  });
 
   const rows = docs.map(({ slug, title, latest }) => `<div class="doc-row" data-slug="${escapeHtml(slug)}" data-title="${escapeHtml(title)}">
       <label class="row-check">
@@ -2058,16 +2082,88 @@ async function sha256Hex(s) {
   return [...new Uint8Array(buf)].map(b => b.toString(16).padStart(2, '0')).join('');
 }
 
-function hostedRegistrationEnabled(env) {
-  const v = String(env.TDOC_HOSTED_REGISTRATION || env.TDOC_HOSTED_SIGNUP || '').toLowerCase();
-  return v === '1' || v === 'true' || v === 'yes';
+function requestOrigin(reqOrUrl) {
+  if (typeof reqOrUrl === 'string') {
+    try { return new URL(reqOrUrl).origin; } catch { return ''; }
+  }
+  if (reqOrUrl && reqOrUrl.url) {
+    try { return new URL(reqOrUrl.url).origin; } catch { return ''; }
+  }
+  return '';
+}
+
+// Explicit 1/true/yes: on (wrangler dev). Explicit 0/false/no: off.
+// Unset: only the hosted product hostname (tdoc.dev) — BYOK stays single-owner.
+function hostedRegistrationEnabled(env, origin) {
+  const v = String((env && (env.TDOC_HOSTED_REGISTRATION || env.TDOC_HOSTED_SIGNUP)) || '').toLowerCase();
+  if (v === '1' || v === 'true' || v === 'yes') return true;
+  if (v === '0' || v === 'false' || v === 'no') return false;
+  return origin === 'https://tdoc.dev';
+}
+
+function canSeeMyDocs(env, session, origin) {
+  if (!sessionLogin(session)) return false;
+  if (hostedRegistrationEnabled(env, origin)) return true;
+  return isOwnerSession(env, session);
+}
+
+function hostedMaxDocs(env) {
+  const n = Number(env && env.TDOC_HOSTED_MAX_DOCS);
+  return Number.isFinite(n) && n > 0 ? Math.floor(n) : 50;
+}
+
+function hostedMaxUploadBytes(env) {
+  const n = Number(env && env.TDOC_HOSTED_MAX_UPLOAD_BYTES);
+  return Number.isFinite(n) && n > 0 ? Math.floor(n) : 2 * 1024 * 1024;
+}
+
+async function countHostedDocs(env, accountId) {
+  if (!accountId || !env.META) return 0;
+  let n = 0;
+  let cursor;
+  do {
+    const r = await env.META.list({ prefix: 'meta:', cursor });
+    for (const k of r.keys || []) {
+      let meta = null;
+      try {
+        const raw = await env.META.get(k.name);
+        if (raw) meta = JSON.parse(raw);
+      } catch {}
+      if (meta && meta.hosted && meta.hosted.account_id === accountId) n++;
+    }
+    cursor = r.cursor;
+    if (r.list_complete) break;
+  } while (cursor);
+  return n;
 }
 
 async function issueHostedToken(env, body = {}) {
+  const github_login = normalizeGithubLogin(body.login);
+  if (!github_login) {
+    return { error: 'sign_in_required', status: 401 };
+  }
+  const accountKey = `hosted-account:${github_login}`;
+  let account = null;
+  try {
+    const raw = await env.META.get(accountKey);
+    if (raw) account = JSON.parse(raw);
+  } catch {}
+  const account_id = (account && typeof account.account_id === 'string' && account.account_id)
+    ? account.account_id
+    : `acct_${rand(12)}`;
+  if (!account || account.account_id !== account_id) {
+    account = {
+      account_id,
+      github_login,
+      created: (account && account.created) || new Date().toISOString(),
+    };
+    await env.META.put(accountKey, JSON.stringify(account));
+  }
   const token = `tdoc_${rand(24)}`;
   const tokenHash = await sha256Hex(token);
   const record = {
-    account_id: `acct_${rand(12)}`,
+    account_id,
+    github_login,
     created: new Date().toISOString(),
   };
   if (typeof body.label === 'string' && body.label.trim()) {
@@ -2086,7 +2182,8 @@ async function hostedTokenActor(env, token) {
     if (raw) record = JSON.parse(raw);
   } catch {}
   if (!record || typeof record.account_id !== 'string' || !record.account_id) return null;
-  return { kind: 'hosted', account_id: record.account_id, token_hash: tokenHash };
+  const github_login = normalizeGithubLogin(record.github_login);
+  return { kind: 'hosted', account_id: record.account_id, token_hash: tokenHash, github_login };
 }
 
 async function hostedOwnerOp(env, slug, op) {
@@ -2194,18 +2291,21 @@ async function requireDocWriteAccess(env, actor, slug, opts = {}) {
 
 function stampHostedOwnership(meta, actor) {
   if (!actor || actor.kind !== 'hosted') return meta;
+  const hosted = {
+    ...((meta && meta.hosted && typeof meta.hosted === 'object') ? meta.hosted : {}),
+    account_id: actor.account_id,
+  };
+  if (actor.github_login) hosted.github_login = actor.github_login;
   return {
     ...(meta || {}),
-    hosted: {
-      ...((meta && meta.hosted && typeof meta.hosted === 'object') ? meta.hosted : {}),
-      account_id: actor.account_id,
-    },
+    hosted,
   };
 }
 
 // Combined write gate for browser-facing admin routes (DELETE /api/doc,
 // PATCH /api/doc/access). One of:
-//   - signed in as TDOC_OWNER (session cookie; CSP makes this safe);
+//   - signed in as the doc publisher (hosted.github_login, or TDOC_OWNER on
+//     unhosted/legacy docs; CSP makes the cookie path safe);
 //   - provider-wide upload token (self-host CLI, global admin);
 //   - hosted account token AND requireDocWriteAccess for `slug`.
 //
@@ -2214,10 +2314,11 @@ function stampHostedOwnership(meta, actor) {
 // session, meta? } or { ok: false, response }.
 async function authorizeOwnerMutation(req, env, slug) {
   const session = await getSession(env, req);
-  if (isOwnerSession(env, session)) return { ok: true, session, actor: { kind: 'owner_session' } };
+  const meta = slug ? await loadDocMeta(env, slug) : null;
+  if (isDocOwnerSession(env, session, meta)) return { ok: true, session, actor: { kind: 'owner_session' }, meta };
   const auth = await requireUploadAuth(req, env);
   if (!auth.ok) return { ok: false, response: auth.response };
-  if (auth.actor.kind === 'admin') return { ok: true, session: null, actor: auth.actor };
+  if (auth.actor.kind === 'admin') return { ok: true, session: null, actor: auth.actor, meta };
   if (!slug) return { ok: false, response: json({ error: 'slug required' }, { status: 400 }) };
   const writeGate = await requireDocWriteAccess(env, auth.actor, slug);
   if (!writeGate.ok) return writeGate;
@@ -2747,20 +2848,22 @@ export default {
       return html(authDoneHtml());
     }
 
-    // ---- owner-only doc catalog ----
-    // `/me` returns the list of every doc hosted on THIS worker, but only
-    // to the configured owner (TDOC_OWNER) when signed in. Everyone else
-    // is sent to the landing page (with a toast) — never to github.com.
+    // ---- owner catalog ----
+    // BYOK (registration off): `/me` lists every doc on THIS worker, but only
+    // for TDOC_OWNER. Hosted tdoc.dev (registration on): any signed-in GitHub
+    // user sees *their* slugs (meta.hosted.github_login). Everyone else is
+    // sent to the landing page (with a toast) — never to github.com, and
+    // never a public catalog.
     if (p === '/me' && method === 'GET') {
       const s = await getSession(env, req);
-      if (!isOwnerSession(env, s)) {
+      if (!canSeeMyDocs(env, s, url.origin)) {
         const notice = sessionLogin(s) ? 'me' : 'signin';
         return new Response(null, {
           status: 302,
           headers: { Location: `/?notice=${notice}` },
         });
       }
-      return html(await indexHtml(env, s));
+      return html(await indexHtml(env, s, url.origin));
     }
 
     // ---- interactive island (sandboxed widget) ----
@@ -2925,6 +3028,7 @@ export default {
       return json({
         identity: s ? { login: s.login, avatar_url: s.avatar_url, name: s.name } : null,
         isOwner: isOwnerSession(env, s),
+        canSeeMyDocs: canSeeMyDocs(env, s, url.origin),
         authConfigured: true,
       });
     }
@@ -3051,21 +3155,25 @@ export default {
     // ---- hosted publish token bootstrap ----
     // Hosted/OOB users should not create Cloudflare resources or receive the
     // provider-wide TDOC_UPLOAD_TOKEN. The central Worker mints an account-
-    // scoped upload token, and write routes enforce slug ownership for that
-    // token. Registration is provider-gated by env so tdoc.dev can stay
-    // closed without changing client code. Do not set TDOC_HOSTED_REGISTRATION
-    // on tdoc.dev until signup is intentionally opened.
+    // scoped upload token bound to the caller's GitHub login. Same login
+    // remints the same account_id so a lost ~/.tdoc/published.json is
+    // recoverable. Unset env: on for https://tdoc.dev only; explicit 0 disables.
     if (p === '/api/hosted/token' && method === 'POST') {
-      if (!hostedRegistrationEnabled(env)) {
+      if (!hostedRegistrationEnabled(env, url.origin)) {
         return json({ error: 'hosted_registration_disabled' }, { status: 403 });
       }
+      const session = await getSession(env, req);
+      const login = sessionLogin(session);
+      if (!login) return json({ error: 'sign_in_required' }, { status: 401 });
       let body = {};
       try { body = await req.json(); } catch {}
-      const issued = await issueHostedToken(env, body);
+      const issued = await issueHostedToken(env, { ...body, login });
+      if (issued.error) return json({ error: issued.error }, { status: issued.status || 401 });
       return json({
         ok: true,
         token: issued.token,
         account_id: issued.record.account_id,
+        github_login: issued.record.github_login,
         base: url.origin,
       });
     }
@@ -3100,8 +3208,8 @@ export default {
       {
         const meta = await loadDocMeta(env, slug);
         const access = accessFromMeta(meta || {});
-        if (!canReadDoc(access, s, env)) return json({ error: 'access_denied' }, { status: 403 });
-        if (!canCommentOnDoc(access, s, env)) return json({ error: 'commenting_disabled' }, { status: 403 });
+        if (!canReadDoc(access, s, env, meta)) return json({ error: 'access_denied' }, { status: 403 });
+        if (!canCommentOnDoc(access, s, env, meta)) return json({ error: 'commenting_disabled' }, { status: 403 });
       }
       const author = { login: s.login, avatar_url: s.avatar_url, name: s.name };
       const created = new Date().toISOString();
@@ -3117,7 +3225,7 @@ export default {
         const meta = await loadDocMeta(env, slug);
         const title = (meta && meta.title) || slug;
         if (!parent_id) {
-          await deliverInbox(env, env.TDOC_OWNER, {
+          await deliverInbox(env, hostedGithubLogin(meta) || env.TDOC_OWNER, {
             kind: 'comment', slug, version: V, comment_id: op.id, thread_id: op.id,
             actor: author, preview: commentText, title, at: created,
           });
@@ -3337,6 +3445,19 @@ export default {
       if (!Number.isInteger(verNum) || verNum < 1) return json({ error: 'invalid_version' }, { status: 400 });
       const writeGate = await requireDocWriteAccess(env, auth.actor, slug, { create: true });
       if (!writeGate.ok) return writeGate.response;
+      if (auth.actor && auth.actor.kind === 'hosted') {
+        const maxBytes = hostedMaxUploadBytes(env);
+        if (doc.length > maxBytes) {
+          return json({ error: 'quota_upload_bytes', limit: maxBytes, size: doc.length }, { status: 413 });
+        }
+        if (!writeGate.meta) {
+          const used = await countHostedDocs(env, auth.actor.account_id);
+          const limit = hostedMaxDocs(env);
+          if (used >= limit) {
+            return json({ error: 'quota_docs', limit, used }, { status: 403 });
+          }
+        }
+      }
       // Validate write-side access policy before writing doc bytes. Read paths
       // stay tolerant for legacy/corrupt stored meta; writes must fail closed.
       // Hosted claim happens AFTER this so a 400 cannot park the slug.

--- a/worker/worker.js
+++ b/worker/worker.js
@@ -90,8 +90,8 @@ function isOwnerSession(env, session) {
 // pattern short-circuited to "allow" on null, letting any GitHub session
 // delete/re-anchor authorless legacy comments. Same logic for the three
 // mutation sites, in one place.
-function canMutate(record, session, env) {
-  if (isOwnerSession(env, session)) return true;
+function canMutate(record, session, env, meta) {
+  if (isDocOwnerSession(env, session, meta)) return true;
   const who = record && record.author && record.author.login;
   return !!(who && session && session.login && who === session.login);
 }
@@ -2147,7 +2147,7 @@ function utf8ByteLength(s) {
   return new TextEncoder().encode(String(s || '')).byteLength;
 }
 
-async function countHostedDocs(env, accountId) {
+async function countHostedDocs(env, accountId, stopAt) {
   if (!accountId || !env.META) return 0;
   let n = 0;
   let cursor;
@@ -2159,7 +2159,10 @@ async function countHostedDocs(env, accountId) {
         const raw = await env.META.get(k.name);
         if (raw) meta = JSON.parse(raw);
       } catch {}
-      if (meta && meta.hosted && meta.hosted.account_id === accountId) n++;
+      if (meta && meta.hosted && meta.hosted.account_id === accountId) {
+        n++;
+        if (stopAt && n >= stopAt) return n;
+      }
     }
     cursor = r.cursor;
     if (r.list_complete) break;
@@ -2201,24 +2204,36 @@ function nextDuplicateSlug(sourceSlug, n) {
 }
 
 async function hostedAccountForGithub(env, login) {
-  const norm = String(login || '').trim().toLowerCase();
+  const norm = normalizeGithubLogin(login);
   if (!norm || !env || !env.META) return null;
-  const key = `hosted-github:${norm}`;
+  const primary = `hosted-account:${norm}`;
+  const legacy = `hosted-github:${norm}`;
+  let rec = null;
   try {
-    const raw = await env.META.get(key);
-    if (raw) {
-      const rec = JSON.parse(raw);
-      if (rec && typeof rec.account_id === 'string' && rec.account_id) return rec;
-    }
+    const raw = await env.META.get(primary);
+    if (raw) rec = JSON.parse(raw);
   } catch {}
-  const record = {
-    account_id: `acct_${rand(12)}`,
-    github_login: norm,
-    created: new Date().toISOString(),
-    source: 'duplicate',
-  };
-  await env.META.put(key, JSON.stringify(record));
-  return record;
+  if (!(rec && typeof rec.account_id === 'string' && rec.account_id)) {
+    try {
+      const raw = await env.META.get(legacy);
+      if (raw) rec = JSON.parse(raw);
+    } catch {}
+  }
+  if (!(rec && typeof rec.account_id === 'string' && rec.account_id)) {
+    rec = {
+      account_id: `acct_${rand(12)}`,
+      github_login: norm,
+      created: new Date().toISOString(),
+    };
+  } else {
+    rec = {
+      account_id: rec.account_id,
+      github_login: norm,
+      created: rec.created || new Date().toISOString(),
+    };
+  }
+  await env.META.put(primary, JSON.stringify(rec));
+  return rec;
 }
 
 async function sourceHasWidgets(env, slug, version) {
@@ -2235,27 +2250,12 @@ async function issueHostedToken(env, body = {}) {
   if (!github_login) {
     return { error: 'sign_in_required', status: 401 };
   }
-  const accountKey = `hosted-account:${github_login}`;
-  let account = null;
-  try {
-    const raw = await env.META.get(accountKey);
-    if (raw) account = JSON.parse(raw);
-  } catch {}
-  const account_id = (account && typeof account.account_id === 'string' && account.account_id)
-    ? account.account_id
-    : `acct_${rand(12)}`;
-  if (!account || account.account_id !== account_id) {
-    account = {
-      account_id,
-      github_login,
-      created: (account && account.created) || new Date().toISOString(),
-    };
-    await env.META.put(accountKey, JSON.stringify(account));
-  }
+  const account = await hostedAccountForGithub(env, github_login);
+  if (!account) return { error: 'sign_in_required', status: 401 };
   const token = `tdoc_${rand(24)}`;
   const tokenHash = await sha256Hex(token);
   const record = {
-    account_id,
+    account_id: account.account_id,
     github_login,
     created: new Date().toISOString(),
   };
@@ -3159,7 +3159,19 @@ export default {
       if (!ownerCopy) {
         const acct = await hostedAccountForGithub(env, session.login);
         if (!acct) return json({ error: 'account_copy_unavailable' }, { status: 403 });
-        actor = { kind: 'hosted', account_id: acct.account_id };
+        actor = { kind: 'hosted', account_id: acct.account_id, github_login: acct.github_login };
+      }
+      if (actor.kind === 'hosted') {
+        const maxBytes = hostedMaxUploadBytes(env);
+        const size = utf8ByteLength(rawHtml);
+        if (size > maxBytes) {
+          return json({ error: 'quota_upload_bytes', limit: maxBytes, size }, { status: 413 });
+        }
+        const limit = hostedMaxDocs(env);
+        const used = await countHostedDocs(env, actor.account_id, limit);
+        if (used >= limit) {
+          return json({ error: 'quota_docs', limit, used }, { status: 403 });
+        }
       }
 
       let newSlug = null;
@@ -3203,12 +3215,6 @@ export default {
         access: normalizeAccess({}, { legacy: false }),
       };
       incoming = stampHostedOwnership(incoming, actor);
-      if (actor.kind === 'hosted') {
-        incoming.hosted = {
-          ...(incoming.hosted || {}),
-          github_login: String(session.login).trim().toLowerCase(),
-        };
-      }
 
       const { html: stampedHtml } = stampAids(rawHtml);
       const r2Key = `docs/${newSlug}/v1/index.html`;
@@ -3230,7 +3236,7 @@ export default {
       const s = await getSession(env, req);
       return json({
         identity: s ? { login: s.login, avatar_url: s.avatar_url, name: s.name } : null,
-        isOwner: isOwnerSession(env, s),
+        isOwner: isOwnerSession(env, s), // worker operator; overlay must not clobber per-doc isOwner
         canSeeMyDocs: canSeeMyDocs(env, s, url.origin),
         authConfigured: true,
       });
@@ -3462,7 +3468,8 @@ export default {
       ensureMigrated(authList);
       const target = authList.find(c => c.id === id);
       if (!target) return json({ error: 'not_found' }, { status: 404 });
-      if (!canMutate(target, s, env)) return json({ error: 'not_author' }, { status: 403 });
+      const meta = await loadDocMeta(env, slug);
+      if (!canMutate(target, s, env, meta)) return json({ error: 'not_author' }, { status: 403 });
       const V = coerceBodyVersion(version, target.created_in || 1);
       const res = await mutateComments(env, slug, {
         kind: 'patch_anchor', slug, id, anchor, reset_status: true, version: V, actor: { login: s.login },
@@ -3507,17 +3514,18 @@ export default {
       // is harmless (applyCommentOp returns 404).
       const authList = await readComments(env, slug);
       ensureMigrated(authList);
+      const meta = await loadDocMeta(env, slug);
       let authorized = false;
       const top = authList.find(c => c.id === id);
       if (top) {
-        if (!canMutate(top, s, env)) return json({ error: 'not_author' }, { status: 403 });
+        if (!canMutate(top, s, env, meta)) return json({ error: 'not_author' }, { status: 403 });
         authorized = true;
       } else {
         for (const c of authList) {
           ensureEventLog(c);
           const reply = (c.events || []).find(e => e.kind === 'reply_added' && e.reply && e.reply.id === id);
           if (reply) {
-            if (!canMutate(reply.reply, s, env)) return json({ error: 'not_author' }, { status: 403 });
+            if (!canMutate(reply.reply, s, env, meta)) return json({ error: 'not_author' }, { status: 403 });
             authorized = true;
             break;
           }
@@ -3655,8 +3663,8 @@ export default {
           return json({ error: 'quota_upload_bytes', limit: maxBytes, size }, { status: 413 });
         }
         if (!writeGate.meta) {
-          const used = await countHostedDocs(env, auth.actor.account_id);
           const limit = hostedMaxDocs(env);
+          const used = await countHostedDocs(env, auth.actor.account_id, limit);
           if (used >= limit) {
             return json({ error: 'quota_docs', limit, used }, { status: 403 });
           }

--- a/worker/worker.js
+++ b/worker/worker.js
@@ -1041,7 +1041,8 @@ function injectOverlay(rawHtml, slug, version, identity, versions, isOwner, owne
     identity: identity || null,
     isOwner: !!isOwner,
     // Hosted tdoc.dev: any signed-in GitHub user. BYOK: TDOC_OWNER only.
-    canSeeMyDocs: canSeeMyDocsFlag != null ? !!canSeeMyDocsFlag : !!isOwner,
+    // Never fall back to isOwner — that hid My docs from hosted readers.
+    canSeeMyDocs: !!canSeeMyDocsFlag,
     // `/` is the site itself, not a doc someone published. The slug and the
     // version number are storage detail; printing them in the bar tells a
     // first-time visitor they are looking at somebody's document.
@@ -1287,9 +1288,9 @@ function authDoneHtml() {
 //     the right place to manage that doc, not a spreadsheet of every doc.
 //   - the admin-token field is gone because DELETE /api/doc now accepts the
 //     owner's session cookie (authorizeOwnerMutation) — safe because of the
-//     CSP set on every doc response (see cspHeader()). /me is only reachable
-//     by the signed-in owner in the first place (isOwnerSession gate in the
-//     route above), so its own fetches are already same-origin + cookied.
+//     CSP set on every doc response (see cspHeader()). /me is gated by
+//     canSeeMyDocs (hosted: any signed-in GitHub user; BYOK: TDOC_OWNER),
+//     so its own fetches are already same-origin + cookied.
 // What's left: title, slug, version, search, multi-select batch delete, and
 // a quiet ⋯ Delete. No access data of any kind is computed or emitted here
 // (gate: response HTML must not contain `allowed_users` — there is nothing
@@ -2140,6 +2141,10 @@ function hostedMaxDocs(env) {
 function hostedMaxUploadBytes(env) {
   const n = Number(env && env.TDOC_HOSTED_MAX_UPLOAD_BYTES);
   return Number.isFinite(n) && n > 0 ? Math.floor(n) : 2 * 1024 * 1024;
+}
+
+function utf8ByteLength(s) {
+  return new TextEncoder().encode(String(s || '')).byteLength;
 }
 
 async function countHostedDocs(env, accountId) {
@@ -3645,8 +3650,9 @@ export default {
       if (!writeGate.ok) return writeGate.response;
       if (auth.actor && auth.actor.kind === 'hosted') {
         const maxBytes = hostedMaxUploadBytes(env);
-        if (doc.length > maxBytes) {
-          return json({ error: 'quota_upload_bytes', limit: maxBytes, size: doc.length }, { status: 413 });
+        const size = utf8ByteLength(doc);
+        if (size > maxBytes) {
+          return json({ error: 'quota_upload_bytes', limit: maxBytes, size }, { status: 413 });
         }
         if (!writeGate.meta) {
           const used = await countHostedDocs(env, auth.actor.account_id);

--- a/worker/wrangler.toml.template
+++ b/worker/wrangler.toml.template
@@ -30,11 +30,11 @@ new_sqlite_classes = ["CommentsStore"]
 # test/no-drift.test.js fails if this drifts from the SoT module.
 GITHUB_CLIENT_ID = "Ov23li1jJiBkS23x4O07"
 
-# The worker owner's GitHub login. Only this signed-in viewer sees the
-# "My docs" catalog (profile chip → My docs). Empty = catalog stays fully
-# private (no one can enumerate docs; they're reachable only by direct link).
+# The worker operator's GitHub login. On BYOK (hosted registration unset),
+# only this signed-in viewer sees /me. On tdoc.dev, /me is per signed-in user;
+# TDOC_OWNER still owns legacy docs with no hosted.github_login.
 TDOC_OWNER = "PLACEHOLDER_OWNER"
 
 # Secret: TDOC_UPLOAD_TOKEN — set via `wrangler secret put TDOC_UPLOAD_TOKEN`
-# TDOC_HOSTED_REGISTRATION — leave unset. /api/hosted/token stays closed.
-# Do not set this on tdoc.dev until hosted signup is intentionally opened.
+# TDOC_HOSTED_REGISTRATION — leave unset on BYOK so /me stays single-owner.
+# Unset + hostname https://tdoc.dev enables hosted signup; set to "0" to force off.


### PR DESCRIPTION
## What & why

Fixes #131. Fixes #154. Hosted token mint requires a GitHub session; `/me` lists that user's slugs (`meta.hosted.github_login`), not the Worker operator dump. BYOK `/me` stays single-owner. Signup is on by hostname for `https://tdoc.dev` so CD does not write a workflow env flag.

## Checklist

- [x] `npm test` passes locally (offline suite).
- [ ] If I touched anything browser-facing (`server/overlay.js`, `server/server.js`)
      or the worker (`worker/worker.js`), I ran `npm run test:all` with Playwright
      installed (`npm i -D playwright && npx playwright install chromium`).
- [x] If I edited `SKILL.md`, I copied it to `skills/tdoc/SKILL.md` so the two
      stay in sync (`cp SKILL.md skills/tdoc/SKILL.md`). They must match — the
      plugin-mode install reads the copy.
- [ ] If I changed the version, I bumped `VERSION` **and** `.claude-plugin/plugin.json`
      together (the manifest test enforces this).

## Security note

Hosted mint and `/me` now take untrusted session cookies and upload tokens. Mint is GitHub-session-gated (no anonymous `acct_*`), tokens stay hashed, slug ACL still blocks cross-account overwrite, and `/me` filters by `meta.hosted.github_login` instead of dumping the operator catalog. BYOK with unset registration stays closed except on origin `https://tdoc.dev`. Quota + upload-size caps bound hosted creates.