### PR TITLE
Notification clicks open the target doc and comment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,12 @@ file and `.claude-plugin/plugin.json`.
 
 ### Fixed
 
+- **Notification clicks open the target doc and comment.** Inbox rows
+  go to `/d/<slug>/v/<n>?comment=<id>` (including from `/me` and `/`).
+  Same-doc clicks no longer pin the card and then immediately unpin it
+  because the click bubbled as an outside click. `?comment=` expands the
+  thread before the card is built, pins it, and on a phone opens the
+  comment drawer. `#180`.
 - **Download PDF uses the browser print engine.** The JPEG-page wrap was
   ~100 DPI and looked mushy. PDF now prints `/export` (reader CSS, no bar)
   so Save as PDF keeps vector text.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,7 +60,8 @@ file and `.claude-plugin/plugin.json`.
   Same-doc clicks no longer pin the card and then immediately unpin it
   because the click bubbled as an outside click. `?comment=` expands the
   thread before the card is built, pins it, and on a phone opens the
-  comment drawer. `#180`.
+  comment drawer. Same-doc clicks also add `.open` on the live replies
+  list, so a collapsed thread actually shows the target reply. `#180`.
 - **Download PDF uses the browser print engine.** The JPEG-page wrap was
   ~100 DPI and looked mushy. PDF now prints `/export` (reader CSS, no bar)
   so Save as PDF keeps vector text.

--- a/server/overlay.js
+++ b/server/overlay.js
@@ -2761,7 +2761,17 @@
   function applyCommentDeepLink(want) {
     if (!want) return;
     const root = findCommentRoot(state.activeComments, want);
-    if (root) state.openReplyThreads.add(root);
+    if (root) {
+      state.openReplyThreads.add(root);
+      // Same-doc inbox clicks run after cards already exist. The set is
+      // only consulted at buildCard — collapsed threads stay display:none
+      // until .tdoc-replies.open is on the live card.
+      const card = state.cardEls.get(root);
+      if (card) {
+        card.querySelector('.tdoc-replies')?.classList.add('open');
+        card.querySelector('.tdoc-replies-toggle')?.classList.add('open');
+      }
+    }
     if (state.narrow) commentLayer.classList.add('open');
     // Opening a reply must not activate the root — that would mark the
     // root's own notifications (e.g. a reaction) as read.
@@ -2769,6 +2779,7 @@
     else if (root && state.cardEls.has(root)) pinOpenCard(root);
     const el = document.querySelector(`[data-comment-id="${CSS.escape(want)}"]`);
     if (el && el.scrollIntoView) el.scrollIntoView({ block: 'center' });
+    if (root) requestAnimationFrame(repositionCards);
     markInboxSeen(want);
   }
 

--- a/server/overlay.js
+++ b/server/overlay.js
@@ -1179,6 +1179,35 @@
     if (row.kind === 'reaction') return n > 1 ? `${n} people reacted to your comment` : `${who} reacted to your comment`;
     return 'Notification';
   }
