### PR TITLE
fix: park the comment popup at the selection end, not the line origin

### DIFF
--- a/server/overlay.js
+++ b/server/overlay.js
@@ -120,6 +120,55 @@
     box.style.height = (r.height + inset * 2) + 'px';
   }
 
+  // Range.getBoundingClientRect() is the UNION of every line box. A wrapped
+  // selection is therefore a tall rectangle whose bottom-left is nowhere near
+  // the caret; WebKit also sometimes returns a 0×0 rect when the range
+  // crosses a block. The new-comment popup and pin Y used that union, so the
+  // card "sometimes" sat off the highlight. Prefer the live line box.
+  function isVisibleClientRect(r) {
+    return !!r && (r.width > 0 || r.height > 0);
+  }
+  function nearestClientRect(rects, x, y) {
+    let best = null, bestD = Infinity;
+    const list = rects && rects.length != null ? rects : [];
+    for (let i = 0; i < list.length; i++) {
+      const r = list[i];
+      if (!isVisibleClientRect(r)) continue;
+      const dx = x - Math.max(r.left, Math.min(x, r.right));
+      const dy = y - Math.max(r.top, Math.min(y, r.bottom));
+      const d = dx * dx + dy * dy;
+      if (d < bestD) { bestD = d; best = r; }
+    }
+    return best;
+  }
+  function firstVisibleClientRect(target) {
+    if (!target) return null;
+    if (target.getClientRects) {
+      const rects = target.getClientRects();
+      for (let i = 0; i < rects.length; i++) {
+        if (isVisibleClientRect(rects[i])) return rects[i];
+      }
+    }
+    if (!target.getBoundingClientRect) return null;
+    const r = target.getBoundingClientRect();
+    return isVisibleClientRect(r) ? r : null;
+  }
+  function clientRectNearPoint(target, x, y) {
+    if (!target) return null;
+    if (target.getClientRects && Number.isFinite(x) && Number.isFinite(y)) {
+      const near = nearestClientRect(target.getClientRects(), x, y);
+      if (near) return near;
+    }
+    return firstVisibleClientRect(target);
+  }
+  // A zero-width box on `line` at x — the caret / mouse-up, not the line origin.
+  function endRectOnLine(line, x) {
+    if (!line) return null;
+    const left = Number.isFinite(x) ? x : line.right;
+    const height = line.height || (line.bottom - line.top) || 0;
+    return { left, right: left, top: line.top, bottom: line.bottom, width: 0, height };
+  }
+
   // ========== Styles ==========
   // Each logical group is one comment block; rules within a group are tightly
   // packed. The narrow visual mode lives at the bottom and overrides base.
@@ -2237,7 +2286,7 @@
     const mark = state.anchorMarks.get(c.id);
     if (mark && (mark.ranges?.[0] || mark.el)) {
       const target = mark.ranges?.[0] || mark.el;
-      const r = target.getBoundingClientRect();
+      const r = firstVisibleClientRect(target) || target.getBoundingClientRect();
       // For element anchors expose the element + its rect so renderPins can
       // spread multiple comments DOWN a tall element instead of stacking them
       // all at its top edge. (targetEl is the live element; el may be the outline.)
@@ -2592,9 +2641,9 @@
     let anchorRect = null;
     // Prefer the underlying TARGET ELEMENT (canvas/img/video etc) over the
     // overlay outline div — same rect, but more semantically correct.
-    if (mark.ranges?.[0]) anchorRect = mark.ranges[0].getBoundingClientRect();
-    else if (mark.targetEl?.getBoundingClientRect) anchorRect = mark.targetEl.getBoundingClientRect();
-    else if (mark.el?.getBoundingClientRect) anchorRect = mark.el.getBoundingClientRect();
+    if (mark.ranges?.[0]) anchorRect = firstVisibleClientRect(mark.ranges[0]);
+    else if (mark.targetEl) anchorRect = firstVisibleClientRect(mark.targetEl);
+    else if (mark.el) anchorRect = firstVisibleClientRect(mark.el);
     if (!anchorRect) return;
 
     // We consider the anchor "comfortably visible" if its top is between the
@@ -3273,13 +3322,18 @@
     // body. The caller signals this by setting anchor._placeAbove = true.
     document.body.appendChild(popup);   // append first so offsetHeight is known
     const popupH = popup.offsetHeight || 140;
+    const popupW = popup.offsetWidth || 320;
     if (anchor._placeAbove && rect.top - 8 - popupH >= 8) {
       popup.style.top = (window.scrollY + rect.top - popupH - 8) + 'px';
     } else {
       popup.style.top = (window.scrollY + rect.bottom + 8) + 'px';
     }
-    const left = Math.min(rect.left + window.scrollX, window.innerWidth - 340);
-    popup.style.left = Math.max(8, left) + 'px';
+    // `rect.left` is the caret / mouse-up X for text selections (not the
+    // line-box origin). Clamp in document coords so a caret near the right
+    // edge still keeps the 320px sheet on screen.
+    const maxLeft = window.scrollX + window.innerWidth - popupW - 8;
+    const left = Math.min(Math.max(window.scrollX + 8, window.scrollX + rect.left), maxLeft);
+    popup.style.left = left + 'px';
 
     if (anchor.kind === 'text' && anchor._range) {
       setPendingTextHighlight(anchor._range);
@@ -3352,8 +3406,8 @@
     const articleTop = articleEl.getBoundingClientRect().top + window.scrollY;
     const articleHeight = Math.max(1, articleEl.scrollHeight);
     let rect = null;
-    if (anchor.kind === 'text' && anchor._range) rect = anchor._range.getBoundingClientRect();
-    else if (anchor.kind === 'element' && anchor._el) rect = anchor._el.getBoundingClientRect();
+    if (anchor.kind === 'text' && anchor._range) rect = firstVisibleClientRect(anchor._range);
+    else if (anchor.kind === 'element' && anchor._el) rect = firstVisibleClientRect(anchor._el) || anchor._el.getBoundingClientRect();
     if (!rect) return null;
     const centerY = rect.top + rect.height / 2 + window.scrollY;
     const ratio = Math.max(0, Math.min(1, (centerY - articleTop) / articleHeight));
@@ -3755,7 +3809,7 @@
         // Dragged but no artifact hit — likely a text selection. Fall through.
       }
     }
