### PR TITLE
fix: put the overlay bar in flow and slim site chrome

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,18 @@ file and `.claude-plugin/plugin.json`.
 
 ### Changed
 
+- **Overlay top bar sits in document flow** instead of `position: fixed`.
+  Page HTML no longer scrolls underneath a floating strip; the bar (and the
+  old-version strip) occupy the top of the layout.
+- **Site chrome on `/` and `/me` is no longer a document toolbar.** The
+  bar title is gone (those pages already have an h1). `/` keeps the
+  tdoc logo, a GitHub icon, appearance, and sign-in. The mark is the same
+  logo as the favicon, not a text pill.
+- **Doc title sits in the left cluster**, after the logo and version, not
+  in a fake-centered middle slot. Left and right chrome are different
+  widths, so a flex "center" never looked viewport-centered. Google Docs
+  and Notion keep the title on the left.
+
 - **Default `/tdoc publish` target is hosted tdoc.dev** (Cloudflare/Vercel via
   `--platform`). First hosted publish runs GitHub Device Flow, then mints a
   token bound to that login. Closed signup on a host that left registration

--- a/server/overlay.js
+++ b/server/overlay.js
@@ -130,7 +130,7 @@
      artifacts like transcript panes). UI chrome opts out explicitly via
      .tdoc-* selectors below. Media artifacts (img/svg/canvas/video) are
      non-selectable by their nature so they don't need an exception. */
-  body { padding-top: 44px !important; padding-bottom: 24px; -webkit-user-select: text; user-select: text; }
+  body { margin: 0; padding-bottom: 24px; -webkit-user-select: text; user-select: text; }
   body .tdoc-bar, body .tdoc-bar *, body #tdoc-comment-layer, body #tdoc-comment-layer *, body #tdoc-pin-layer, body #tdoc-pin-layer *, body .tdoc-cluster-pop, body .tdoc-cluster-pop *, body .tdoc-hover-outline, body .tdoc-comment-pill, body .tdoc-emoji-picker, body .tdoc-secondary-menu, body .tdoc-anchor-mark.tdoc-anchor-mark-element, body .tdoc-drag-marquee, body .tdoc-modal, body .tdoc-modal * { -webkit-user-select: none !important; user-select: none !important; }
   body .tdoc-modal .code, body .tdoc-modal textarea, body .tdoc-modal input { -webkit-user-select: text !important; user-select: text !important; }
   /* Comment pins/cards are provider chrome, not document layout. Keep the
@@ -291,25 +291,29 @@
   }
   /* TDOC_READER_CSS_END */
 
