### PR TITLE
Stop the deploy check from failing on a homepage rewrite

### DIFF
--- a/.github/workflows/publish-landing.yml
+++ b/.github/workflows/publish-landing.yml
@@ -180,9 +180,13 @@ jobs:
             # while /start is still on the fallback is a broken hand-off, not
             # a success. Both, or keep waiting.
             tour=$(curl -sS https://tdoc.dev/start || true)
-            if [[ "$home" == *'A doc that answers its own comments'* \
+            # Match on what proves the doc rendered, not on its wording: the
+            # slug and the landing flag come from the overlay config, and the
+            # neutral fallback carries neither. Keying on the headline meant
+            # every homepage rewrite failed its own deploy.
+            if [[ "$home" == *'"slug":"tornado-doc"'* \
               && "$home" == *'"isLanding":true'* \
-              && "$tour" == *'Everything tdoc does'* ]]; then
+              && "$tour" == *'"slug":"tdoc-start"'* ]]; then
               echo "tdoc.dev/ and /start are both serving their docs."
               exit 0
             fi

--- a/test/tornado-doc-landing.test.js
+++ b/test/tornado-doc-landing.test.js
@@ -525,12 +525,12 @@ t('shipping the homepage ships content, not just worker code', () => {
   // gate, wrong slug). Green must mean the homepage actually renders.
   assert(/is still serving the neutral fallback/.test(content),
     'publish workflow must fail when tdoc.dev/ falls back to the neutral page');
-  assert(/\[\[ "\$home" == \*'A doc that answers its own comments'\*/.test(content),
-    'homepage verify must use bash [[ ]], not echo|grep -q under pipefail');
+  assert(/\[\[ "\$home" == \*'"slug":"tornado-doc"'\*/.test(content),
+    'homepage verify must use bash [[ ]] on the slug, not echo|grep -q under pipefail');
   // The homepage links to /start. Shipping one without the other leaves that
   // link on the neutral fallback, which reads as "the tour does not exist".
   assert(/upload tdoc-start/.test(content), 'the tutorial is never uploaded to tdoc.dev');
-  assert(/"\$tour" == \*'Everything tdoc does'\*/.test(content),
+  assert(/"\$tour" == \*'"slug":"tdoc-start"'\*/.test(content),
     'a green run must mean /start renders too, not just the homepage');
   assert(!/echo "\$body" \| grep -q/.test(content),
     'echo|grep -q SIGPIPEs on a 300kB landing page and fails a successful ship');


### PR DESCRIPTION
Fixes #172

The verify step keyed on the homepage headline, so the deploy that ships
a new headline could never go green. On #171 both uploads returned 200,
`/` and `/start` both served their docs, and the run still went red
against its own copy.

Match on what proves the doc rendered instead: `"slug":"tornado-doc"` and
`"isLanding":true` from the overlay config, and `"slug":"tdoc-start"` for
the tutorial. The neutral fallback carries none of them, so the check
keeps its meaning without encoding the words on the page.

The landing test pinned the same string, so the copy lived in three
places at once. It still requires bash `[[ ]]` over `echo | grep -q`
under pipefail, and still requires both pages to be checked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011TPaMk9sTPxsHHPXGze7QB