### PR TITLE
Ship the onboarding modal wherever its CTA is

### DIFF
--- a/worker/worker.js
+++ b/worker/worker.js
@@ -1041,7 +1041,11 @@ function injectOverlay(rawHtml, slug, version, identity, versions, isOwner, owne
   // nonce. The doc's own <script> would never run (#138), which is why the
   // landing CTA still carries a plain href: with scripting off the visitor
   // gets the /start page instead of a dead button.
-  const withOnboard = (slug === LANDING_SLUG || slug === START_SLUG) && nonce
+  // The modal ships wherever its trigger is. Gating on the slug meant a doc
+  // could carry the CTA and get a dead link to /start instead — which is what
+  // happened the first time the landing page was drafted under another slug.
+  const hasCta = /<a[^>]+href="\/start"/.test(rawHtml);
+  const withOnboard = (slug === LANDING_SLUG || slug === START_SLUG || hasCta) && nonce
     ? rawHtml.replace('</body>', `<script nonce="${nonce}">${ONBOARD_JS}</script>\n</body>`)
     : rawHtml;
   return injectOverlayCfg(withOnboard, {


### PR DESCRIPTION
Fixes #169

`injectOverlay` gated the onboarding script on two hardcoded slugs, so a
doc could carry the "Create your first doc" CTA and get a plain
navigation to `/start` instead of the modal. Gate on the trigger instead.

Both slugs stay in the condition, so nothing that works today depends on
the new check, and the no-script fallback is unchanged: with scripting
off the CTA still lands on `/start`.

Verified by clicking the CTA on a published doc under a non-landing slug:
the modal opens and the URL does not change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011TPaMk9sTPxsHHPXGze7QB