### PR TITLE
Sign-in: put the device code on the clipboard, not just on screen

### DIFF
--- a/server/signin.js
+++ b/server/signin.js
@@ -118,8 +118,9 @@
         var code = document.getElementById('tds-code');
         code.textContent = d.user_code;
         var cbtn = document.getElementById('tds-copy');
+        var copied = false;
+        function mark() { copied = true; cbtn.textContent = 'Copied'; cbtn.className = 'tds-copy done'; }
         function copyCode() {
-          var mark = function () { cbtn.textContent = 'Copied'; cbtn.className = 'tds-copy done'; };
           if (navigator.clipboard && navigator.clipboard.writeText) {
             navigator.clipboard.writeText(d.user_code).then(mark, function () { selectCode(); });
           } else { selectCode(); }
@@ -135,6 +136,21 @@
         }
         cbtn.onclick = copyCode;
         code.onclick = copyCode;
+
+        // Put the code on the clipboard the moment it exists, so a visitor who
+        // lands on GitHub's login first (which never shows the code) can paste
+        // it without coming back for it — the miss this whole flow is built to
+        // avoid. On desktop the click that opened this modal still counts as
+        // recent activation, so this lands silently and the button reads
+        // "Copied". Where activation is gone (Safari drops it across the
+        // device/start round-trip) it stays quiet: no false "Copied", and the
+        // Open-GitHub tap below copies again from a real gesture. Never fall
+        // back to the "Press Ctrl+C" hint here — that's only honest after a
+        // real click.
+        if (navigator.clipboard && navigator.clipboard.writeText) {
+          navigator.clipboard.writeText(d.user_code).then(mark, function () {});
+        }
+
         var uri = d.verification_uri_complete || d.verification_uri;
         var where = document.getElementById('tds-where');
         // A native target=_blank anchor is the only hop that every browser
@@ -154,6 +170,12 @@
             + ' 0 0 1.005-.322 3.3 1.23.96-.267 1.98-.399 3-.405 1.02.006 2.04.138 3 .405 2.28-1.552 3.285-1.23 3.285-1.23.645 1.653.24'
             + ' 2.873.12 3.176.765.84 1.23 1.91 1.23 3.22 0 4.61-2.805 5.625-5.475 5.92.42.36.81 1.096.81 2.22 0 1.606-.015 2.896-.015'
             + ' 3.286 0 .315.21.69.825.57C20.565 22.092 24 17.592 24 12.297c0-6.627-5.373-12-12-12"/></svg>Open GitHub</a>';
+          // Copy on the tap that leaves for GitHub — the reliable moment, and
+          // the belt to the auto-copy's braces if activation was gone above.
+          // The anchor still navigates; this only seeds the clipboard first.
+          document.getElementById('tds-open').addEventListener('click', function () {
+            if (!copied) copyCode();
+          });
           // Try the convenience popup too, but never depend on it.
           var popped = null;
           try { popped = window.open(uri, '_blank', 'noopener'); } catch (e) {}

--- a/test/ui.test.js
+++ b/test/ui.test.js
@@ -637,15 +637,17 @@ async function tPub(name, fn) {
   await tPub('Clicking + React on anon view triggers sign-in (no picker)', async () => {
     // Anon: should NOT open the emoji picker — should redirect to sign-in modal.
     await page.click('.tdoc-react-add');
-    // Modal appears after the device/start network round-trip (~1-2s).
+    // Modal appears after the device/start network round-trip (~1-2s). It is
+    // the shared server/signin.js dialog (.tds-bg), not the old inline overlay
+    // modal those selectors predate.
     try {
-      await page.waitForSelector('#tdoc-device-modal', { timeout: 5000 });
+      await page.waitForSelector('.tds-bg', { timeout: 5000 });
     } catch {
       throw new Error('expected device-flow modal to appear');
     }
     const picker = await page.$('.tdoc-emoji-picker');
     if (picker) throw new Error('emoji picker opened without sign-in');
-    await page.click('#tdoc-modal-cancel');
+    await page.click('#tds-cancel');
     await page.waitForTimeout(150);
   });
 


### PR DESCRIPTION
Builds on #183 (which gave sign-in a reliable Open-GitHub tab). Rebased onto it — this PR is now just the one thing #183 left out.

## The remaining gap

#183 fixed the *new tab*. But the code is still **copy-only** — it's only ever shown, never placed on the clipboard. Many visitors hit GitHub's **login page first**, which does not display the device code. In the branch where GitHub returns only `verification_uri` (no pre-fill), the visitor has to *paste* the code — so they go **Back** to grab it and lose the auth tab. That's the exact miss the flow exists to prevent.

## The fix

**Auto-copy the code the moment it exists**, layered on #183's design:

- **Desktop:** the click that opened the modal still counts as recent user activation, so the write lands silently — the Copy button reads **"Copied"** with no action needed.
- **iOS Safari** (activation dropped across the `device/start` round-trip): the auto-write is rejected and we stay quiet — no false "Copied", no misleading "Press ⌘C". The **"Open GitHub" tap** then copies the code from a real gesture, so it's on the clipboard when GitHub asks.

`verification_uri_complete` still pre-fills the code, so it's covered three ways: **pre-filled + auto-copied + copied on the tap that leaves.**

Shared module → the overlay comment sign-in, the landing page, and onboarding all get it.

## Verification

- All 40 default test suites green; `tds-copy`, the `Press ⌘C`/`Ctrl+C` fallback, `.tds-bg`, `.tds-open`, and the `tdoc:signedin` event are all preserved.
- Drove both paths in real Chrome against a stubbed device API:
  - **Desktop:** code auto-copies on open (`clipboard = [WDJB-MJHT]`, button "Copied"); `.tds-open` anchor carries the pre-filled URL, `target=_blank`.
  - **iOS Safari:** auto-write rejected → clipboard empty, button stays "Copy"; the **Open-GitHub tap copies the code** (`clipboard = [WDJB-MJHT]`).
- Also fixed two stale selectors in the gated `test/ui.test.js` (`#tdoc-device-modal` → `.tds-bg`, `#tdoc-modal-cancel` → `#tds-cancel`) that predate the shared sign-in module.

🤖 Generated with [Claude Code](https://claude.com/claude-code)