-    maybeOpenSelectionPopup(e.target);
+    maybeOpenSelectionPopup(e.target, e);
   }, true);
 
   // Mouse and touch both surface here. On iOS Safari long-press text-selection
@@ -3765,7 +3819,8 @@
   document.addEventListener('touchend', (e) => {
     const t = e.target || (e.changedTouches?.[0] && document.elementFromPoint(e.changedTouches[0].clientX, e.changedTouches[0].clientY));
     // Touchend fires before the OS finalizes selection — defer one tick.
-    setTimeout(() => maybeOpenSelectionPopup(t), 0);
+    const touch = e.changedTouches && e.changedTouches[0];
+    setTimeout(() => maybeOpenSelectionPopup(t, touch || e), 0);
   }, true);
 
   // An author can mark a phrase as an invitation: `data-tdoc-select`. Clicking
@@ -3785,7 +3840,7 @@
     maybeOpenSelectionPopup(invite);
   }, true);
 
-  function maybeOpenSelectionPopup(target) {
+  function maybeOpenSelectionPopup(target, event) {
     // Selected text wins over "comment whole artifact." If there's a real text
     // selection, open the text-selection popup regardless of whether the
     // selection lives inside a commentable artifact. The hover pill remains
@@ -3826,8 +3881,41 @@
       });
       return;
     }
-    const rect = range.getBoundingClientRect();
+    const rect = selectionEndRect(sel, range, event);
+    if (!rect) return;
     openPopup({ kind: 'text', text, context_before: ctx.before, context_after: ctx.after, _range: range }, rect);
+  }
+
+  // Where the user *finished* the selection — mouse-up / caret — not the
+  // left edge of the line box. That's what the popup must sit under.
+  function selectionEndRect(sel, range, event) {
+    const pointerX = event && Number.isFinite(event.clientX) ? event.clientX : NaN;
+    const pointerY = event && Number.isFinite(event.clientY) ? event.clientY : NaN;
+    if (Number.isFinite(pointerX) && Number.isFinite(pointerY)) {
+      const line = clientRectNearPoint(range, pointerX, pointerY);
+      const onLine = endRectOnLine(line, pointerX);
+      if (onLine) return onLine;
+    }
+    if (sel && sel.focusNode != null) {
+      try {
+        const caret = document.createRange();
+        caret.setStart(sel.focusNode, sel.focusOffset);
+        caret.collapse(true);
+        const cr = caret.getBoundingClientRect();
+        if (cr && (cr.height > 0 || cr.width > 0 || cr.left !== 0 || cr.top !== 0)) {
+          const line = clientRectNearPoint(range, cr.left, cr.top + cr.height / 2)
+            || { top: cr.top, bottom: cr.bottom || cr.top + 16, height: cr.height || 16, right: cr.left };
+          return endRectOnLine(line, cr.left);
+        }
+      } catch { /* focus not in a text node */ }
+    }
+    const rects = range.getClientRects ? range.getClientRects() : [];
+    let last = null;
+    for (let i = 0; i < rects.length; i++) {
+      if (isVisibleClientRect(rects[i])) last = rects[i];
+    }
+    if (last) return endRectOnLine(last, last.right);
+    return firstVisibleClientRect(range);
   }
 
   // Begin the re-anchor flow: future text selection on the doc will rebind
