### PR TITLE
Sign-in: let the visitor open GitHub, never open it for them

### DIFF
--- a/server/signin.js
+++ b/server/signin.js
@@ -152,15 +152,22 @@
         }
 
         var uri = d.verification_uri_complete || d.verification_uri;
+        var prefilled = !!d.verification_uri_complete;
         var where = document.getElementById('tds-where');
-        // A native target=_blank anchor is the only hop that every browser
-        // honours: a scripted window.open() fired after this await is outside
-        // the click's activation window, so Safari and in-app webviews either
-        // swallow it or, worse, open it in this tab. Losing this tab loses the
-        // poll below, and the sign-in can never complete. The anchor cannot
-        // navigate the page it sits on.
+        // One hop to GitHub, and the visitor takes it. We deliberately do not
+        // open it for them: a dialog that yanks you to a fresh GitHub tab
+        // the instant it appears reads as a hijack, not a sign-in — and on
+        // desktop that scripted open actually lands, so the visitor is gone
+        // before they've read a word. A native target=_blank anchor is the only
+        // hop every browser honours anyway (a scripted open() after this await
+        // is outside the click's activation window, so Safari and in-app
+        // webviews swallow it or open it in this tab, losing the poll). The tap is a
+        // fresh gesture, so the new tab is allowed on phones too, and it copies
+        // the code as the visitor leaves. The anchor cannot navigate this page.
         if (isGithubHttpsUrl(uri)) {
-          where.innerHTML = 'Open GitHub and approve. The code is already filled in.'
+          where.innerHTML = (prefilled
+              ? 'Open GitHub and approve — the code is already filled in.'
+              : 'Open GitHub, paste the code, and approve.')
             + '<a class="tds-open" id="tds-open" href="' + esc(uri) + '"'
             + ' target="_blank" rel="noopener noreferrer">'
             + '<svg viewBox="0 0 24 24" aria-hidden="true"><path d="M12 .297c-6.63 0-12 5.373-12 12 0'
@@ -170,17 +177,14 @@
             + ' 0 0 1.005-.322 3.3 1.23.96-.267 1.98-.399 3-.405 1.02.006 2.04.138 3 .405 2.28-1.552 3.285-1.23 3.285-1.23.645 1.653.24'
             + ' 2.873.12 3.176.765.84 1.23 1.91 1.23 3.22 0 4.61-2.805 5.625-5.475 5.92.42.36.81 1.096.81 2.22 0 1.606-.015 2.896-.015'
             + ' 3.286 0 .315.21.69.825.57C20.565 22.092 24 17.592 24 12.297c0-6.627-5.373-12-12-12"/></svg>Open GitHub</a>';
-          // Copy on the tap that leaves for GitHub — the reliable moment, and
-          // the belt to the auto-copy's braces if activation was gone above.
-          // The anchor still navigates; this only seeds the clipboard first.
+          // The tap copies the code (reliable gesture, and the belt to the
+          // auto-copy's braces if activation was gone above) and flips the
+          // status to waiting; the anchor itself opens the tab.
           document.getElementById('tds-open').addEventListener('click', function () {
             if (!copied) copyCode();
+            status('Waiting for you to approve…');
           });
-          // Try the convenience popup too, but never depend on it.
-          var popped = null;
-          try { popped = window.open(uri, '_blank', 'noopener'); } catch (e) {}
-          if (!popped) status('Click Open GitHub to approve, then come back to this tab.');
-          else status('Waiting for you to approve…');
+          status('Click Open GitHub to approve, then come back to this tab.');
         } else {
           where.innerHTML = 'Paste it at <b>' + esc(d.verification_uri) + '</b> and approve.';
           status('Waiting for you to approve…');

--- a/test/signin-github-tab.test.js
+++ b/test/signin-github-tab.test.js
@@ -1,4 +1,4 @@
-// #179: the sign-in dialog must hand GitHub off to a new tab, always.
+// #179: the sign-in dialog hands GitHub off to a new tab the visitor opens.
 //
 // The device flow's only route to GitHub used to be a scripted
 // window.open() fired after `await api('/api/auth/device/start')`. That is
@@ -7,9 +7,13 @@
 // text with nothing to click — or open it in the current tab. Losing this
 // tab loses the poll loop, and the sign-in can never finish.
 //
-// A native <a target="_blank"> cannot navigate the page it sits on, so the
-// guard here is: the anchor exists, points at the verification URL, and the
-// flow never depends on the popup landing.
+// #179 answered that with a native <a target="_blank"> AND an auto
+// window.open() "convenience popup". The popup was the mistake: on desktop it
+// lands, so the dialog yanks the visitor to a GitHub tab the instant it opens
+// — reads as a hijack, not a sign-in. So the anchor is now the ONLY hop, and
+// the visitor takes it. The guard: the anchor exists, points at the
+// verification URL, cannot navigate this page, and nothing opens GitHub for
+// the visitor.
 const fs = require('fs');
 const path = require('path');
 
@@ -43,16 +47,19 @@ t('only an https github.com URL is ever linked or opened', () => {
     'the anchor and the popup must both sit behind isGithubHttpsUrl');
 });
 
