### PR TITLE
Add a web OAuth redirect flow for browsers, alongside device flow

### DIFF
--- a/server/signin.js
+++ b/server/signin.js
@@ -76,6 +76,19 @@
   }
 
   function run() {
+    var cfg = window.__TDOC__ || {};
+    // Web redirect flow: hand the whole tab to GitHub and let it bring the
+    // visitor back already signed in — the callback sets the cookie and 302s
+    // to `return`. This is the path phones need: no device code to copy, no
+    // second tab to find, no GitHub "Congratulations" dead end. The device-code
+    // modal below is the fallback when no client secret is configured
+    // (cfg.webAuth false) and for anything without a browser (the CLI). On this
+    // path the page navigates away, so the promise intentionally never settles.
+    if (cfg.webAuth) {
+      var ret = cfg.signinReturn || (location.pathname + location.search + location.hash);
+      location.href = '/api/auth/web/login?return=' + encodeURIComponent(ret);
+      return new Promise(function () {});
+    }
     styles();
     return new Promise(function (resolve, reject) {
       var timer = null, done = false;

--- a/shared/github-oauth.js
+++ b/shared/github-oauth.js
@@ -1,11 +1,17 @@
-// Single source of truth: org-owned GitHub OAuth App for Device Flow
-// commenter login on published docs. Owned by github.com/tornado-doc.
-// Client ID is public; tdoc does not use a client secret for device flow.
+// Single source of truth: org-owned GitHub OAuth App for commenter login on
+// published docs. Owned by github.com/tornado-doc. Client ID is public.
+//
+// Two flows share this App:
+//   - Device flow (CLIs, and the fallback when no secret is set) — no secret.
+//   - Web redirect flow (browsers) — needs a client secret, injected out of
+//     band as the GITHUB_CLIENT_SECRET worker secret (never in git). Set the
+//     App's Authorization callback URL to https://<host>/auth/github/callback
+//     for the redirect flow (a device approve may still bounce to /auth/done,
+//     which stays a friendly static page).
 //
 // Consumers: worker/wrangler.toml.template (literal must match this module —
 // enforced by test/no-drift.test.js), vercel/api/tdoc.js via
-// vercel/lib/github-oauth.js. Set the OAuth App's Authorization callback URL
-// to https://<host>/auth/done so GitHub's post-authorize redirect is not a 404.
+// vercel/lib/github-oauth.js.
 
 module.exports = {
   GITHUB_CLIENT_ID: 'Ov23li1jJiBkS23x4O07',

--- a/test/run.js
+++ b/test/run.js
@@ -37,6 +37,7 @@ const OFFLINE = [
   'tdoc-start.test.js',
   'landing-demo-tabs.test.js', // the homepage demo: four stages, one reader
   'signin-github-tab.test.js', // #179: GitHub opens in a new tab, never this one // #142 onboarding: /start page + the modal served with it
+  'web-oauth.test.js',        // web redirect flow: sanitizeReturn open-redirect guard + flow wiring + device fallback
   'cli.test.js',              // CLI resilience (drives bash hermetically)
   'no-drift.test.js',         // duplicated-helper drift guard
   'coverage.test.js',         // migration, bundle inlining, pull-merge, rich fold

--- a/test/web-oauth.test.js
+++ b/test/web-oauth.test.js
@@ -1,0 +1,117 @@
+// Web OAuth redirect flow (browsers), alongside the existing device flow.
+//
+// Device flow strands phone users: after Approve they sit on GitHub's
+// "Congratulations" page while the tab that was polling is somewhere they
+// can't find. The redirect flow hands the whole tab to GitHub and GitHub sends
+// it back signed in. This guards the security-critical piece (the post-login
+// redirect target can't be pointed off-site) with real behaviour, and pins the
+// structure so the flow — and its safe fallback to device flow — can't silently
+// regress.
+//
+// Run with: node test/web-oauth.test.js
+
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+
+let pass = 0, fail = 0;
+function ok(n) { console.log(`  ✓ ${n}`); pass++; }
+function bad(n, e) { console.log(`  ✗ ${n}\n    ${e}`); fail++; }
+function t(n, fn) { try { fn(); ok(n); } catch (e) { bad(n, e.message); } }
+function assert(c, m) { if (!c) throw new Error(m || 'assertion failed'); }
+
+const worker = fs.readFileSync(path.join(__dirname, '..', 'worker', 'worker.js'), 'utf8');
+const signin = fs.readFileSync(path.join(__dirname, '..', 'server', 'signin.js'), 'utf8');
+const tomlProd = fs.readFileSync(path.join(__dirname, '..', 'worker', 'wrangler.toml.template'), 'utf8');
+const tomlPrev = fs.readFileSync(path.join(__dirname, '..', 'worker', 'wrangler.preview.toml.template'), 'utf8');
+
+// VM-extract sanitizeReturn from worker.js so we test its real behaviour, not a
+// copy. (Same approach as overlay-pure.test.js.)
+function sliceFn(src, name) {
+  const start = src.indexOf(`function ${name}(`);
+  if (start === -1) throw new Error(`fn ${name} not found`);
+  let i = src.indexOf('{', start), depth = 0;
+  for (; i < src.length; i++) {
+    if (src[i] === '{') depth++;
+    else if (src[i] === '}') { depth--; if (depth === 0) { i++; break; } }
+  }
+  return src.slice(start, i);
+}
+const box = {};
+vm.createContext(box);
+vm.runInContext(sliceFn(worker, 'sanitizeReturn'), box);
+const { sanitizeReturn } = box;
+
+console.log('web OAuth redirect flow');
+
+// --- sanitizeReturn: the open-redirect guard ---
+t('same-origin paths pass through untouched', () => {
+  assert(sanitizeReturn('/d/conway-life/v/2') === '/d/conway-life/v/2', 'doc path');
+  assert(sanitizeReturn('/me') === '/me', '/me');
+  assert(sanitizeReturn('/?notice=x') === '/?notice=x', 'query kept');
+});
+
+t('off-site and protocol-relative targets are refused', () => {
+  assert(sanitizeReturn('//evil.com') === '/', 'protocol-relative //');
+  assert(sanitizeReturn('https://evil.com') === '/', 'absolute https');
+  assert(sanitizeReturn('http://evil.com') === '/', 'absolute http');
+  assert(sanitizeReturn('/\\evil.com') === '/', 'backslash smuggling');
+  assert(sanitizeReturn('javascript:alert(1)') === '/', 'scheme');
+});
+
+t('empty / non-string / control chars fall back to root', () => {
+  assert(sanitizeReturn('') === '/', 'empty');
+  assert(sanitizeReturn(null) === '/', 'null');
+  assert(sanitizeReturn(undefined) === '/', 'undefined');
+  assert(sanitizeReturn('/a\nb') === '/', 'newline');
+  assert(sanitizeReturn('/a\x00b') === '/', 'NUL');
+});
+
+// --- structure: the redirect flow exists and is wired correctly ---
+t('the worker serves the authorize redirect and the token-exchange callback', () => {
+  assert(/p === '\/api\/auth\/web\/login'/.test(worker), 'no /api/auth/web/login route');
+  assert(/login\/oauth\/authorize/.test(worker), 'never sends the visitor to GitHub authorize');
+  assert(/p === '\/auth\/github\/callback'/.test(worker), 'no callback route');
+  assert(/client_secret: env\.GITHUB_CLIENT_SECRET/.test(worker),
+    'the callback must exchange the code using the client secret');
+});
+
+t('the callback is CSRF-guarded and mints the same session as device flow', () => {
+  assert(/tdoc_oauth=/.test(worker), 'no state cookie for CSRF');
+  assert(/oauthstate:/.test(worker), 'no server-side state/return record');
+  assert(/state !== cookieNonce/.test(worker), 'state is not checked against the cookie');
+  assert(/session:\$\{sid\}/.test(worker) && /tdoc_sid=\$\{sid\}/.test(worker),
+    'the callback must mint the same tdoc_sid session');
+});
+
+t('a callback with no code stays a friendly static page (device soft-landing)', () => {
+  assert(/if \(!code\) return html\(authDoneHtml\(\)\)/.test(worker),
+    'a code-less callback must not error — it is the device-flow soft landing');
+});
+
+// --- graceful fallback: no secret ⇒ device flow, nothing breaks ---
+t('web flow is gated on the secret so a deploy without it keeps device flow', () => {
+  assert(/if \(!env\.GITHUB_CLIENT_SECRET\)/.test(worker),
+    'the worker must guard the web routes on the secret');
+  assert(/webAuth: !!webAuth/.test(worker) || /webAuth: !!env\.GITHUB_CLIENT_SECRET/.test(worker),
+    'the page cfg must expose webAuth from the secret');
+});
+
+t('signin.js takes the redirect when webAuth is on, else the device modal', () => {
+  assert(/cfg\.webAuth/.test(signin), 'signin.js does not branch on webAuth');
+  assert(/\/api\/auth\/web\/login\?return=/.test(signin),
+    'signin.js does not hand off to the web login route');
+  assert(/tds-code/.test(signin), 'the device-code modal must remain as the fallback');
+});
+
+t('both wrangler templates document GITHUB_CLIENT_SECRET as a secret, not a var', () => {
+  for (const [name, toml] of [['prod', tomlProd], ['preview', tomlPrev]]) {
+    assert(/wrangler secret put GITHUB_CLIENT_SECRET/.test(toml),
+      `${name} template must document the secret via 'wrangler secret put'`);
+    assert(!/^\s*GITHUB_CLIENT_SECRET\s*=/m.test(toml),
+      `${name} template must NOT put the secret in [vars]`);
+  }
+});
+
+console.log(`\n${pass} passed, ${fail} failed.`);
+process.exit(fail ? 1 : 0);

--- a/worker/worker.js
+++ b/worker/worker.js
@@ -1036,7 +1036,7 @@ function injectReaderCss(html, css) {
   return tag + html;
 }
 
-function injectOverlay(rawHtml, slug, version, identity, versions, isOwner, ownerManage, nonce, isLanding, canSeeMyDocsFlag, isCatalog) {
+function injectOverlay(rawHtml, slug, version, identity, versions, isOwner, ownerManage, nonce, isLanding, canSeeMyDocsFlag, isCatalog, webAuth) {
   // The onboarding modal is product UI, so it ships from here under the page
   // nonce. The doc's own <script> would never run (#138), which is why the
   // landing CTA still carries a plain href: with scripting off the visitor
@@ -1065,6 +1065,9 @@ function injectOverlay(rawHtml, slug, version, identity, versions, isOwner, owne
     // the overlay's `if (!cfg.ownerManage) return;` guard is unambiguous.
     ownerManage: isOwner ? (ownerManage || null) : null,
     authConfigured: true,
+    // When the client secret is set, browsers use the redirect flow (signin.js
+    // sends them to /api/auth/web/login) instead of the device-code modal.
+    webAuth: !!webAuth,
     mode: 'published',
     versions: Array.isArray(versions) && versions.length ? versions : [{ n: version }],
   }, nonce);
@@ -1136,7 +1139,7 @@ async function serveDocVersion(env, req, slug, version, isLanding) {
   const nonce = rand(16);
   return {
     ok: true,
-    response: html(injectOverlay(raw, slug, version, identity, versions, isOwner, ownerManage, nonce, isLanding, canSeeMyDocs(env, session, requestOrigin(req))), {
+    response: html(injectOverlay(raw, slug, version, identity, versions, isOwner, ownerManage, nonce, isLanding, canSeeMyDocs(env, session, requestOrigin(req)), false, !!env.GITHUB_CLIENT_SECRET), {
       headers: { 'Content-Security-Policy': cspHeader(nonce) },
     }),
   };
@@ -1171,6 +1174,7 @@ async function landingResponse(env, req, slug = LANDING_SLUG) {
 // bounce users here from /me or an unknown path.
 function landingHtml(env, notice) {
   const authOk = !!(env && String(env.GITHUB_CLIENT_ID || '').trim());
+  const authWeb = !!(env && env.GITHUB_CLIENT_SECRET);
   const toastMsg = ({
     me: 'My docs is only available after you sign in as the worker owner.',
     signin: 'Sign in with GitHub to continue.',
@@ -1210,10 +1214,12 @@ function landingHtml(env, notice) {
   <p class="sub">Open a document from its shared link ·
     <a href="https://github.com/tornado-doc/tdoc">github.com/tornado-doc/tdoc</a></p>
   <div id="toast" role="status" aria-live="polite"></div>
+<script>window.__TDOC__ = { authConfigured: true, webAuth: ${authWeb ? 'true' : 'false'}, signinReturn: '/me' };</script>
 <script>${SIGNIN_JS}</script>
 <script>
-  // One shared device flow (server/signin.js). This page used to carry its own
-  // copy with its own retry loop and its own error strings.
+  // One shared sign-in (server/signin.js): web redirect flow when webAuth is on,
+  // else the device-code modal. On the redirect path __tdocSignIn navigates away
+  // and never resolves, so the .then below only runs on the device path.
   (function () {
     var btn = document.getElementById('signin');
     if (!btn || !window.__tdocSignIn) return;
@@ -1241,6 +1247,47 @@ function authDoneHtml() {
   <h1>You're signed in</h1>
   <p>You can close this tab and return to tdoc.</p>
 </body></html>`;
+}
+
+// Web OAuth redirect flow (browsers). Device flow stays for CLIs; this is the
+// hop that phones need — GitHub sends the visitor straight back here after
+// Approve, so nobody is stranded on GitHub's "Congratulations" page. Active
+// only when GITHUB_CLIENT_SECRET is set (the token exchange requires it), so a
+// deploy without the secret silently keeps the device flow.
+function authErrorHtml(msg) {
+  const safe = String(msg || 'Sign-in failed.').replace(/[<>&]/g, (c) => ({ '<': '&lt;', '>': '&gt;', '&': '&amp;' })[c]);
+  return `<!doctype html><html><head><meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>tdoc — sign-in</title>
+<style>
+  body { font: 15px system-ui, -apple-system, sans-serif; min-height: 100vh; margin: 0;
+    display: flex; flex-direction: column; align-items: center; justify-content: center;
+    color: #111; background: #fff; gap: 8px; text-align: center; padding: 0 20px; }
+  h1 { font-size: 22px; margin: 0; color: #c3452f; }
+  p { color: #666; margin: 0; }
+  a { color: #1652f0; }
+</style></head><body>
+  <h1>Sign-in failed</h1>
+  <p>${safe}</p>
+  <p><a href="/">Back to tdoc</a></p>
+</body></html>`;
+}
+
+// Only ever redirect to a same-origin path we produced. Reject absolute URLs
+// and protocol-relative (`//evil.com`) targets so a crafted `?return=` can't
+// bounce a signed-in visitor off-site. Falls back to the site root.
+function sanitizeReturn(raw) {
+  if (typeof raw !== 'string' || !raw) return '/';
+  if (raw[0] !== '/' || raw[1] === '/' || raw[1] === '\\') return '/';
+  if (/[\x00-\x1f]/.test(raw)) return '/';
+  return raw;
+}
+
+// 302 that can also set cookies — no existing helper does both at once.
+function redirectTo(location, cookies) {
+  const h = new Headers({ Location: location });
+  (cookies || []).forEach((c) => h.append('Set-Cookie', c));
+  return new Response(null, { status: 302, headers: h });
 }
 
 // /me — the owner's doc catalog. JUL-36 tail (2026-08-13): this used to be a
@@ -2976,10 +3023,54 @@ export default {
       return landingResponse(env, req, START_SLUG);
     }
 
-    // Soft landing for the OAuth App "Authorization callback URL". Device
-    // Flow does not need a callback, but GitHub may still redirect here
-    // after Approve — serve a friendly page instead of a 404.
-    if ((p === '/auth/done' || p === '/auth/github/callback') && method === 'GET') {
+    // Web OAuth callback. With a `code` this is the redirect flow: exchange it
+    // for a token (needs the client secret), mint the same session the device
+    // flow does, and 302 the visitor back to the page they started from — one
+    // tab, no "Congratulations" dead end. Without a code it's the device-flow
+    // soft landing GitHub may bounce to after Approve; keep the friendly page.
+    if (p === '/auth/github/callback' && method === 'GET') {
+      const code = url.searchParams.get('code');
+      if (!code) return html(authDoneHtml());
+      const state = url.searchParams.get('state');
+      const cookieNonce = (/tdoc_oauth=([a-f0-9]+)/.exec(req.headers.get('cookie') || '') || [])[1];
+      if (!state || !cookieNonce || state !== cookieNonce) {
+        return html(authErrorHtml('Sign-in could not be verified (state mismatch). Please try again.'), { status: 400 });
+      }
+      if (!env.GITHUB_CLIENT_SECRET) {
+        return html(authErrorHtml('Web sign-in is not configured on this host.'), { status: 500 });
+      }
+      const ret = sanitizeReturn(await env.META.get(`oauthstate:${state}`));
+      await env.META.delete(`oauthstate:${state}`);
+      try {
+        const r = await ghPost('/login/oauth/access_token', {
+          client_id: env.GITHUB_CLIENT_ID,
+          client_secret: env.GITHUB_CLIENT_SECRET,
+          code,
+          redirect_uri: `${url.origin}/auth/github/callback`,
+        });
+        if (r.error || !r.access_token) {
+          return html(authErrorHtml('GitHub sign-in failed: ' + (r.error_description || r.error || 'no token returned')), { status: 400 });
+        }
+        const user = await ghUser(r.access_token);
+        if (!user.login) return html(authErrorHtml('GitHub returned no account.'), { status: 500 });
+        const sid = rand(24);
+        const session = {
+          login: user.login,
+          avatar_url: user.avatar_url,
+          name: user.name || user.login,
+          created: new Date().toISOString(),
+        };
+        await env.META.put(`session:${sid}`, JSON.stringify(session), { expirationTtl: 60 * 60 * 24 * 30 });
+        return redirectTo(ret, [
+          `tdoc_sid=${sid}; Path=/; HttpOnly; Secure; SameSite=Lax; Max-Age=${60 * 60 * 24 * 30}`,
+          'tdoc_oauth=; Path=/; Max-Age=0',
+        ]);
+      } catch (e) {
+        return html(authErrorHtml('Sign-in error: ' + e.message), { status: 500 });
+      }
+    }
+    // Static soft landing (device flow, or the OAuth App's callback URL).
+    if (p === '/auth/done' && method === 'GET') {
       return html(authDoneHtml());
     }
 
@@ -3001,7 +3092,7 @@ export default {
       const nonce = rand(16);
       const page = await indexHtml(env, s, url.origin, nonce);
       const identity = { login: s.login, avatar_url: s.avatar_url, name: s.name };
-      return html(injectOverlay(page, '', 0, identity, [], false, null, nonce, false, true, true), {
+      return html(injectOverlay(page, '', 0, identity, [], false, null, nonce, false, true, true, !!env.GITHUB_CLIENT_SECRET), {
         headers: { 'Content-Security-Policy': cspHeader(nonce) },
       });
     }
@@ -3287,6 +3378,25 @@ export default {
         canSeeMyDocs: canSeeMyDocs(env, s, url.origin),
         authConfigured: true,
       });
+    }
+
+    // Web redirect flow, step 1: stash where to land afterwards against a CSRF
+    // nonce, then send the browser to GitHub's authorize page. The browser only
+    // reaches here when cfg.webAuth is on (secret configured); the guard keeps a
+    // stray hit from 500ing.
+    if (p === '/api/auth/web/login' && method === 'GET') {
+      if (!env.GITHUB_CLIENT_SECRET) return redirectTo('/?notice=signin');
+      const ret = sanitizeReturn(url.searchParams.get('return'));
+      const nonce = rand(16);
+      await env.META.put(`oauthstate:${nonce}`, ret, { expirationTtl: 600 });
+      const gh = new URL('https://github.com/login/oauth/authorize');
+      gh.searchParams.set('client_id', env.GITHUB_CLIENT_ID);
+      gh.searchParams.set('redirect_uri', `${url.origin}/auth/github/callback`);
+      gh.searchParams.set('scope', 'read:user');
+      gh.searchParams.set('state', nonce);
+      return redirectTo(gh.toString(), [
+        `tdoc_oauth=${nonce}; Path=/; HttpOnly; Secure; SameSite=Lax; Max-Age=600`,
+      ]);
     }
 
     if (p === '/api/auth/device/start' && method === 'POST') {

--- a/worker/worker.js
+++ b/worker/worker.js
@@ -3032,7 +3032,9 @@ export default {
       const code = url.searchParams.get('code');
       if (!code) return html(authDoneHtml());
       const state = url.searchParams.get('state');
-      const cookieNonce = (/tdoc_oauth=([a-f0-9]+)/.exec(req.headers.get('cookie') || '') || [])[1];
+      // Anchor to a cookie-pair boundary so a cookie merely ending in
+      // "tdoc_oauth" (e.g. "xtdoc_oauth=") can't supply the nonce.
+      const cookieNonce = (/(?:^|;\s*)tdoc_oauth=([a-f0-9]+)/.exec(req.headers.get('cookie') || '') || [])[1];
       if (!state || !cookieNonce || state !== cookieNonce) {
         return html(authErrorHtml('Sign-in could not be verified (state mismatch). Please try again.'), { status: 400 });
       }

--- a/worker/wrangler.preview.toml.template
+++ b/worker/wrangler.preview.toml.template
@@ -30,4 +30,8 @@ TDOC_OWNER = ""
 TDOC_PREVIEW = "1"
 
 # Secret: TDOC_UPLOAD_TOKEN — preview-only; never the production token.
+# Secret: GITHUB_CLIENT_SECRET — set via `wrangler secret put GITHUB_CLIENT_SECRET`
+#   for the web OAuth redirect flow. Generate it on the SAME OAuth App as the
+#   preview GITHUB_CLIENT_ID above, with callback URL
+#   https://<preview-host>/auth/github/callback. Unset ⇒ device-code flow.
 # TDOC_HOSTED_REGISTRATION — leave unset.

--- a/worker/wrangler.toml.template
+++ b/worker/wrangler.toml.template
@@ -36,5 +36,10 @@ GITHUB_CLIENT_ID = "Ov23li1jJiBkS23x4O07"
 TDOC_OWNER = "PLACEHOLDER_OWNER"
 
 # Secret: TDOC_UPLOAD_TOKEN — set via `wrangler secret put TDOC_UPLOAD_TOKEN`
+# Secret: GITHUB_CLIENT_SECRET — set via `wrangler secret put GITHUB_CLIENT_SECRET`.
+#   The web OAuth redirect flow (browsers) needs it to exchange the code for a
+#   token; generate it on the SAME OAuth App as GITHUB_CLIENT_ID above, and set
+#   that App's Authorization callback URL to https://<host>/auth/github/callback.
+#   Leave unset to keep the device-code flow (no browser redirect).
 # TDOC_HOSTED_REGISTRATION — leave unset on BYOK so /me stays single-owner.
 # Unset + hostname https://tdoc.dev enables hosted signup; set to "0" to force off.


### PR DESCRIPTION
Fixes the phone dead-end from the last thread: after Approve, device flow leaves you on GitHub's "Congratulations, you're all set" page while the polling tab is a stacked tab you can't find — so you never get back to tdoc. Device flow is for input-constrained devices (TVs, CLIs); a phone browser is neither.

## What this adds

The flow browsers should use: **click sign-in → whole tab goes to GitHub → GitHub redirects back → worker exchanges the code for a token → mints the same session → 302s you back to the exact page you started on.** One tab, no code to copy, no dead end.

- **`GET /api/auth/web/login`** — stashes the post-login return path against a CSRF nonce (`tdoc_oauth` cookie + `oauthstate:` KV, 10-min TTL), redirects to GitHub authorize. The return path is server-side only — never passed through GitHub.
- **`/auth/github/callback`** — with a `code`: verifies `state == cookie nonce`, exchanges via `client_secret`, mints the same `tdoc_sid` session the device poll does, 302s to `sanitizeReturn(storedReturn)`. Without a code: stays the friendly static soft-landing (a device approve can still bounce here).
- **`sanitizeReturn()`** — same-origin paths only; rejects `//host`, absolute URLs, backslash smuggling, control chars → `/`. Real unit coverage in `test/web-oauth.test.js`.

## Safe by default — gated on the secret

The web flow is active **only when `GITHUB_CLIENT_SECRET` is set**. Unset ⇒ `webAuth:false` ⇒ `signin.js` keeps the device-code modal. **So merging this changes nothing until the secret is configured**; the CLI always stays on device flow.

Verified on a preview with **no secret**: `webAuth:false`, `/api/auth/web/login` safely 302s to the landing page (no 500), `/api/auth/device/start` still issues codes. Fallback intact.

## To turn it on (out of band, per host)

1. On the OAuth App (same one as `GITHUB_CLIENT_ID`), generate a **client secret** and set the **Authorization callback URL** to `https://<host>/auth/github/callback`.
2. `wrangler secret put GITHUB_CLIENT_SECRET` on that worker.

Documented in both wrangler templates as a `wrangler secret put` (never a `[vars]` entry).

## Tests
41 suites green, incl. new `test/web-oauth.test.js` (open-redirect guard + flow wiring + device fallback). `signin-github-tab.test.js` still green (device modal preserved as fallback).

🤖 Generated with [Claude Code](https://claude.com/claude-code)