@@ -3851,9 +3939,9 @@
     const articleTop = articleEl.getBoundingClientRect().top + window.scrollY;
     const articleHeight = Math.max(1, articleEl.scrollHeight);
     let rect = null;
-    if (mark.ranges?.[0]) rect = mark.ranges[0].getBoundingClientRect();
-    else if (mark.el) rect = mark.el.getBoundingClientRect();
-    else if (mark.targetEl) rect = mark.targetEl.getBoundingClientRect();
+    if (mark.ranges?.[0]) rect = firstVisibleClientRect(mark.ranges[0]);
+    else if (mark.el) rect = firstVisibleClientRect(mark.el) || mark.el.getBoundingClientRect();
+    else if (mark.targetEl) rect = firstVisibleClientRect(mark.targetEl) || mark.targetEl.getBoundingClientRect();
     if (!rect) return null;
     const centerY = rect.top + rect.height / 2 + window.scrollY;
     return { ratio: Math.max(0, Math.min(1, (centerY - articleTop) / articleHeight)), nearestHeading: null };

--- a/test/overlay-pure.test.js
+++ b/test/overlay-pure.test.js
@@ -9,7 +9,8 @@
 // functions become a documented, testable surface.
 //
 // Pure functions covered: escapeHtml, normalizeNeedle, normalizeContext,
-// normalizeQuery, commonPrefixLen, commonSuffixLen.
+// normalizeQuery, commonPrefixLen, commonSuffixLen, isVisibleClientRect,
+// nearestClientRect, endRectOnLine.
 //
 // Run with: node test/overlay-pure.test.js
 
@@ -48,10 +49,12 @@ vm.runInContext([
   'commonPrefixLen', 'commonSuffixLen', 'isGithubHttpsUrl',
   'isAnthropicCompanyMark', 'tdocLogoUrl', 'agentLogoUrl', 'childrenOf',
   'inboxTargetUrl', 'findCommentRoot',
+  'isVisibleClientRect', 'nearestClientRect', 'endRectOnLine',
 ].map(sliceFn).join('\n\n'), box);
 const { escapeHtml, normalizeNeedle, normalizeContext, normalizeQuery,
         commonPrefixLen, commonSuffixLen, isGithubHttpsUrl, agentLogoUrl,
-        childrenOf, inboxTargetUrl, findCommentRoot } = box;
+        childrenOf, inboxTargetUrl, findCommentRoot,
+        isVisibleClientRect, nearestClientRect, endRectOnLine } = box;
 
 console.log('overlay-pure (#23 testable surface)');
 