-  /* ========== Top bar (HackMD-inspired rhythm) ==========
-     Three groups: left breadcrumb (workspace + slug + version), center
-     doc title (truncates), right cluster (identity, primary CTA, more).
-     No borders on individual buttons — uses hover background instead, so
-     the bar reads as a clean strip rather than a row of chiclets.
-     Light theme to match the doc body. */
-  .tdoc-bar { position: fixed; top: 0; left: 0; right: 0; height: 48px; background: #fff; color: #1a1a1a; display: flex; align-items: center; padding: 0 12px; font: 13px system-ui, -apple-system, "Segoe UI", Roboto, sans-serif; z-index: 999999; gap: 8px; border-bottom: 1px solid #e5e5e7; box-shadow: 0 1px 2px rgba(0,0,0,0.02); }
-  .tdoc-bar-left { display: flex; align-items: center; gap: 6px; min-width: 0; flex-shrink: 1; }
-  .tdoc-bar-center { flex: 1 1 auto; display: flex; justify-content: center; min-width: 0; padding: 0 8px; }
-  .tdoc-bar-right { display: flex; align-items: center; gap: 4px; flex-shrink: 0; }
+  /* ========== Top bar ==========
+     Two groups, Google Docs / Notion style: left (logo + crumb + title)
+     and right (identity, primary CTA, more). The title is NOT viewport-
+     centered — left and right chrome are different widths, so a flex
+     "center" slot always looks off. Title truncates in the left group.
+     No borders on individual buttons — hover background instead. */
+  /* In document flow, not position:fixed: the bar occupies the top of the
+     layout so page HTML cannot scroll underneath a floating strip. */
+  .tdoc-bar { position: relative; width: 100%; height: 48px; box-sizing: border-box; background: #fff; color: #1a1a1a; display: flex; align-items: center; padding: 0 12px; font: 13px system-ui, -apple-system, "Segoe UI", Roboto, sans-serif; z-index: 999999; gap: 8px; border-bottom: 1px solid #e5e5e7; box-shadow: 0 1px 2px rgba(0,0,0,0.02); }
+  .tdoc-bar-left { display: flex; align-items: center; gap: 6px; min-width: 0; flex: 1 1 auto; }
+  .tdoc-bar-right { display: flex; align-items: center; gap: 4px; flex-shrink: 0; margin-left: auto; }
 
-  /* Workspace mark — circular dot like HackMD's logo. Clicks → /. */
-  .tdoc-bar-mark { display: inline-flex; align-items: center; justify-content: center; height: 28px; padding: 0 12px; border-radius: 999px; background: var(--td-accent); color: #fff; font-weight: 700; font-size: 13px; letter-spacing: -0.01em; cursor: pointer; flex-shrink: 0; border: none; }
-  .tdoc-bar-mark:hover { background: var(--td-accent-hover); }
+  /* Site mark — the tdoc logo (same asset as the favicon), not a text pill. */
+  .tdoc-bar button.tdoc-bar-mark { width: 32px; height: 32px; padding: 0; border-radius: 8px; background: transparent; }
+  .tdoc-bar-mark img { width: 24px; height: 24px; display: block; }
+  .tdoc-bar .tdoc-github-btn { display: inline-flex; align-items: center; justify-content: center; width: 32px; height: 32px; padding: 0; border-radius: 8px; color: #555; }
+  .tdoc-bar .tdoc-github-btn:hover { background: #f0f1f4; color: #1a1a1a; }
+  .tdoc-bar .tdoc-github-btn svg { display: block; }
 
   /* Breadcrumb: workspace · slug · v3 — separated by " / ". */
   .tdoc-bar .crumb { color: #555; font-weight: 500; padding: 4px 6px; border-radius: 6px; max-width: 24ch; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
   .tdoc-bar .crumb-sep { color: #c0c0c4; user-select: none; padding: 0 1px; }
-  .tdoc-bar .doc-title { color: #1a1a1a; font-weight: 600; font-size: 14px; max-width: 100%; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+  .tdoc-bar .doc-title { color: #1a1a1a; font-weight: 600; font-size: 14px; min-width: 0; flex: 1 1 auto; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 
   /* Default action button — icon and/or label, no border, hover bg only. */
   .tdoc-bar button { background: transparent; border: none; color: #555; padding: 6px 8px; border-radius: 6px; font: inherit; cursor: pointer; transition: background .12s, color .12s; display: inline-flex; align-items: center; gap: 6px; }
@@ -391,10 +395,9 @@
   /* Old-version strip — a thin, quiet bar just under the top bar shown when
      the viewer is on a non-latest version. Single-direction nudge: it only
      points forward to the latest version. Hidden by default; the bar-setup
-     code reveals it (and adds the body padding) only when version < latest. */
-  .tdoc-oldver-strip { display: none; position: fixed; top: 44px; left: 0; right: 0; height: 28px; background: #fbf6e9; color: #6b5e3a; border-bottom: 1px solid #efe6cd; font: 12px system-ui, -apple-system, "Segoe UI", Roboto, sans-serif; align-items: center; justify-content: center; gap: 6px; z-index: 999998; padding: 0 12px; }
+     code reveals it only when version < latest. In flow under the top bar. */
+  .tdoc-oldver-strip { display: none; position: relative; width: 100%; height: 28px; box-sizing: border-box; background: #fbf6e9; color: #6b5e3a; border-bottom: 1px solid #efe6cd; font: 12px system-ui, -apple-system, "Segoe UI", Roboto, sans-serif; align-items: center; justify-content: center; gap: 6px; z-index: 999998; padding: 0 12px; }
   body.tdoc-has-oldver-strip .tdoc-oldver-strip { display: flex; }
-  body.tdoc-has-oldver-strip { padding-top: 72px !important; }
   .tdoc-oldver-strip a { color: #8a6d1f; font-weight: 600; text-decoration: none; border-bottom: 1px solid currentColor; }
   .tdoc-oldver-strip a:hover { color: #6b5413; }
   /* Ghost marker — a faint horizontal line at the unanchored comment's
@@ -641,10 +644,10 @@
   /* Bar collapse breakpoints — tied to viewport width, not layout class.
      The bar progressively hides elements as the viewport tightens, so it
      stays elegant at every size.
-       ≥1100px: workspace · slug · v · | title | identity · share · ⋯
-       <1100px: workspace ·          v · | title | identity · share · ⋯  (slug hides)
-       < 900px: workspace ·          v · | title | avatar   · share · ⋯  (name hides)
-       < 700px: workspace             · | title |            share · ⋯  (version+identity into ⋯) */
+       ≥1100px: logo · slug · v · title ……………… identity · share · ⋯
+       <1100px: logo ·      · v · title ……………… identity · share · ⋯  (slug hides)
+       < 900px: logo ·      · v · title ……………… avatar   · share · ⋯  (name hides)
+       < 700px: logo ·          title ………………            share · ⋯  (version+identity into ⋯) */
   @media (max-width: 1100px) {
     .tdoc-bar .crumb-slug, .tdoc-bar .crumb-sep-slug { display: none; }
   }
@@ -720,6 +723,9 @@
   html[data-tdoc-theme="dark"] .tdoc-emoji {
     filter: invert(1) hue-rotate(180deg);
   }
+  /* The site mark is a black-on-white PNG. Let it invert with the page
+     instead of restoring, or it becomes a white tile on the dark bar. */
+  html[data-tdoc-theme="dark"] .tdoc-bar-mark img { filter: none; }
   /* Color emoji are OS bitmaps. The page invert turns ❤️ purple; wrap
      them in .tdoc-emoji so they get the same restore as photos. */
   .tdoc-emoji { display: inline-block; line-height: 1; }
@@ -783,7 +789,7 @@
     return String(s).replace(/[&<>"']/g, c => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' }[c]));
   }
 
-  // ========== Top bar (HackMD-style three-group layout) ==========
+  // ========== Top bar (left title + right actions) ==========
   const bar = document.createElement('div');
   bar.className = 'tdoc-bar';
 
@@ -791,17 +797,14 @@
   versions.sort((a, b) => (a.n || 0) - (b.n || 0));
   const slugCrumbLabel = isFork ? `fork of ${cfg.originalSlug || slug}` : slug;
 
-  // Left group: workspace mark + slug crumb + version picker.
-  //
-  // On the site homepage the crumb and the picker are dropped. `/` is the
-  // site, not a doc someone published: the slug it happens to be stored
-  // under and the version it happens to be on are our filing system, and
-  // printing them tells a first-time visitor they are reading somebody's
-  // document. The mark stays, and so does everything on the right, because
-  // the page really is a tdoc and you really can comment on it.
+  // Left group: site mark + slug crumb + version picker + title.
+  // Title lives here (not a fake viewport-center) because left and right
+  // chrome are different widths. `/` and `/me` drop crumb/picker/title —
+  // those pages already name themselves in the document.
+  const isSiteBar = !!(cfg.isLanding || isCatalog);
   const leftHtml = `
-    <button class="tdoc-bar-mark" id="tdoc-bar-mark" title="tdoc on GitHub" aria-label="tdoc on GitHub">tdoc</button>
-    ${cfg.isLanding ? '' : isCatalog ? '' : `
+    <button class="tdoc-bar-mark" id="tdoc-bar-mark" title="tdoc home" aria-label="tdoc home"><img src="/tdoc_logo.png" alt="" width="24" height="24"></button>
+    ${isSiteBar ? '' : `
     <span class="crumb crumb-slug" title="${escapeHtml(slugCrumbLabel)}">${escapeHtml(slugCrumbLabel)}</span>
     <span class="crumb-sep crumb-sep-slug" aria-hidden="true">/</span>
     <div class="tdoc-version-wrap">
@@ -811,10 +814,8 @@
           ${versions.map(v => `<button role="option" data-version="${v.n}" class="${v.n === version ? 'current' : ''}">v${v.n}${v.n === version ? ' · current' : ''}</button>`).join('')}
         </div>
       ` : ''}
-    </div>`}`;
-
-  // Center: doc title (pulled from <title>). Hidden on very narrow.
-  const centerHtml = `<span class="doc-title" id="tdoc-title">tdoc</span>`;
+    </div>
+    <span class="doc-title" id="tdoc-title">tdoc</span>`}`;
 
   // Right: copy menu + primary CTA (Share or Publish) + ⋯ overflow + identity.
   const copyMenuHtml = `
@@ -858,12 +859,18 @@
       <svg class="tdoc-theme-icon-sun" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="4"/><path d="M12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M4.93 19.07l1.41-1.41M17.66 6.34l1.41-1.41"/></svg>
     </button>`;
 
+  const githubBtnHtml = `
+    <a class="tdoc-github-btn" id="tdoc-github-btn" href="https://github.com/tornado-doc/tdoc" target="_blank" rel="noopener" title="tdoc on GitHub" aria-label="tdoc on GitHub">
+      <svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27s1.36.09 2 .27c1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.01 8.01 0 0 0 16 8c0-4.42-3.58-8-8-8z"/></svg>
+    </a>`;
+
   const rightHtml = `
+    ${cfg.isLanding ? githubBtnHtml : ''}
     ${themeBtnHtml}
-    ${isCatalog ? '' : copyMenuHtml}
-    ${isCatalog ? '' : forkBtnHtml}
-    ${isCatalog ? '' : primaryCtaHtml}
-    ${!isCatalog && (isPublished || isFork) ? `<div class="tdoc-menu-wrap">
+    ${isSiteBar ? '' : copyMenuHtml}
+    ${isSiteBar ? '' : forkBtnHtml}
+    ${isSiteBar ? '' : primaryCtaHtml}
+    ${!isSiteBar && (isPublished || isFork) ? `<div class="tdoc-menu-wrap">
       <button class="tdoc-secondary-toggle" id="tdoc-more-btn" aria-label="More" title="More">⋯</button>
       <div class="tdoc-secondary-menu" id="tdoc-secondary-menu">
         ${isPublished ? '<button data-action="duplicate">Duplicate</button><button data-action="download">Download HTML</button><button data-action="download-pdf">Download PDF</button>' : ''}
@@ -874,10 +881,9 @@
 
   bar.innerHTML = `
     <div class="tdoc-bar-left">${leftHtml}</div>
-    <div class="tdoc-bar-center">${centerHtml}</div>
     <div class="tdoc-bar-right">${rightHtml}</div>
   `;
-  document.body.appendChild(bar);
+  document.body.insertBefore(bar, document.body.firstChild);
 
   // Old-version strip — a quiet, single-direction nudge shown only when a
   // published viewer is looking at a non-latest version. `versions` is already
@@ -890,7 +896,7 @@
       strip.className = 'tdoc-oldver-strip';
       const latestUrl = `/d/${encodeURIComponent(slug)}/v/${latestVersion}`;
       strip.innerHTML = `<span>You're viewing v${version} — the latest is <a href="${latestUrl}">v${latestVersion}</a></span>`;
-      document.body.appendChild(strip);
+      bar.insertAdjacentElement('afterend', strip);
       document.body.classList.add('tdoc-has-oldver-strip');
     }
   }
@@ -910,13 +916,11 @@
   }
 
   const titleEl = document.querySelector('title');
-  if (titleEl && titleEl.textContent) document.getElementById('tdoc-title').textContent = titleEl.textContent;
+  const barTitle = document.getElementById('tdoc-title');
+  if (barTitle && titleEl && titleEl.textContent) barTitle.textContent = titleEl.textContent;
 
-  // Workspace mark in the bar's left → the open-source project. There is
-  // no public catalog; the owner reaches their doc list via the profile
-  // chip menu instead.
-  document.getElementById('tdoc-bar-mark').onclick = () =>
-    window.open('https://github.com/tornado-doc/tdoc', '_blank', 'noopener');
+  // Site mark → home. GitHub lives in its own icon on `/`.
+  document.getElementById('tdoc-bar-mark').onclick = () => { location.href = '/'; };
 
   paintTheme(currentTheme());
   document.getElementById('tdoc-theme-btn').onclick = () => {

--- a/test/csp-xss.test.js
+++ b/test/csp-xss.test.js
@@ -104,8 +104,8 @@ function waitReady(port, ms = 5000) {
 
   await t('the nonced overlay script DID execute — the tdoc bar renders', async () => {
     await page.waitForSelector('.tdoc-bar', { timeout: 2000 });
-    const markText = await page.$eval('.tdoc-bar-mark', (el) => el.textContent);
-    if (!markText || !markText.trim()) throw new Error('tdoc bar mark is empty — overlay may not have booted');
+    const markSrc = await page.$eval('.tdoc-bar-mark img', (el) => el.getAttribute('src'));
+    if (markSrc !== '/tdoc_logo.png') throw new Error('tdoc bar mark is missing the logo — overlay may not have booted');
   });
 
   await t('commenting still works end-to-end under the CSP (drag INTO the element opens the popup, submit persists)', async () => {

--- a/test/me-management.test.js
+++ b/test/me-management.test.js
@@ -125,6 +125,19 @@ t('/me catalog does not fold comment logs or HEAD R2 per row', () => {
   assert(index.includes('Promise.all'), '/me should fetch meta rows in parallel');
 });
 
+t('overlay top bar occupies layout instead of floating over the document', () => {
+  assert(overlay.includes('.tdoc-bar { position: relative;'),
+    'bar must sit in document flow, not overlay the page');
+  assert(!overlay.includes('.tdoc-bar { position: fixed;'),
+    'bar must not be position:fixed');
+  assert(overlay.includes('document.body.insertBefore(bar, document.body.firstChild)'),
+    'bar must be the first body child so it occupies the top of the layout');
+  assert(!overlay.includes('padding-top: 44px !important'),
+    'in-flow bar must not reserve a fake padding-top gap');
+  assert(!overlay.includes('body.tdoc-has-oldver-strip { padding-top: 72px !important; }'),
+    'old-version strip must occupy flow, not extra body padding');
+});
+
 t('/me reuses the overlay top bar and hides Share / Duplicate / Copy', () => {
   const meStart = worker.indexOf("if (p === '/me' && method === 'GET')");
   const meEnd = worker.indexOf('// ---- interactive island', meStart);
@@ -137,9 +150,16 @@ t('/me reuses the overlay top bar and hides Share / Duplicate / Copy', () => {
   assert(!index.includes('class="who"'), 'identity belongs in the overlay chip');
   assert(index.includes('nonce="${nonce}"'), '/me catalog script must carry the CSP nonce');
   assert(overlay.includes('const isCatalog = !!cfg.isCatalog'), 'overlay must read isCatalog');
-  assert(overlay.includes("${isCatalog ? '' : copyMenuHtml}"), 'catalog must hide Copy');
-  assert(overlay.includes("${isCatalog ? '' : primaryCtaHtml}"), 'catalog must hide Share');
-  assert(overlay.includes("${isCatalog ? '' : forkBtnHtml}"), 'catalog must hide Duplicate/Download');
+  assert(overlay.includes("${isSiteBar ? '' : copyMenuHtml}"), 'catalog must hide Copy');
+  assert(overlay.includes("${isSiteBar ? '' : primaryCtaHtml}"), 'catalog must hide Share');
+  assert(overlay.includes("${isSiteBar ? '' : forkBtnHtml}"), 'catalog must hide Duplicate/Download');
+  assert(overlay.includes('id="tdoc-title"'),
+    'doc pages still show the title in the left cluster');
+  assert(!overlay.includes('tdoc-bar-center'),
+    'title must not sit in a fake-centered middle slot');
+  assert(overlay.includes('src="/tdoc_logo.png"'),
+    'bar mark must be the tdoc logo, not a text pill');
+  assert(index.includes('class="wrap"'), 'catalog content must sit in a wrap so the bar can be full-bleed');
   const catalogGate = overlay.indexOf('if (isCatalog) {');
   const commentsBoot = overlay.indexOf('// ========== Comment layer + FAB ==========');
   assert(catalogGate >= 0 && commentsBoot > catalogGate, 'catalog must not boot comment chrome');

--- a/test/tornado-doc-landing.test.js
+++ b/test/tornado-doc-landing.test.js
@@ -377,11 +377,12 @@ t('doc view and homepage share one render path', () => {
   assert(occurrences === 1, `injectOverlay(raw, ...) called ${occurrences} times; expected exactly 1 shared call site`);
 });
 
-t('homepage bar drops the slug crumb and the version picker', () => {
+t('homepage bar is site chrome, not a document toolbar', () => {
   // `/` is the site, not a doc someone published. Printing the storage slug
   // ("tornado-doc") and the version it happens to be on tells a first-time
   // visitor they are reading somebody else's document. The /d/ route keeps
-  // both — same render path, one flag.
+  // both — same render path, one flag. Share / Copy / Duplicate and the
+  // document title are document chrome; `/` keeps GitHub + sign-in + theme.
   const fn = worker.match(/async function landingResponse[\s\S]*?\n}\n/);
   assert(fn, 'landingResponse not found');
   assert(/serveDocVersion\(env, req, LANDING_SLUG, Number\(latest\), true\)/.test(fn[0]),
@@ -391,10 +392,22 @@ t('homepage bar drops the slug crumb and the version picker', () => {
   const overlay = fs.readFileSync(path.join(root, 'server', 'overlay.js'), 'utf8');
   const left = overlay.match(/const leftHtml = `[\s\S]*?`;\n/);
   assert(left, 'overlay leftHtml block not found');
-  assert(/cfg\.isLanding \? '' :/.test(left[0]),
+  assert(/isSiteBar \? '' :/.test(left[0]),
     'overlay still renders the slug crumb and version picker on the homepage');
-  assert(/tdoc-bar-mark/.test(left[0].split('cfg.isLanding')[0]),
+  assert(/tdoc-bar-mark/.test(left[0].split('isSiteBar')[0]),
     'the tdoc mark must stay outside the landing conditional');
+  assert(/tdoc_logo\.png/.test(left[0]),
+    'the mark must be the tdoc logo, not a text pill');
+  assert(/tdoc-title/.test(left[0]) && /isSiteBar \? '' :/.test(left[0]),
+    'homepage bar must not repeat the page title');
+  assert(!overlay.includes('tdoc-bar-center'),
+    'title must sit in the left cluster, not a fake-centered slot');
+  assert(overlay.includes("${cfg.isLanding ? githubBtnHtml : ''}"),
+    'homepage bar must expose a GitHub icon');
+  assert(overlay.includes("${isSiteBar ? '' : copyMenuHtml}"),
+    'homepage bar must drop Copy');
+  assert(overlay.includes("${isSiteBar ? '' : primaryCtaHtml}"),
+    'homepage bar must drop Share');
 
   // Share on `/` must copy the canonical homepage, not /d/tornado-doc/v/N.
   const shareFn = overlay.match(/function publicShareUrl\(\) \{[\s\S]*?\n  \}/);

--- a/test/ui.test.js
+++ b/test/ui.test.js
@@ -55,6 +55,21 @@ async function tPub(name, fn) {
     await page.waitForSelector('.tdoc-bar', { timeout: 5000 });
   });
 
+  await t('top bar occupies layout instead of floating over the document', async () => {
+    const info = await page.evaluate(() => {
+      const bar = document.querySelector('.tdoc-bar');
+      const cs = getComputedStyle(bar);
+      return {
+        position: cs.position,
+        firstChildIsBar: document.body.firstElementChild === bar,
+      };
+    });
+    if (info.position === 'fixed' || info.position === 'sticky') {
+      throw new Error(`bar must be in document flow, got position:${info.position}`);
+    }
+    if (!info.firstChildIsBar) throw new Error('bar must be the first body element');
+  });
+
   await t('Dark mode switch is in the top bar', async () => {
     const btn = await page.$('#tdoc-theme-btn');
     if (!btn) throw new Error('no #tdoc-theme-btn');

--- a/worker/worker.js
+++ b/worker/worker.js
@@ -1352,7 +1352,8 @@ async function indexHtml(env, session, origin, nonce) {
     --td-danger: #b42318; --td-danger-hover: #931c14; --td-danger-tint: #fdeceb; --td-ok: #087443;
     --td-ink: #111; --td-muted: #666; --td-line: #eee; --td-surface: #f7f7f7;
   }
-  body { font: 15px system-ui, -apple-system, sans-serif; max-width: 680px; margin: 0 auto; padding: 24px 20px 48px; color: var(--td-ink); }
+  body { font: 15px system-ui, -apple-system, sans-serif; margin: 0; color: var(--td-ink); }
+  .wrap { max-width: 680px; margin: 0 auto; padding: 24px 20px 48px; }
   h1 { font-size: 28px; margin: 0 0 24px; color: var(--td-accent); }
   a { color: var(--td-accent); text-decoration: none; }
   a:hover { text-decoration: underline; }
@@ -1399,6 +1400,7 @@ async function indexHtml(env, session, origin, nonce) {
   .tdoc-modal button.danger:hover { background: var(--td-danger-hover); border-color: var(--td-danger-hover); }
 </style>
 </head><body>
+<div class="wrap">
 <h1>My docs</h1>
 ${rows.length === 0 ? '<p class="empty">No published docs yet.</p>' :
   `<div class="toolbar">
@@ -1410,6 +1412,7 @@ ${rows.length === 0 ? '<p class="empty">No published docs yet.</p>' :
   </div>
   <div class="doc-list">${rows.join('')}</div>
   <p id="no-match" class="empty" hidden>No matches.</p>`}
+</div>
 <script${nonce ? ` nonce="${nonce}"` : ''}>
 (() => {
   // Tiny top-right toast — no third-party runtime on the privileged /me page.


### PR DESCRIPTION
## Summary
- Overlay bar sits in document flow instead of `position: fixed`, so page HTML no longer scrolls underneath it.
- `/` and `/me` drop document chrome (title, Share, Copy, Duplicate). Landing keeps the tdoc logo, GitHub, appearance, and sign-in.
- Doc title lives in the left cluster (Google/Notion), not a fake-centered middle slot.

## Test plan
- [ ] Open a published doc: bar is in flow; title is on the left after logo/slug/version; content does not slide under the bar.
- [ ] Open `/`: logo, GitHub, appearance, sign-in only — no Share/Copy/title.
- [ ] Open `/me`: no duplicate "My docs" in the bar; catalog list stays in the wrap; identity + appearance remain.
- [ ] Dark mode: T-Rex mark is not a white tile.


Made with [Cursor](https://cursor.com)