### PR TITLE
Sign-in hands GitHub to a new tab, always

### DIFF
--- a/server/signin.js
+++ b/server/signin.js
@@ -31,6 +31,9 @@
     '.tds-copy{position:absolute;right:10px;bottom:10px;border:1px solid #d3d8e3;background:#fff;color:#10121a;border-radius:8px;padding:6px 13px;font:13px system-ui,-apple-system,sans-serif;font-weight:650;cursor:pointer}',
     '.tds-copy:hover{border-color:#b9c0cd}',
     '.tds-copy.done{background:#1a7340;border-color:#1a7340;color:#fff}',
+    '.tds-open{display:inline-flex;align-items:center;gap:7px;margin:2px 0 12px;background:#1652f0;color:#fff;border-radius:999px;padding:9px 16px;font:14px system-ui,-apple-system,sans-serif;font-weight:650;text-decoration:none}',
+    '.tds-open:hover{background:#0f43cc}',
+    '.tds-open svg{width:15px;height:15px;fill:currentColor}',
     '.tds-status{color:#767c8b;font-size:13px}',
     '.tds-err{color:#c3452f}',
     '.tds-ft{padding:13px 20px;border-top:1px solid #e4e7ee;background:#fafbfd;text-align:right}',
@@ -133,10 +136,33 @@
         cbtn.onclick = copyCode;
         code.onclick = copyCode;
         var uri = d.verification_uri_complete || d.verification_uri;