@@ -173,6 +176,30 @@ t('inboxTargetUrl encodes slug and comment id', () => {
 t('inboxTargetUrl treats bad versions as 1', () => {
   assert(inboxTargetUrl({ slug: 'd', version: 'nope', comment_id: 'c' }, {}) === '/d/d/v/1?comment=c');
   assert(inboxTargetUrl({ slug: 'd', version: 0 }, {}) === '/d/d/v/1');
+});
+t('isVisibleClientRect rejects empty / missing boxes', () => {
+  assert(isVisibleClientRect(null) === false);
+  assert(isVisibleClientRect({ width: 0, height: 0 }) === false);
+  assert(isVisibleClientRect({ width: 12, height: 0 }) === true);
+  assert(isVisibleClientRect({ width: 0, height: 16 }) === true);
+});
+t('endRectOnLine sits at the caret X, not the line origin', () => {
+  const line = { left: 40, right: 400, top: 120, bottom: 140, width: 360, height: 20 };
+  const end = endRectOnLine(line, 280);
+  assert(end.left === 280 && end.right === 280, 'x is the caret, not line.left');
+  assert(end.top === 120 && end.bottom === 140, 'stays on the same line');
+  assert(endRectOnLine(line).left === 400, 'no x → line end');
+  assert(endRectOnLine(null) === null);
+});
+t('nearestClientRect picks the line box under the caret, not the union', () => {
+  const line1 = { left: 40, right: 400, top: 100, bottom: 120, width: 360, height: 20 };
+  const line2 = { left: 40, right: 180, top: 120, bottom: 140, width: 140, height: 20 };
+  const empty = { left: 0, right: 0, top: 0, bottom: 0, width: 0, height: 0 };
+  const hit = nearestClientRect([line1, empty, line2], 170, 132);
+  assert(hit === line2, 'caret on the second line should not snap to line 1');
+  const up = nearestClientRect([line1, line2], 80, 108);
+  assert(up === line1, 'upward selection caret stays on the first line');
+  assert(nearestClientRect([], 0, 0) === null);
 });
 t('findCommentRoot maps a reply id to its top-level card', () => {
   const list = [

--- a/test/ui.test.js
+++ b/test/ui.test.js
@@ -352,6 +352,61 @@ async function tPub(name, fn) {
     await page.click('.tdoc-popup .head .x').catch(() => {});
   });
 
+  await t('Text-selection popup follows the caret line, not the union box', async () => {
+    // Regression: Range.getBoundingClientRect() is the union of every line.
+    // Selecting across blocks (or wrapping) then releasing on the last line
+    // used to park the popup at the union's bottom-left, away from the caret.
+    const pos = await page.evaluate(() => {
+      const h = document.querySelector('.wrap h2');
+      const p = document.querySelector('.wrap h2 + p, .wrap h2 ~ p');
+      if (!h || !p) return null;
+      const start = [...h.childNodes].find(n => n.nodeType === 3);
+      const endNode = [...p.childNodes].find(n => n.nodeType === 3 && n.textContent.trim().length > 8);
+      if (!start || !endNode) return null;
+      const r = document.createRange();
+      r.setStart(start, 0);
+      r.setEnd(endNode, Math.min(12, endNode.textContent.length));
+      const union = r.getBoundingClientRect();
+      const rects = [...r.getClientRects()].filter(x => x.width || x.height);
+      if (rects.length < 2) return null;
+      const last = rects[rects.length - 1];
+      const sel = window.getSelection();
+      sel.removeAllRanges();
+      sel.addRange(r);
+      return {
+        unionTop: union.top,
+        lastTop: last.top,
+        lastBottom: last.bottom,
+        lineLeft: last.left,
+        x: last.right - 2,
+        y: last.top + last.height / 2,
+      };
+    });
+    if (!pos) { console.log('  (could not build a multi-line selection, skipping)'); return; }
+    await page.evaluate(({ x, y }) => {
+      document.dispatchEvent(new MouseEvent('mouseup', {
+        clientX: x, clientY: y, bubbles: true, cancelable: true, view: window, button: 0,
+      }));
+    }, { x: pos.x, y: pos.y });
+    await page.waitForSelector('.tdoc-popup', { timeout: 2000 });
+    const popup = await page.$eval('.tdoc-popup', el => {
+      const r = el.getBoundingClientRect();
+      return { top: r.top, left: r.left };
+    });
+    // Opened below the caret line (last.bottom + 8). Must not sit on the first
+    // line of a multi-block selection.
+    if (popup.top < pos.lastTop - 4) {
+      throw new Error(`popup top ${popup.top.toFixed(1)} is above the caret line (${pos.lastTop.toFixed(1)}–${pos.lastBottom.toFixed(1)}); union top was ${pos.unionTop.toFixed(1)}`);
+    }
+    // And at the mouse-up X, not the line's left edge.
+    const distEnd = Math.abs(popup.left - pos.x);
+    const distLeft = Math.abs(popup.left - pos.lineLeft);
+    if (distEnd > distLeft && distEnd > 48) {
+      throw new Error(`popup left ${popup.left.toFixed(1)} is nearer the line origin (${pos.lineLeft.toFixed(1)}) than the caret (${pos.x.toFixed(1)})`);
+    }
+    await page.click('.tdoc-popup .head .x').catch(() => {});
+  });
+
   await t('Drag STARTED INSIDE canvas does NOT open popup (passes through)', async () => {
     const canvas = await page.$('canvas');
     if (!canvas) { console.log('  (no canvas, skipping)'); return; }


### PR DESCRIPTION
## Problem

On a multi-line text selection the new-comment sheet sat at the **left of the wrap**, not where the mouse/caret finished. `Range.getBoundingClientRect()` is the union of every line box.

## Fix

- Pick the live line box under mouse-up / caret X (`getClientRects`), not the union.
- Park the sheet at that X (selection end), clamped in document coordinates so a caret near the right edge still keeps the 320px sheet on screen.
- Pins / fallback Y use the first visible line box so a WebKit 0×0 union does not send them to the top of the page.

## Tests

- `overlay-pure`: nearest-line math + end-rect X is the caret, not `line.left`.
- `ui.test.js`: multi-rect `<h2>`+`<p>` selection; popup is on the last line and nearer the caret than the line origin.

Review of the local diff: 0 bugs, 4 non-blocking suggestions (pointer X clamp on a short last line, stronger Playwright Y check, shorter comments, `commentY` empty-rect fallback). Shipping as-is.