-t('a blocked popup is handled, not assumed away', () => {
-  assert(/popped = window\.open\(uri, '_blank', 'noopener'\)/.test(src),
-    'the convenience popup should still be attempted');
-  assert(/if \(!popped\)/.test(src),
-    'a blocked popup must change the copy; the flow cannot depend on it landing');
-  assert(/try \{ popped = window\.open/.test(src),
-    'window.open can throw in embedded webviews; it must be guarded');
+t('nothing opens GitHub for the visitor — they tap the anchor', () => {
+  // A dialog that auto-opens a GitHub tab the instant it appears reads as a
+  // hijack; on desktop the scripted open lands and the visitor is gone before
+  // reading anything. The anchor tap is the only hop.
+  assert(!/window\.open\(/.test(src),
+    'the dialog must not open GitHub itself; the visitor taps the anchor');
+  assert(/getElementById\('tds-open'\)\.addEventListener\('click'/.test(src),
+    'the anchor tap must be wired: it copies the code as the visitor leaves');
+  assert(/Click Open GitHub to approve/.test(src),
+    'the status must point the visitor at the Open GitHub button');
 });
 
-t('the poll keeps running whether or not the popup landed', () => {
+t('the poll keeps running however the visitor reaches GitHub', () => {
   const after = src.slice(src.indexOf('if (isGithubHttpsUrl(uri))'));
   assert(/\(function poll\(\)/.test(after),
     'the poll must start regardless of how the user reaches GitHub');


### PR DESCRIPTION
Follow-up to #183/#184. Fixes the "why did it just throw me to GitHub?" confusion.

## The problem

#179 gave the sign-in dialog a real **Open GitHub** anchor *and* an auto `window.open()` "convenience popup" beside it. On desktop that popup **lands**, so the dialog yanks you into a GitHub tab the instant it appears — before you've read the code or understood what's happening. It reads as a hijack, not a sign-in. (Reported first-hand: "自动跳转我都是蒙蔽的" — even with the code auto-copied, the auto-jump is disorienting.)

## The fix

**Drop the auto-open. The anchor is the only hop, and the visitor takes it.**

- Until they tap, the dialog just sits there: code already on the clipboard ("Copied"), and a clear **"Click Open GitHub to approve, then come back to this tab."** prompt.
- The **tap** is a fresh gesture (so the new tab is allowed on phones too), copies the code as they leave, and flips the status to "Waiting…".
- The poll runs the whole time, so approval still lands back on its own — nobody has to hunt for the tab.

Also stops claiming *"the code is already filled in"* when GitHub returned no `verification_uri_complete` — it says **"Open GitHub, paste the code, and approve."** in that case, so nobody arrives on GitHub expecting a pre-filled field that isn't there. (I hit exactly this on the #184 preview: the button pointed at plain `github.com/login/device`.)

## Tests

`test/signin-github-tab.test.js` (#179) had **pinned the popup as required**. Flipped it to guard the opposite intent: nothing opens GitHub for the visitor; the anchor tap is the only hop and it's wired to copy + flip status. All 40 offline suites green.

## Verified in a browser
- **On dialog open:** `window.open` calls = **0** (no hijack); code auto-copied; status = "Click Open GitHub to approve…".
- **After tapping Open GitHub:** still no scripted open (native `target=_blank`); status → "Waiting for you to approve…"; href carries the pre-filled code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)