+  // Canonical inbox destination. Never returns /d/undefined — empty slug is ''.
+  function inboxTargetUrl(row, current) {
+    row = row || {};
+    current = current || {};
+    const destSlug = row.slug || current.slug || '';
+    if (!destSlug) return '';
+    const rawVer = row.version != null && row.version !== '' ? row.version : current.version;
+    const destVer = Number(rawVer);
+    const ver = Number.isFinite(destVer) && destVer > 0 ? destVer : 1;
+    const target = row.comment_id || row.thread_id || '';
+    let href = '/d/' + encodeURIComponent(destSlug) + '/v/' + ver;
+    if (target) href += '?comment=' + encodeURIComponent(target);
+    return href;
+  }
+  // Map a comment or reply id to the top-level card that holds it.
+  function findCommentRoot(list, want) {
+    if (!want) return null;
+    const comments = Array.isArray(list) ? list : [];
+    for (let i = 0; i < comments.length; i++) {
+      const c = comments[i];
+      if (!c) continue;
+      if (c.id === want) return c.id;
+      const replies = c.replies || [];
+      for (let j = 0; j < replies.length; j++) {
+        if (replies[j] && replies[j].id === want) return c.id;
+      }
+    }
+    return want;
+  }
   function inboxFingerprint(body) {
     const items = (body && Array.isArray(body.items)) ? body.items : [];
     return `${body && body.unread}|${items.map(i => [i.id, i.count, i.at, i.read].join(':')).join(',')}`;
@@ -1216,7 +1245,8 @@
       btn.dataset.thread = row.thread_id || '';
       if (btn._bound) return;
       btn._bound = true;
-      const go = () => {
+      const go = (e) => {
+        if (e && typeof e.stopPropagation === 'function') e.stopPropagation();
         openInboxTarget({
           slug: btn.dataset.slug, version: btn.dataset.version,
           comment_id: btn.dataset.comment, thread_id: btn.dataset.thread,
@@ -1224,7 +1254,7 @@
         closeAuxModal();
       };
       btn.onclick = go;
-      btn.onkeydown = (e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); go(); } };
+      btn.onkeydown = (e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); go(e); } };
     });
   }
   async function refreshInboxBadge() {
@@ -1279,22 +1309,23 @@
     refreshInboxBadge();
   }
   function openInboxTarget(row) {
-    const target = row.comment_id || row.thread_id;
-    const root = row.thread_id || row.comment_id;
-    const destSlug = row.slug || slug;
-    const destVer = row.version || version;
-    if (destSlug === slug && Number(destVer) === Number(version)) {
-      if (root) {
-        state.openReplyThreads.add(root);
-        pinOpenCard(root);
-        if (target === root) setActiveComment(root);
-      }
-      const el = document.querySelector(`[data-comment-id="${CSS.escape(target || '')}"]`);
-      if (el && el.scrollIntoView) el.scrollIntoView({ block: 'center' });
-      markInboxSeen(target);
+    const href = inboxTargetUrl(row, { slug, version });
+    if (!href) return;
+    const q = href.indexOf('?');
+    const destPath = q >= 0 ? href.slice(0, q) : href;
+    const destSearch = q >= 0 ? href.slice(q) : '';
+    const herePath = (typeof location !== 'undefined' && location.pathname) || '';
+    // /me and `/` always assign /d/<slug>/v/<n>?comment=. Same-doc stays
+    // in place and only replaceState-s the query.
+    if (!isCatalog && herePath === destPath) {
+      const want = (row && (row.comment_id || row.thread_id)) || '';
+      applyCommentDeepLink(want);
+      try {
+        if (destSearch && location.search !== destSearch) history.replaceState(null, '', href);
+      } catch {}
       return;
     }
-    location.href = `/d/${encodeURIComponent(destSlug)}/v/${destVer}?comment=${encodeURIComponent(target || root || '')}`;
+    location.assign(href);
   }
   async function showInboxPanel() {
     closeAuxModal();
@@ -2481,6 +2512,10 @@
   function closeClusterPopover() { clusterPop.classList.remove('open'); clusterPop._key = null; }
   document.addEventListener('click', (e) => {
     if (!clusterPop.contains(e.target) && !e.target.closest?.('.tdoc-pin-cluster')) closeClusterPopover();
+    // Inbox / Share / profile chrome is overlay UI. A click there must not
+    // count as "outside the card" or opening a notification would pin the
+    // comment and the same click would immediately unpin it.
+    if (isInUI(e.target)) return;
     // Click outside an open pinned card (and not on a pin) unpins it.
     if (state.pinnedId && !e.target.closest?.('.tdoc-margin-comment') && !e.target.closest?.('.tdoc-pin')) {
       const id = state.pinnedId; state.pinnedId = null; hideCardIfIdle(id); markPinActive(id, false);
@@ -2642,6 +2677,13 @@
     const fabCount = document.getElementById('tdoc-fab-count');
     if (fabCount) fabCount.textContent = state.activeComments.length;
 
+    const want = allowDeepLink
+      ? (() => { try { return new URLSearchParams(location.search).get('comment'); } catch { return null; } })()
+      : null;
+    const deepRoot = findCommentRoot(state.activeComments, want);
+    // Expand the thread before buildCard so a reply deep-link is not born collapsed.
+    if (deepRoot) state.openReplyThreads.add(deepRoot);
+
     let textCache = state.activeComments.some(c => (c.anchor?.kind || (c.anchor?.text ? 'text' : null)) === 'text')
       ? collectTextNodes() : null;
     for (const comment of state.activeComments) {
@@ -2703,33 +2745,31 @@
     evaluateLayout();
     requestAnimationFrame(() => {
       repositionCards();
-      // Restore the pinned floating card if its comment survived the refresh
-      // and we're in wide (pins) mode. Runs after repositionCards so the pin
-      // elements exist to mark active.
-      if (keepPinnedId && !state.narrow && state.cardEls.has(keepPinnedId)) {
+      if (want) {
+        applyCommentDeepLink(want);
+      } else if (keepPinnedId && !state.narrow && state.cardEls.has(keepPinnedId)) {
+        // Restore the pinned floating card if its comment survived the refresh.
         // Use setActiveComment (not the manual pin/show/mark trio) so the
         // card's .active class, anchor highlight, activeId, AND the pin state
         // are all re-established together. The manual version desynced activeId
         // and lost the card's .active state (+ the "move anchor" affordance).
         setActiveComment(keepPinnedId);
       }
-      const want = allowDeepLink
-        ? (() => { try { return new URLSearchParams(location.search).get('comment'); } catch { return null; } })()
-        : null;
-      if (want) {
-        const hit = state.activeComments.find(c => c.id === want)
-          || state.activeComments.find(c => (c.replies || []).some(r => r.id === want));
-        const root = hit ? hit.id : want;
-        state.openReplyThreads.add(root);
-        // Opening a reply must not activate the root — that would mark the
-        // root's own notifications (e.g. a reaction) as read.
-        if (want === root && state.cardEls.has(root)) setActiveComment(root);
-        else if (state.cardEls.has(root)) pinOpenCard(root);
-        const el = document.querySelector(`[data-comment-id="${CSS.escape(want)}"]`);
-        if (el && el.scrollIntoView) el.scrollIntoView({ block: 'center' });
-        markInboxSeen(want);
-      }
     });
+  }
+
+  function applyCommentDeepLink(want) {
+    if (!want) return;
+    const root = findCommentRoot(state.activeComments, want);
+    if (root) state.openReplyThreads.add(root);
+    if (state.narrow) commentLayer.classList.add('open');
+    // Opening a reply must not activate the root — that would mark the
+    // root's own notifications (e.g. a reaction) as read.
+    if (want === root && state.cardEls.has(root)) setActiveComment(root);
+    else if (root && state.cardEls.has(root)) pinOpenCard(root);
+    const el = document.querySelector(`[data-comment-id="${CSS.escape(want)}"]`);
+    if (el && el.scrollIntoView) el.scrollIntoView({ block: 'center' });
+    markInboxSeen(want);
   }
 
   // Click on a Highlight-API range → activate. Highlight API has no per-range

--- a/test/overlay-inbox.test.js
+++ b/test/overlay-inbox.test.js
@@ -71,6 +71,16 @@ t('applyCommentDeepLink opens the phone drawer and the card', () => {
   assert(fn.includes('markInboxSeen(want)'), 'deep-link must mark the notification read');
 });
 
+t('applyCommentDeepLink expands an already-built collapsed thread', () => {
+  const fn = sliceFn('applyCommentDeepLink');
+  assert(fn.includes("card.querySelector('.tdoc-replies')?.classList.add('open')"),
+    'same-doc must add .open on the live .tdoc-replies list');
+  assert(fn.includes("card.querySelector('.tdoc-replies-toggle')?.classList.add('open')"),
+    'same-doc must flip the replies chevron');
+  assert(fn.includes('requestAnimationFrame(repositionCards)'),
+    'expanding replies must reflow the card');
+});
+
 t('deep-link reads ?comment= from the page URL', () => {
   const refresh = sliceFn('refreshComments');
   assert(refresh.includes("URLSearchParams(location.search).get('comment')"),

--- a/test/overlay-inbox.test.js
+++ b/test/overlay-inbox.test.js
@@ -1,0 +1,88 @@
+// Inbox click → doc/comment deep-link contract. #180
+//
+// Overlay UI is mostly un-runnable DOM, so this suite pins the wiring in
+// source: destination URL, stopPropagation on the row, outside-click must
+// not unpin overlay chrome, ?comment= expands the thread before buildCard
+// and opens the phone drawer.
+//
+// Run with: node test/overlay-inbox.test.js
+
+const fs = require('fs');
+const path = require('path');
+
+let pass = 0, fail = 0;
+function ok(n) { console.log(`  ✓ ${n}`); pass++; }
+function bad(n, e) { console.log(`  ✗ ${n}\n    ${e}`); fail++; }
+function t(n, fn) { try { fn(); ok(n); } catch (e) { bad(n, e.message); } }
+function assert(c, m) { if (!c) throw new Error(m || 'assertion failed'); }
+
+const src = fs.readFileSync(path.join(__dirname, '..', 'server', 'overlay.js'), 'utf8');
+
+function sliceFn(name) {
+  const start = src.indexOf(`function ${name}(`);
+  if (start === -1) throw new Error(`fn ${name} not found`);
+  let i = src.indexOf('{', start), depth = 0;
+  for (; i < src.length; i++) {
+    if (src[i] === '{') depth++;
+    else if (src[i] === '}') { depth--; if (depth === 0) { i++; break; } }
+  }
+  return src.slice(start, i);
+}
+
+console.log('overlay inbox (#180 notification deep-link)');
+
+t('inboxTargetUrl is the only destination builder', () => {
+  const open = sliceFn('openInboxTarget');
+  assert(open.includes('inboxTargetUrl(row, { slug, version })'), 'openInboxTarget must use inboxTargetUrl');
+  assert(open.includes('location.assign(href)'), 'other-doc clicks must navigate');
+  assert(!/\/d\/\$\{encodeURIComponent\(destSlug\)\}/.test(open),
+    'openInboxTarget still interpolates destSlug itself');
+  assert(!open.includes("location.href = `/d/"), 'legacy location.href assignment came back');
+});
+
+t('inbox row click stops the document unpin handler from seeing it', () => {
+  const write = sliceFn('writeInboxRows');
+  assert(write.includes('e.stopPropagation'), 'row go() must stopPropagation');
+  assert(/btn\.onclick = go/.test(write), 'row click must call go');
+});
+
+t('outside-click unpin ignores overlay chrome (inbox modal)', () => {
+  const unpin = src.indexOf("Click outside an open pinned card");
+  assert(unpin !== -1, 'unpin handler missing');
+  const window = src.slice(unpin - 400, unpin + 200);
+  assert(window.includes('if (isInUI(e.target)) return;'),
+    'unpin handler must bail out for overlay UI clicks');
+});
+
+t('?comment= expands the thread before cards are built', () => {
+  const refresh = sliceFn('refreshComments');
+  const expandAt = refresh.indexOf('if (deepRoot) state.openReplyThreads.add(deepRoot)');
+  const buildAt = refresh.indexOf('const card = buildCard(comment)');
+  assert(expandAt !== -1, 'deep-link does not add the root to openReplyThreads');
+  assert(buildAt !== -1, 'buildCard missing from refreshComments');
+  assert(expandAt < buildAt, 'thread must be marked open before buildCard');
+});
+
+t('applyCommentDeepLink opens the phone drawer and the card', () => {
+  const fn = sliceFn('applyCommentDeepLink');
+  assert(fn.includes("commentLayer.classList.add('open')"), 'narrow mode must open the drawer');
+  assert(fn.includes('setActiveComment(root)'), 'top-level comment must activate');
+  assert(fn.includes('pinOpenCard(root)'), 'reply deep-link must pin the root card');
+  assert(fn.includes('markInboxSeen(want)'), 'deep-link must mark the notification read');
+});
+
+t('deep-link reads ?comment= from the page URL', () => {
+  const refresh = sliceFn('refreshComments');
+  assert(refresh.includes("URLSearchParams(location.search).get('comment')"),
+    'refreshComments must read location.search comment');
+});
+
+t('/me catalog still has the inbox and navigates via inboxTargetUrl', () => {
+  assert(src.includes('const isCatalog = !!cfg.isCatalog'), 'catalog mode missing');
+  const open = sliceFn('openInboxTarget');
+  assert(open.includes('!isCatalog && herePath === destPath'),
+    'catalog must not take the in-place path');
+});
+
+console.log(`\n${pass} passed, ${fail} failed`);
+process.exit(fail ? 1 : 0);

--- a/test/overlay-pure.test.js
+++ b/test/overlay-pure.test.js
@@ -47,10 +47,11 @@ vm.runInContext([
   'escapeHtml', 'normalizeNeedle', 'normalizeContext', 'normalizeQuery',
   'commonPrefixLen', 'commonSuffixLen', 'isGithubHttpsUrl',
   'isAnthropicCompanyMark', 'tdocLogoUrl', 'agentLogoUrl', 'childrenOf',
+  'inboxTargetUrl', 'findCommentRoot',
 ].map(sliceFn).join('\n\n'), box);
 const { escapeHtml, normalizeNeedle, normalizeContext, normalizeQuery,
         commonPrefixLen, commonSuffixLen, isGithubHttpsUrl, agentLogoUrl,
-        childrenOf } = box;
+        childrenOf, inboxTargetUrl, findCommentRoot } = box;
 
 console.log('overlay-pure (#23 testable surface)');
 
@@ -144,6 +145,46 @@ t('childrenOf nests replies under their immediate parent', () => {
   assert(childrenOf(replies, 'c1', 'c1').map(r => r.id).join() === 'r1,r3', 'tops');
   assert(childrenOf(replies, 'r1', 'c1').map(r => r.id).join() === 'r2', 'nested');
   assert(childrenOf(replies, 'r2', 'c1').length === 0, 'leaf');
+});
+
+t('inboxTargetUrl builds /d/<slug>/v/<n>?comment=<id>', () => {
+  assert(inboxTargetUrl(
+    { slug: 'conway-life', version: 3, comment_id: 'c_1' },
+    { slug: 'other', version: 1 }
+  ) === '/d/conway-life/v/3?comment=c_1');
+});
+t('inboxTargetUrl falls back to the current doc when the row has no slug', () => {
+  assert(inboxTargetUrl(
+    { comment_id: 'r_9', thread_id: 'c_1' },
+    { slug: 'sample-doc', version: 2 }
+  ) === '/d/sample-doc/v/2?comment=r_9');
+});
+t('inboxTargetUrl never emits /d/undefined', () => {
+  assert(inboxTargetUrl({}, {}) === '');
+  assert(inboxTargetUrl({ comment_id: 'c_1' }, { version: 1 }) === '');
+  assert(inboxTargetUrl(null, null) === '');
+});
+t('inboxTargetUrl encodes slug and comment id', () => {
+  assert(inboxTargetUrl(
+    { slug: 'a b', version: 1, comment_id: 'c 1' },
+    {}
+  ) === '/d/a%20b/v/1?comment=c%201');
+});
+t('inboxTargetUrl treats bad versions as 1', () => {
+  assert(inboxTargetUrl({ slug: 'd', version: 'nope', comment_id: 'c' }, {}) === '/d/d/v/1?comment=c');
+  assert(inboxTargetUrl({ slug: 'd', version: 0 }, {}) === '/d/d/v/1');
+});
+t('findCommentRoot maps a reply id to its top-level card', () => {
+  const list = [
+    { id: 'c1', replies: [{ id: 'r1' }, { id: 'r2' }] },
+    { id: 'c2', replies: [] },
+  ];
+  assert(findCommentRoot(list, 'c1') === 'c1');
+  assert(findCommentRoot(list, 'r2') === 'c1');
+  assert(findCommentRoot(list, 'c2') === 'c2');
+  assert(findCommentRoot(list, 'missing') === 'missing');
+  assert(findCommentRoot(list, '') === null);
+  assert(findCommentRoot(null, 'c1') === 'c1');
 });
 
 console.log(`\n${pass} passed, ${fail} failed`);

--- a/test/run.js
+++ b/test/run.js
@@ -46,6 +46,7 @@ const OFFLINE = [
   'comment-upload.test.js',   // local→worker comment merge (non-destructive)
   'comment-ops.test.js',      // #34 DO-serialized mutation ops
   'notifications.test.js',    // inbox aggregation + Reddit recipients
+  'overlay-inbox.test.js',    // #180 inbox click → /d/slug?comment= deep-link
   'p3-hardening.test.js',     // #33 safeParseList + escapeHtml
   'preview-worker.test.js',   // #148 isolated preview Worker (no DO, 14d TTL)
   'csp-headers.test.js',      // CSP header + nonce plumbing (hermetic, no browser)

--- a/test/ui.test.js
+++ b/test/ui.test.js
@@ -465,6 +465,111 @@ async function tPub(name, fn) {
     if (!/\d+ repl(y|ies)/.test(text)) throw new Error(`toggle text was "${text}"`);
   });
 
+  await t('?comment= deep-link opens the target comment card', async () => {
+    const deep = await ctx.newPage();
+    try {
+      const u = URL.replace(/\/?$/, '') + '?comment=c_fixture_1';
+      await deep.goto(u, { waitUntil: 'networkidle' });
+      await deep.waitForFunction(() => document.body.dataset.tdocReady === '1', null, { timeout: 5000 });
+      await deep.waitForTimeout(250);
+      const st = await deep.evaluate(() => {
+        const card = document.querySelector('.tdoc-margin-comment[data-comment-id="c_fixture_1"]');
+        const narrow = document.body.classList.contains('tdoc-narrow');
+        const drawerOpen = !!document.getElementById('tdoc-comment-layer')?.classList.contains('open');
+        return {
+          hasCard: !!card,
+          active: !!(card && card.classList.contains('active')),
+          floating: !!(card && card.classList.contains('tdoc-floating-open')),
+          visible: !!(card && card.getClientRects().length > 0),
+          narrow, drawerOpen,
+        };
+      });
+      if (!st.hasCard) throw new Error('deep-linked comment card missing');
+      if (st.narrow) {
+        if (!st.drawerOpen) throw new Error('narrow deep-link must open the comment drawer');
+      } else if (!st.floating && !st.active) {
+        throw new Error('wide deep-link must pin or activate the card');
+      } else if (!st.visible) {
+        throw new Error('deep-linked card is not visible');
+      }
+    } finally {
+      await deep.close();
+    }
+  });
+
+  await t('?comment= on a reply expands the thread', async () => {
+    const deep = await ctx.newPage();
+    try {
+      const u = URL.replace(/\/?$/, '') + '?comment=r_fixture_1';
+      await deep.goto(u, { waitUntil: 'networkidle' });
+      await deep.waitForFunction(() => document.body.dataset.tdocReady === '1', null, { timeout: 5000 });
+      await deep.waitForTimeout(250);
+      const st = await deep.evaluate(() => {
+        const replies = document.querySelector('.tdoc-replies');
+        const reply = document.querySelector('[data-comment-id="r_fixture_1"]');
+        const card = document.querySelector('.tdoc-margin-comment[data-comment-id="c_fixture_1"]');
+        return {
+          repliesOpen: !!(replies && replies.classList.contains('open')),
+          hasReply: !!reply,
+          cardOpen: !!(card && (card.classList.contains('tdoc-floating-open') || card.classList.contains('active')
+            || document.body.classList.contains('tdoc-narrow'))),
+        };
+      });
+      if (!st.hasReply) throw new Error('reply node missing');
+      if (!st.repliesOpen) throw new Error('reply deep-link must expand the thread');
+      if (!st.cardOpen) throw new Error('reply deep-link must open the root card');
+    } finally {
+      await deep.close();
+    }
+  });
+
+  await t('?comment= on a phone opens the comment drawer', async () => {
+    const deep = await ctx.newPage();
+    try {
+      await deep.setViewportSize({ width: 375, height: 812 });
+      const u = URL.replace(/\/?$/, '') + '?comment=c_fixture_1';
+      await deep.goto(u, { waitUntil: 'networkidle' });
+      await deep.waitForFunction(() => document.body.dataset.tdocReady === '1', null, { timeout: 5000 });
+      await deep.waitForTimeout(250);
+      const st = await deep.evaluate(() => ({
+        narrow: document.body.classList.contains('tdoc-narrow'),
+        drawerOpen: !!document.getElementById('tdoc-comment-layer')?.classList.contains('open'),
+        hasCard: !!document.querySelector('.tdoc-margin-comment[data-comment-id="c_fixture_1"]'),
+      }));
+      if (!st.narrow) throw new Error(`expected tdoc-narrow at 375px, got narrow=${st.narrow}`);
+      if (!st.hasCard) throw new Error('phone deep-link missing comment card');
+      if (!st.drawerOpen) throw new Error('phone deep-link must open the comment drawer');
+    } finally {
+      await deep.close();
+    }
+  });
+
+  await t('Clicking an inbox row does not unpin the open comment card', async () => {
+    // Regression #180: the inbox click used to bubble to the document
+    // "click outside card" handler and immediately close the card it opened.
+    const card = await openFirstCommentCard();
+    if (!card) { console.log('  (no comments, skipping)'); return; }
+    const pinned = await page.evaluate(() => {
+      const c = document.querySelector('.tdoc-margin-comment.tdoc-floating-open, .tdoc-margin-comment.active');
+      if (!c) return false;
+      const bg = document.createElement('div');
+      bg.className = 'tdoc-modal-bg';
+      bg.id = 'tdoc-aux-modal';
+      bg.innerHTML = '<div class="tdoc-modal"><div class="tdoc-cluster-row" id="tdoc-fake-inbox-row" role="button">fake notification</div></div>';
+      document.body.appendChild(bg);
+      return true;
+    });
+    if (!pinned) throw new Error('could not pin a comment card before fake inbox click');
+    await page.click('#tdoc-fake-inbox-row');
+    await page.waitForTimeout(150);
+    const still = await page.evaluate(() => {
+      const c = document.querySelector('.tdoc-margin-comment');
+      return !!(c && (c.classList.contains('tdoc-floating-open') || c.classList.contains('active')));
+    });
+    await page.evaluate(() => document.getElementById('tdoc-aux-modal')?.remove());
+    if (!still) throw new Error('inbox-row click unpinned the open comment card');
+  });
+
   await t('Clicking replies toggle expands replies', async () => {
     await openFirstCommentCard();
     const toggle = await page.$('.tdoc-replies-toggle');

--- a/test/ui.test.js
+++ b/test/ui.test.js
@@ -544,6 +544,57 @@ async function tPub(name, fn) {
     }
   });
 
+  await t('without ?comment= the fixture reply thread stays collapsed', async () => {
+    const deep = await ctx.newPage();
+    try {
+      await deep.goto(URL, { waitUntil: 'networkidle' });
+      await deep.waitForFunction(() => document.body.dataset.tdocReady === '1', null, { timeout: 5000 });
+      await deep.waitForTimeout(250);
+      const st = await deep.evaluate(() => {
+        const replies = document.querySelector('.tdoc-replies');
+        const reply = document.querySelector('[data-comment-id="r_fixture_1"]');
+        return {
+          hasReplies: !!replies,
+          hasReply: !!reply,
+          repliesOpen: !!(replies && replies.classList.contains('open')),
+          repliesDisplay: replies ? getComputedStyle(replies).display : null,
+        };
+      });
+      if (!st.hasReplies || !st.hasReply) throw new Error('fixture reply thread missing');
+      if (st.repliesOpen) throw new Error('replies must start collapsed without ?comment=');
+      if (st.repliesDisplay !== 'none') throw new Error(`expected display:none, got ${st.repliesDisplay}`);
+    } finally {
+      await deep.close();
+    }
+  });
+
+  await t('adding .open on a live replies list reveals the hidden reply', async () => {
+    // Same-doc inbox clicks cannot wait for a rebuild. They have to flip
+    // .tdoc-replies.open on the card that is already in the DOM.
+    // Check the list's own computed display, not the reply's client rects —
+    // in pins mode the parent card is hidden until it is pinned.
+    const deep = await ctx.newPage();
+    try {
+      await deep.goto(URL, { waitUntil: 'networkidle' });
+      await deep.waitForFunction(() => document.body.dataset.tdocReady === '1', null, { timeout: 5000 });
+      await deep.waitForTimeout(250);
+      const st = await deep.evaluate(() => {
+        const replies = document.querySelector('.tdoc-replies');
+        const toggle = document.querySelector('.tdoc-replies-toggle');
+        if (!replies) return { missing: true };
+        const before = getComputedStyle(replies).display;
+        replies.classList.add('open');
+        toggle?.classList.add('open');
+        return { before, after: getComputedStyle(replies).display };
+      });
+      if (st.missing) throw new Error('fixture reply thread missing');
+      if (st.before !== 'none') throw new Error(`expected display:none before .open, got ${st.before}`);
+      if (st.after === 'none') throw new Error('replies stayed display:none after .open');
+    } finally {
+      await deep.close();
+    }
+  });
+
   await t('Clicking an inbox row does not unpin the open comment card', async () => {
     // Regression #180: the inbox click used to bubble to the document
     // "click outside card" handler and immediately close the card it opened.


### PR DESCRIPTION
Fixes #180.

Clicking a notification did not land on the doc or the specific comment.

**Cause.** Two things stacked:

1. Same-doc inbox clicks pinned the card, then the same click bubbled to the document `click-outside` handler and immediately unpinned it.
2. `/me` and `/` had no reliable path to `/d/<slug>/v/<n>?comment=<id>`. `?comment=` also expanded the thread *after* `buildCard`, so a reply deep-link was born collapsed, and phones never opened the comment drawer.

**Fix (overlay, provider-enforced).**

- `inboxTargetUrl` is the only destination builder: `/d/<slug>/v/<n>?comment=<id>`. Empty slug returns `''` (never `/d/undefined`).
- Other-doc / `/me` / `/` clicks `location.assign` that URL.
- Same-doc clicks stay in place, `replaceState` the query, `stopPropagation`, and the unpin handler ignores overlay chrome (`isInUI`).
- `?comment=` marks the thread open *before* `buildCard`, pins the card, and on a phone opens the drawer.

**Verified.**

- `npm test` — 39 offline suites green
- `node test/ui.test.js` — 35 passed, including:
  - `?comment=` opens the target card
  - reply `?comment=` expands the thread
  - phone `?comment=` opens the drawer
  - fake inbox-row click does not unpin an open card