### PR TITLE
feat: basic top bar on My docs (/me)

### DIFF
--- a/test/me-management.test.js
+++ b/test/me-management.test.js
@@ -125,6 +125,19 @@ t('/me catalog does not fold comment logs or HEAD R2 per row', () => {
   assert(index.includes('Promise.all'), '/me should fetch meta rows in parallel');
 });
 
+t('/me shows the published-doc top bar (identity chip) without loading overlay.js', () => {
+  assert(index.includes('siteChromeCss()'), '/me must include site chrome CSS');
+  assert(index.includes("siteChromeHtml(session, { page: 'me' })"), '/me must render site chrome HTML');
+  assert(index.includes('siteChromeScript()'), '/me must include site chrome script');
+  assert(worker.includes('function siteChromeHtml(session, opts)'), 'siteChromeHtml helper missing');
+  assert(worker.includes('class="tdoc-bar"'), 'chrome must emit .tdoc-bar');
+  assert(worker.includes('id="tdoc-signout"'), 'chrome must offer Sign out');
+  assert(worker.includes("location.href = '/'"), 'mark / sign-out must return to the site home');
+  assert(!index.includes('class="who"'), 'identity belongs in the bar, not a Signed in as line');
+  assert(!index.includes('OVERLAY_JS'), '/me must not inline overlay.js');
+  assert(/padding:\s*80px 20px 48px/.test(index), '/me body must clear the 48px fixed bar');
+});
+
 t('/me does not introduce a bespoke cookie-only admin-auth path', () => {
   // The session path now used everywhere is the SHARED authorizeOwnerMutation
   // gate (session OR token) — not a one-off same-origin/cookie check bolted

--- a/worker/worker.js
+++ b/worker/worker.js
@@ -1280,6 +1280,92 @@ function authDoneHtml() {
 </body></html>`;
 }
 
+// Site chrome for pages that do not load overlay.js (/me catalog). Same
+// visual language as the published-doc top bar: mark on the left, identity
+// chip on the right. No Share / Fork / Copy — those are doc actions.
+function siteChromeCss() {
+  return `
+  .tdoc-bar { position: fixed; top: 0; left: 0; right: 0; height: 48px; background: #fff; color: #1a1a1a; display: flex; align-items: center; padding: 0 12px; font: 13px system-ui, -apple-system, "Segoe UI", Roboto, sans-serif; z-index: 999999; gap: 8px; border-bottom: 1px solid #e5e5e7; box-shadow: 0 1px 2px rgba(0,0,0,0.02); }
+  .tdoc-bar-left { display: flex; align-items: center; gap: 6px; min-width: 0; flex-shrink: 1; }
+  .tdoc-bar-center { flex: 1 1 auto; display: flex; justify-content: center; min-width: 0; padding: 0 8px; }
+  .tdoc-bar-right { display: flex; align-items: center; gap: 4px; flex-shrink: 0; }
+  .tdoc-bar button { background: transparent; border: none; color: #555; padding: 6px 8px; border-radius: 6px; font: inherit; cursor: pointer; transition: background .12s, color .12s; display: inline-flex; align-items: center; gap: 6px; }
+  .tdoc-bar button:hover { background: #f0f1f4; color: #1a1a1a; }
+  .tdoc-bar button.tdoc-bar-mark { height: 28px; padding: 0 12px; border-radius: 999px; background: var(--td-accent); color: #fff; font-weight: 700; font-size: 13px; letter-spacing: -0.01em; flex-shrink: 0; }
+  .tdoc-bar button.tdoc-bar-mark:hover { background: var(--td-accent-hover); color: #fff; }
+  .tdoc-menu-wrap { position: relative; display: inline-block; }
+  .tdoc-menu { display: none; position: absolute; top: calc(100% + 6px); right: 0; background: #fff; border: 1px solid #e5e5e7; border-radius: 8px; padding: 4px; box-shadow: 0 8px 24px rgba(0,0,0,0.12); z-index: 1000000; min-width: 180px; }
+  .tdoc-menu.open { display: block; }
+  .tdoc-menu button { display: block; width: 100%; text-align: left; padding: 7px 10px; border-radius: 4px; color: #1a1a1a; font: 13px system-ui, sans-serif; }
+  .tdoc-menu button:hover { background: #f0f1f4; }
+  .tdoc-chip { display: inline-flex; align-items: center; gap: 8px; padding: 3px 12px 3px 3px; background: #f0f1f4; border-radius: 999px; cursor: pointer; color: #1a1a1a; font: inherit; border: none; position: relative; }
+  .tdoc-bar button.tdoc-chip { background: #f0f1f4; color: #1a1a1a; padding: 3px 12px 3px 3px; }
+  .tdoc-chip:hover, .tdoc-bar button.tdoc-chip:hover { background: #e5e6ea; color: #1a1a1a; }
+  .tdoc-chip img { width: 26px; height: 26px; border-radius: 50%; }
+  .tdoc-chip .name { font-size: 13px; font-weight: 500; }
+  @media (max-width: 900px) {
+    .tdoc-chip .name { display: none; }
+    .tdoc-chip, .tdoc-bar button.tdoc-chip { padding: 3px; }
+  }`;
+}
+
+function siteChromeHtml(session, opts) {
+  const page = (opts && opts.page) || '';
+  const login = session && typeof session.login === 'string' ? session.login : '';
+  if (!login) return '';
+  const rawAvatar = session.avatar_url;
+  const avatar = typeof rawAvatar === 'string' && /^https:\/\/[^ \n\r\t]+$/i.test(rawAvatar)
+    ? rawAvatar
+    : `https://github.com/${encodeURIComponent(login)}.png`;
+  const extra = page === 'me' ? '' : '<button type="button" id="tdoc-my-docs" role="menuitem">My docs</button>';
+  return `<div class="tdoc-bar">
+    <div class="tdoc-bar-left">
+      <button type="button" class="tdoc-bar-mark" id="tdoc-bar-mark" title="tdoc home" aria-label="tdoc home">tdoc</button>
+    </div>
+    <div class="tdoc-bar-center"></div>
+    <div class="tdoc-bar-right">
+      <div class="tdoc-menu-wrap">
+        <button type="button" class="tdoc-chip" id="tdoc-me" aria-haspopup="menu" aria-expanded="false">
+          <img src="${escapeHtml(avatar)}" alt=""><span class="name">${escapeHtml(login)}</span>
+        </button>
+        <div class="tdoc-menu" id="tdoc-me-menu" role="menu">
+          ${extra}
+          <button type="button" id="tdoc-signout" role="menuitem">Sign out</button>
+        </div>
+      </div>
+    </div>
+  </div>`;
+}
+
+function siteChromeScript() {
+  return `<script>
+(function () {
+  var mark = document.getElementById('tdoc-bar-mark');
+  if (mark) mark.addEventListener('click', function () { location.href = '/'; });
+  var btn = document.getElementById('tdoc-me');
+  var menu = document.getElementById('tdoc-me-menu');
+  if (btn && menu) {
+    btn.addEventListener('click', function (e) {
+      e.stopPropagation();
+      var open = menu.classList.toggle('open');
+      btn.setAttribute('aria-expanded', open ? 'true' : 'false');
+    });
+    document.addEventListener('click', function () {
+      menu.classList.remove('open');
+      btn.setAttribute('aria-expanded', 'false');
+    });
+  }
+  var docs = document.getElementById('tdoc-my-docs');
+  if (docs) docs.addEventListener('click', function () { location.href = '/me'; });
+  var out = document.getElementById('tdoc-signout');
+  if (out) out.addEventListener('click', function () {
+    fetch('/api/auth/logout', { method: 'POST', credentials: 'same-origin' })
+      .finally(function () { location.href = '/'; });
+  });
+})();
+</script>`;
+}
+
 // /me — the owner's doc catalog. JUL-36 tail (2026-08-13): this used to be a
 // dense access-control table (visibility/history/commenting/allowed_users
 // dropdowns + Save) gated by an admin-token field. Both are GONE now:
@@ -1350,10 +1436,8 @@ async function indexHtml(env, session, origin) {
     --td-danger: #b42318; --td-danger-hover: #931c14; --td-danger-tint: #fdeceb; --td-ok: #087443;
     --td-ink: #111; --td-muted: #666; --td-line: #eee; --td-surface: #f7f7f7;
   }
-  body { font: 15px system-ui, -apple-system, sans-serif; max-width: 680px; margin: 48px auto; padding: 0 20px; color: var(--td-ink); }
-  h1 { font-size: 28px; margin: 0 0 4px; color: var(--td-accent); }
-  .who { color: var(--td-muted); font-size: 13px; margin: 0 0 20px; }
-  .who b { color: #444; font-weight: 600; }
+  body { font: 15px system-ui, -apple-system, sans-serif; max-width: 680px; margin: 0 auto; padding: 80px 20px 48px; color: var(--td-ink); }
+  h1 { font-size: 28px; margin: 0 0 24px; color: var(--td-accent); }
   a { color: var(--td-accent); text-decoration: none; }
   a:hover { text-decoration: underline; }
   .empty { color: #888; padding: 40px 0; text-align: center; border: 1px dashed var(--td-line); border-radius: 12px; }
@@ -1389,7 +1473,7 @@ async function indexHtml(env, session, origin) {
   /* Styled confirm modal — replaces window.confirm() (JUL-36). Matches the
      doc overlay's .tdoc-modal-bg/.tdoc-modal visual language; kept as a
      standalone copy here since /me does not load overlay.js. */
-  .tdoc-modal-bg { position: fixed; inset: 0; background: rgba(0,0,0,0.55); z-index: 1000; display: flex; align-items: center; justify-content: center; font: 14px system-ui, sans-serif; }
+  .tdoc-modal-bg { position: fixed; inset: 0; background: rgba(0,0,0,0.55); z-index: 1000000; display: flex; align-items: center; justify-content: center; font: 14px system-ui, sans-serif; }
   .tdoc-modal { background: #fff; color: var(--td-ink); border-radius: 12px; padding: 26px; width: 420px; max-width: calc(100vw - 32px); box-shadow: 0 20px 60px rgba(0,0,0,0.3); }
   .tdoc-modal h3 { margin: 0 0 10px; font-size: 18px; }
   .tdoc-modal p { margin: 0 0 14px; color: #444; line-height: 1.5; }
@@ -1397,10 +1481,11 @@ async function indexHtml(env, session, origin) {
   .tdoc-modal button { padding: 8px 16px; border-radius: 6px; border: 1px solid #ccc; background: #fff; }
   .tdoc-modal button.danger { background: var(--td-danger); border-color: var(--td-danger); color: #fff; }
   .tdoc-modal button.danger:hover { background: var(--td-danger-hover); border-color: var(--td-danger-hover); }
+  ${siteChromeCss()}
 </style>
 </head><body>
+${siteChromeHtml(session, { page: 'me' })}
 <h1>My docs</h1>
-<p class="who">${session && session.login ? `Signed in as <b>${escapeHtml(session.login)}</b>` : 'Your published docs'}.</p>
 ${rows.length === 0 ? '<p class="empty">No published docs yet.</p>' :
   `<div class="toolbar">
     <input type="search" id="doc-search" placeholder="Search title or slug…" autocomplete="off" aria-label="Search docs">
@@ -1421,7 +1506,7 @@ ${rows.length === 0 ? '<p class="empty">No published docs yet.</p>' :
     t.className = 'tdoc-toast';
     t.textContent = message;
     t.setAttribute('role', 'status');
-    t.style.cssText = 'position:fixed;top:18px;right:18px;z-index:2000;background:' +
+    t.style.cssText = 'position:fixed;top:62px;right:18px;z-index:1000001;background:' +
       (kind === 'error' ? '#b42318' : '#1652f0') +
       ';color:#fff;padding:12px 16px;border-radius:8px;font:14px system-ui,sans-serif;box-shadow:0 8px 24px rgba(0,0,0,.18)';
     document.body.appendChild(t);
@@ -1625,6 +1710,7 @@ ${rows.length === 0 ? '<p class="empty">No published docs yet.</p>' :
   syncBatchUi();
 })();
 </script>
+${siteChromeScript()}
 </body></html>`;
 }
 


### PR DESCRIPTION
## Summary
- `/me` did not load overlay.js, so My docs had no site chrome after sign-in.
- Add a basic top bar (tdoc mark → home, identity chip → Sign out). No Share / Duplicate / Copy — those stay on document pages.
- Empty-catalog “Create your first doc” is **not** this PR; that is #157.

## Test plan
- [x] `node test/run.js` (offline suite) green
- [ ] Sign in, open `/me`: bar is visible, mark goes home, chip shows login, Sign out works
- [ ] Empty catalog still shows “No published docs yet” (no create CTA yet)
- [ ] A published doc still has Share / Duplicate in its own overlay bar


Made with [Cursor](https://cursor.com)