-        document.getElementById('tds-where').innerHTML =
-          'Paste it at <b>' + esc(d.verification_uri) + '</b> and approve.';
-        if (isGithubHttpsUrl(uri)) window.open(uri, '_blank', 'noopener');
-        status('Waiting for you to approve…');
+        var where = document.getElementById('tds-where');
+        // A native target=_blank anchor is the only hop that every browser
+        // honours: a scripted window.open() fired after this await is outside
+        // the click's activation window, so Safari and in-app webviews either
+        // swallow it or, worse, open it in this tab. Losing this tab loses the
+        // poll below, and the sign-in can never complete. The anchor cannot
+        // navigate the page it sits on.
+        if (isGithubHttpsUrl(uri)) {
+          where.innerHTML = 'Open GitHub and approve. The code is already filled in.'
+            + '<a class="tds-open" id="tds-open" href="' + esc(uri) + '"'
+            + ' target="_blank" rel="noopener noreferrer">'
+            + '<svg viewBox="0 0 24 24" aria-hidden="true"><path d="M12 .297c-6.63 0-12 5.373-12 12 0'
+            + ' 5.303 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61C4.422'
+            + ' 18.07 3.633 17.7 3.633 17.7c-1.087-.744.084-.729.084-.729 1.205.084 1.838 1.236 1.838 1.236 1.07 1.835 2.809 1.305'
+            + ' 3.495.998.108-.776.417-1.305.76-1.605-2.665-.3-5.466-1.332-5.466-5.93 0-1.31.465-2.38 1.235-3.22-.135-.303-.54-1.523.105-3.176'
+            + ' 0 0 1.005-.322 3.3 1.23.96-.267 1.98-.399 3-.405 1.02.006 2.04.138 3 .405 2.28-1.552 3.285-1.23 3.285-1.23.645 1.653.24'
+            + ' 2.873.12 3.176.765.84 1.23 1.91 1.23 3.22 0 4.61-2.805 5.625-5.475 5.92.42.36.81 1.096.81 2.22 0 1.606-.015 2.896-.015'
+            + ' 3.286 0 .315.21.69.825.57C20.565 22.092 24 17.592 24 12.297c0-6.627-5.373-12-12-12"/></svg>Open GitHub</a>';
+          // Try the convenience popup too, but never depend on it.
+          var popped = null;
+          try { popped = window.open(uri, '_blank', 'noopener'); } catch (e) {}
+          if (!popped) status('Click Open GitHub to approve, then come back to this tab.');
+          else status('Waiting for you to approve…');
+        } else {
+          where.innerHTML = 'Paste it at <b>' + esc(d.verification_uri) + '</b> and approve.';
+          status('Waiting for you to approve…');
+        }
 
         var interval = Math.max(5, Number(d.interval) || 5);
         (function poll() {

--- a/test/run.js
+++ b/test/run.js
@@ -35,7 +35,8 @@ const OFFLINE = [
   'tornado-doc-landing.test.js',
   'browser-bundles-parse.test.js', // syntax-check what we inject into pages
   'tdoc-start.test.js',
-  'landing-demo-tabs.test.js', // the homepage demo: four stages, one reader // #142 onboarding: /start page + the modal served with it
+  'landing-demo-tabs.test.js', // the homepage demo: four stages, one reader
+  'signin-github-tab.test.js', // #179: GitHub opens in a new tab, never this one // #142 onboarding: /start page + the modal served with it
   'cli.test.js',              // CLI resilience (drives bash hermetically)
   'no-drift.test.js',         // duplicated-helper drift guard
   'coverage.test.js',         // migration, bundle inlining, pull-merge, rich fold

--- a/test/signin-github-tab.test.js
+++ b/test/signin-github-tab.test.js
@@ -1,0 +1,62 @@
+// #179: the sign-in dialog must hand GitHub off to a new tab, always.
+//
+// The device flow's only route to GitHub used to be a scripted
+// window.open() fired after `await api('/api/auth/device/start')`. That is
+// outside the click's activation window, so Safari and in-app webviews
+// either swallow it — leaving a dialog whose verification URL was plain
+// text with nothing to click — or open it in the current tab. Losing this
+// tab loses the poll loop, and the sign-in can never finish.
+//
+// A native <a target="_blank"> cannot navigate the page it sits on, so the
+// guard here is: the anchor exists, points at the verification URL, and the
+// flow never depends on the popup landing.
+const fs = require('fs');
+const path = require('path');
+
+let pass = 0, fail = 0;
+function ok(n) { console.log(`  ✓ ${n}`); pass++; }
+function bad(n, e) { console.log(`  ✗ ${n}\n    ${e}`); fail++; }
+function t(n, fn) { try { fn(); ok(n); } catch (e) { bad(n, e.message); } }
+function assert(c, m) { if (!c) throw new Error(m || 'assertion failed'); }
+
+const src = fs.readFileSync(path.join(__dirname, '..', 'server', 'signin.js'), 'utf8');
+
+console.log('sign-in hands GitHub to a new tab (#179)');
+
+t('the dialog ships a real anchor to the verification URL', () => {
+  assert(/<a class="tds-open"/.test(src),
+    'no anchor in the dialog: a blocked popup leaves the user with nothing to click');
+  assert(/href="' \+ esc\(uri\) \+ '"/.test(src),
+    'the anchor must point at the verification URL the API returned');
+});
+
+t('the anchor opens a new tab and cannot move the page it sits on', () => {
+  const anchor = src.match(/<a class="tds-open"[\s\S]{0,240}?>/);
+  assert(anchor, 'could not isolate the anchor');
+  assert(/target="_blank"/.test(anchor[0]), 'anchor must target _blank');
+  assert(/rel="noopener noreferrer"/.test(anchor[0]),
+    'anchor must carry noopener noreferrer: the new tab gets no handle on this one');
+});
+
+t('only an https github.com URL is ever linked or opened', () => {
+  assert(/if \(isGithubHttpsUrl\(uri\)\) \{/.test(src),
+    'the anchor and the popup must both sit behind isGithubHttpsUrl');
+});
+
+t('a blocked popup is handled, not assumed away', () => {
+  assert(/popped = window\.open\(uri, '_blank', 'noopener'\)/.test(src),
+    'the convenience popup should still be attempted');
+  assert(/if \(!popped\)/.test(src),
+    'a blocked popup must change the copy; the flow cannot depend on it landing');
+  assert(/try \{ popped = window\.open/.test(src),
+    'window.open can throw in embedded webviews; it must be guarded');
+});
+
+t('the poll keeps running whether or not the popup landed', () => {
+  const after = src.slice(src.indexOf('if (isGithubHttpsUrl(uri))'));
+  assert(/\(function poll\(\)/.test(after),
+    'the poll must start regardless of how the user reaches GitHub');
+});
+
+console.log(`\n${pass} passed, ${fail} failed.`);
+process.exit(fail ? 1 : 0);


### PR DESCRIPTION
Fixes #179

## What was wrong

The device flow's only route to GitHub was a scripted `window.open()` fired
after `await api('/api/auth/device/start')`. That await spends the click's
user activation, so the popup is no longer user-driven. Safari and in-app
webviews either swallow it or open it in the current tab, and both outcomes
are fatal in the same way:

- swallowed: the dialog's verification URL was plain `<b>` text with nothing
  to click, so the reader is stranded with a code and a URL to retype;
- opened in place: the tdoc tab is gone, and it takes the poll loop with it,
  so approving on GitHub can never complete the sign-in. That is the
  "cannot redirect back" in the report.

## Reproduction

Playwright, WebKit and Chromium, with `window.open` refused the way a popup
blocker refuses it:

```
new tabs opened   : 0 []
clickable link    : NONE — the URL is plain text
```

## The fix

The dialog ships a real anchor. A native `target="_blank"` link cannot
navigate the page it sits on, so the tdoc tab is never the thing that moves,
in any browser. After the fix, same worst case:

```
clickable link    : [ 'https://github.com/login/device?user_code=ABCD-1234' ]
click -> new tab  : https://github.com/login?return_to=...
click -> opener   : unchanged (good)
```

The popup is still attempted as a convenience and the copy tells the truth
when it does not land. Both the anchor and the popup stay behind
`isGithubHttpsUrl`, and `window.open` is wrapped because embedded webviews
throw rather than return null.

## Test

`test/signin-github-tab.test.js` — fails 4 of 5 without the fix, passes with
it. 40 suites green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011TPaMk9sTPxsHHPXGze7QB