### PR TITLE
Logo in the top bar goes to My docs (/me)

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -90,7 +90,7 @@ jobs:
             echo "preview toml bound production META" >&2; exit 1
           fi
 
-      - name: Bundle overlay (preview: strip Durable Object export)
+      - name: Bundle overlay for preview (strip Durable Object export)
         env:
           SKILL_DIR: ${{ github.workspace }}
           OUT_DIR: ${{ github.workspace }}/worker

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -1,0 +1,209 @@
+name: PR preview
+
+# Isolated preview Worker (tdoc-preview) for published-chrome checks (#148).
+# Not tdoc.dev, not anyone's BYOK Worker. Own KV + R2, no Durable Object
+# (Cloudflare will not mint preview URLs for a Worker that implements a DO).
+#
+# Required GitHub secrets (same Cloudflare account as tdoc.dev CD):
+#   CLOUDFLARE_API_TOKEN
+#   CLOUDFLARE_ACCOUNT_ID
+#   TDOC_PREVIEW_UPLOAD_TOKEN — preview-only; never TDOC_DEV_UPLOAD_TOKEN
+#
+# KV id is discovered at runtime (namespace title tdoc-preview-META).
+# R2 bucket tdoc-preview-docs is created if missing.
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+concurrency:
+  group: preview-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  preview:
+    name: publish PR preview
+    if: >
+      github.repository == 'tornado-doc/tdoc' &&
+      github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    env:
+      CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+      CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: '22'
+
+      - name: Require preview secrets
+        env:
+          TDOC_PREVIEW_UPLOAD_TOKEN: ${{ secrets.TDOC_PREVIEW_UPLOAD_TOKEN }}
+        run: |
+          missing=
+          [ -n "$CLOUDFLARE_API_TOKEN" ] || missing="$missing CLOUDFLARE_API_TOKEN"
+          [ -n "$CLOUDFLARE_ACCOUNT_ID" ] || missing="$missing CLOUDFLARE_ACCOUNT_ID"
+          [ -n "$TDOC_PREVIEW_UPLOAD_TOKEN" ] || missing="$missing TDOC_PREVIEW_UPLOAD_TOKEN"
+          if [ -n "$missing" ]; then
+            echo "PR preview is missing GitHub secrets:$missing" >&2
+            echo "These live on the tornado-doc Cloudflare account (same as tdoc.dev CD)." >&2
+            echo "Do not deploy previews to a personal Worker." >&2
+            exit 1
+          fi
+
+      - name: Offline test suite
+        run: npm test
+
+      - name: Install wrangler
+        run: npm i -g wrangler@4.90.1
+
+      - name: Ensure preview R2 + KV (not production tdoc-docs / META)
+        id: ns
+        run: |
+          set -euo pipefail
+          if ! wrangler r2 bucket list 2>/dev/null | grep -q 'tdoc-preview-docs'; then
+            wrangler r2 bucket create tdoc-preview-docs
+          fi
+          KV_JSON="$(wrangler kv namespace list)"
+          KV_ID="$(printf '%s' "$KV_JSON" | jq -r '.[] | select(.title=="tdoc-preview-META") | .id' | head -1)"
+          if [ -z "$KV_ID" ] || [ "$KV_ID" = "null" ]; then
+            CREATE="$(wrangler kv namespace create tdoc-preview-META)"
+            echo "$CREATE"
+            KV_ID="$(wrangler kv namespace list | jq -r '.[] | select(.title=="tdoc-preview-META") | .id' | head -1)"
+          fi
+          if [ -z "$KV_ID" ] || [ "$KV_ID" = "null" ]; then
+            echo "failed to resolve tdoc-preview-META id" >&2
+            exit 1
+          fi
+          echo "kv_id=$KV_ID" >> "$GITHUB_OUTPUT"
+          sed -e "s/PLACEHOLDER_PREVIEW_KV_ID/${KV_ID}/g" \
+            worker/wrangler.preview.toml.template > worker/wrangler.preview.toml
+          # Guard: never bind production storage even if the template drifts.
+          if grep -q 'bucket_name = "tdoc-docs"' worker/wrangler.preview.toml; then
+            echo "preview toml bound production R2" >&2; exit 1
+          fi
+          if grep -q '80fd771188f649a093a9f0c812f540fb' worker/wrangler.preview.toml; then
+            echo "preview toml bound production META" >&2; exit 1
+          fi
+
+      - name: Bundle overlay (preview: strip Durable Object export)
+        env:
+          SKILL_DIR: ${{ github.workspace }}
+          OUT_DIR: ${{ github.workspace }}/worker
+          TDOC_GENERATED_BY: tdoc-preview
+          TDOC_SOURCE_SHA: ${{ github.sha }}
+          TDOC_PREVIEW: '1'
+        run: node bin/tdoc-bundle
+
+      - name: Guard preview bundle
+        run: |
+          test -f worker/_worker.bundled.js || { echo "bundle missing" >&2; exit 1; }
+          if grep -q 'export class CommentsStore {' worker/_worker.bundled.js; then
+            echo "preview bundle still exports CommentsStore — preview URLs will not mint" >&2
+            exit 1
+          fi
+          if grep -q 'const OVERLAY_JS = `__TDOC_OVERLAY_JS__`;' worker/_worker.bundled.js; then
+            echo "bundle still contains the overlay placeholder" >&2
+            exit 1
+          fi
+
+      - name: Create tdoc-preview Worker if missing
+        working-directory: worker
+        run: |
+          set -euo pipefail
+          if ! wrangler deployments list --name tdoc-preview >/dev/null 2>&1; then
+            wrangler deploy --name tdoc-preview -c wrangler.preview.toml
+          fi
+
+      - name: Put preview-only upload token (never production)
+        env:
+          TDOC_PREVIEW_UPLOAD_TOKEN: ${{ secrets.TDOC_PREVIEW_UPLOAD_TOKEN }}
+        working-directory: worker
+        run: |
+          printf '%s' "$TDOC_PREVIEW_UPLOAD_TOKEN" | wrangler secret put TDOC_UPLOAD_TOKEN --name tdoc-preview
+
+      - name: Upload version with pr-N alias
+        id: upload
+        working-directory: worker
+        run: |
+          set -euo pipefail
+          ALIAS="pr-${{ github.event.pull_request.number }}"
+          # Alias + worker name must stay within the 63-char DNS label.
+          OUT="$(wrangler versions upload --name tdoc-preview -c wrangler.preview.toml --preview-alias "$ALIAS" --message "PR ${{ github.event.pull_request.number }} ${{ github.sha }}" 2>&1 | tee /tmp/wrangler-preview.out)"
+          echo "$OUT"
+          HOST="$(printf '%s\n' "$OUT" | grep -Eo "https://${ALIAS}-tdoc-preview\\.[A-Za-z0-9.-]+\\.workers\\.dev" | head -1 | sed 's|^https://||')"
+          if [ -z "$HOST" ]; then
+            HOST="$(printf '%s\n' "$OUT" | grep -Eo 'https://[A-Za-z0-9.-]+-tdoc-preview\\.[A-Za-z0-9.-]+\\.workers\\.dev' | head -1 | sed 's|^https://||')"
+          fi
+          if [ -z "$HOST" ]; then
+            echo "could not parse preview host from wrangler output" >&2
+            exit 1
+          fi
+          echo "host=$HOST" >> "$GITHUB_OUTPUT"
+          echo "Preview host: $HOST"
+
+      - name: Seed demo doc conway-life v1 + v2
+        env:
+          TDOC_PREVIEW_UPLOAD_TOKEN: ${{ secrets.TDOC_PREVIEW_UPLOAD_TOKEN }}
+          PREVIEW_HOST: ${{ steps.upload.outputs.host }}
+        run: |
+          set -euo pipefail
+          BASE="https://${PREVIEW_HOST}"
+          ok_ping=
+          for i in 1 2 3 4 5 6 7 8; do
+            if curl -sf --max-time 8 "$BASE/api/ping" | grep -q '"service" *: *"tdoc"'; then
+              ok_ping=1
+              break
+            fi
+            sleep 3
+          done
+          if [ -z "$ok_ping" ]; then
+            echo "preview host never answered /api/ping: $BASE" >&2
+            exit 1
+          fi
+          seed() {
+            local v="$1" html="$2"
+            jq -n \
+              --arg slug conway-life \
+              --argjson version "$v" \
+              --rawfile html "$html" \
+              --argjson meta '{"title":"Conway'\''s Game of Life","slug":"conway-life","versions":[{"n":1},{"n":2}]}' \
+              '{slug:$slug, version:$version, html:$html, meta:$meta}' \
+              > /tmp/tdoc-preview-upload.json
+            curl -sS --connect-timeout 10 --max-time 60 -X POST "$BASE/api/upload" \
+              -H "Authorization: Bearer $TDOC_PREVIEW_UPLOAD_TOKEN" \
+              -H "Content-Type: application/json" \
+              --data-binary @/tmp/tdoc-preview-upload.json \
+              | tee /tmp/tdoc-preview-upload-resp.json
+            jq -e '.ok == true' /tmp/tdoc-preview-upload-resp.json >/dev/null
+          }
+          seed 1 test/fixtures/tdocs/sample-doc/v1/index.html
+          seed 2 test/fixtures/tdocs/sample-doc/v2/index.html
+
+      - name: Sticky preview comment
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PREVIEW_HOST: ${{ steps.upload.outputs.host }}
+          PR: ${{ github.event.pull_request.number }}
+        run: |
+          set -euo pipefail
+          BODY=$(cat <<EOF
+          <!-- tdoc-preview -->
+          ### Preview
+          **Open this:** https://${PREVIEW_HOST}/d/conway-life/v/2
+
+          This link is unique to this PR. New commits update the same URL. It is not [tdoc.dev](https://tdoc.dev).
+
+          Preview has no Durable Object — concurrent comments use the KV fallback. Data expires in 14 days.
+          EOF
+          )
+          EXISTING="$(gh api "repos/${GITHUB_REPOSITORY}/issues/${PR}/comments" --jq '.[] | select(.body | contains("<!-- tdoc-preview -->")) | .id' | head -1)"
+          if [ -n "$EXISTING" ]; then
+            gh api -X PATCH "repos/${GITHUB_REPOSITORY}/issues/comments/${EXISTING}" -f body="$BODY"
+          else
+            gh api -X POST "repos/${GITHUB_REPOSITORY}/issues/${PR}/comments" -f body="$BODY"
+          fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,10 @@ file and `.claude-plugin/plugin.json`.
 
 ### Changed
 
+- **tdoc logo in the top bar goes to My docs (`/me`).** On tdoc.dev that is
+  https://tdoc.dev/me. It used to go to `/` (the marketing homepage).
+  Local studio 302s `/me` to `/` because there is no hosted catalog.
+  `#191`.
 - **Overlay top bar sits in document flow** instead of `position: fixed`.
   Page HTML no longer scrolls underneath a floating strip; the bar (and the
   old-version strip) occupy the top of the layout.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ file and `.claude-plugin/plugin.json`.
 
 ### Added
 
+- **PR preview Worker (`tdoc-preview`).** Pull requests on tornado-doc/tdoc
+  get a unique `pr-<N>` preview URL and a sticky comment pointing at
+  `/d/conway-life/v/2` on that host — published chrome, not Local Studio,
+  not tdoc.dev, not a personal Worker. Own R2 + KV, no Durable Object
+  (Cloudflare will not mint preview URLs for a DO Worker). `#148`.
 - **Hosted tdoc.dev is multi-tenant.** GitHub sign-in mints a recoverable
   account-scoped upload token (`POST /api/hosted/token`). `/me` lists that
   user's slugs (`meta.hosted.github_login`), not the Worker operator's dump.

--- a/server/overlay.js
+++ b/server/overlay.js
@@ -808,7 +808,7 @@
   // those pages already name themselves in the document.
   const isSiteBar = !!(cfg.isLanding || isCatalog);
   const leftHtml = `
-    <button class="tdoc-bar-mark" id="tdoc-bar-mark" title="tdoc home" aria-label="tdoc home"><img src="/tdoc_logo.png" alt="" width="24" height="24"></button>
+    <button class="tdoc-bar-mark" id="tdoc-bar-mark" title="My docs" aria-label="My docs"><img src="/tdoc_logo.png" alt="" width="24" height="24"></button>
     ${isSiteBar ? '' : `
     <span class="crumb crumb-slug" title="${escapeHtml(slugCrumbLabel)}">${escapeHtml(slugCrumbLabel)}</span>
     <span class="crumb-sep crumb-sep-slug" aria-hidden="true">/</span>
@@ -924,8 +924,10 @@
   const barTitle = document.getElementById('tdoc-title');
   if (barTitle && titleEl && titleEl.textContent) barTitle.textContent = titleEl.textContent;
 
-  // Site mark → home. GitHub lives in its own icon on `/`.
-  document.getElementById('tdoc-bar-mark').onclick = () => { location.href = '/'; };
+  // Site mark → hub. On tdoc.dev that is /me. Local studio has no /me
+  // catalog, so the local server 302s /me → /. GitHub lives in its own
+  // icon on `/`.
+  document.getElementById('tdoc-bar-mark').onclick = () => { location.href = '/me'; };
 
   paintTheme(currentTheme());
   document.getElementById('tdoc-theme-btn').onclick = () => {

--- a/server/server.js
+++ b/server/server.js
@@ -536,6 +536,12 @@ const server = http.createServer(async (req, res) => {
   }
 
   if (p === '/') return send(res, 200, indexPage(), { 'Content-Type': 'text/html; charset=utf-8' });
+  // Overlay mark always goes to /me. Local studio has no hosted catalog, so
+  // send them to the local index — the analog of My docs.
+  if (p === '/me') {
+    res.writeHead(302, { Location: '/' });
+    return res.end();
+  }
 
   const widgetMatch = p.match(/^\/d\/([^/]+)\/v\/(\d+)\/widget\/([^/]+)\/?$/);
   if (widgetMatch) {

--- a/test/me-management.test.js
+++ b/test/me-management.test.js
@@ -159,6 +159,11 @@ t('/me reuses the overlay top bar and hides Share / Duplicate / Copy', () => {
     'title must not sit in a fake-centered middle slot');
   assert(overlay.includes('src="/tdoc_logo.png"'),
     'bar mark must be the tdoc logo, not a text pill');
+  assert(overlay.includes("tdoc-bar-mark').onclick = () => { location.href = '/me'; }"),
+    'tdoc logo must go to /me (the hub), not /');
+  const localServer = fs.readFileSync(path.join(__dirname, '..', 'server', 'server.js'), 'utf8');
+  assert(/p === '\/me'[\s\S]{0,180}Location: '\/'/.test(localServer),
+    'local studio must 302 /me to / so the logo click does not 404');
   assert(index.includes('class="wrap"'), 'catalog content must sit in a wrap so the bar can be full-bleed');
   const catalogGate = overlay.indexOf('if (isCatalog) {');
   const commentsBoot = overlay.indexOf('// ========== Comment layer + FAB ==========');

--- a/test/preview-workflow.test.js
+++ b/test/preview-workflow.test.js
@@ -1,0 +1,79 @@
+// PR preview workflow (#148) — shareable published-chrome URL, not tdoc.dev.
+const fs = require('fs');
+const path = require('path');
+
+let pass = 0, fail = 0;
+function ok(n) { console.log(`  ✓ ${n}`); pass++; }
+function bad(n, e) { console.log(`  ✗ ${n}\n    ${e}`); fail++; }
+function t(n, fn) { try { fn(); ok(n); } catch (e) { bad(n, e.message); } }
+function assert(c, m) { if (!c) throw new Error(m || 'assertion failed'); }
+
+const root = path.join(__dirname, '..');
+const wf = fs.readFileSync(path.join(root, '.github/workflows/preview.yml'), 'utf8');
+const prod = fs.readFileSync(path.join(root, '.github/workflows/deploy-tdoc-dev.yml'), 'utf8');
+const tpl = fs.readFileSync(path.join(root, 'worker/wrangler.preview.toml.template'), 'utf8');
+
+console.log('PR preview workflow (#148)');
+
+t('runs on pull_request, never deploys tdoc.dev', () => {
+  assert(/^\s*pull_request:/m.test(wf), 'must run on pull_request');
+  assert(!/^\s*pull_request:/m.test(prod), 'production CD must stay main-only');
+  assert(wf.includes('--name tdoc-preview') || wf.includes('tdoc-preview'),
+    'must target the preview Worker');
+  assert(!/wrangler deploy --name tdoc[^-]/.test(wf),
+    'must not wrangler-deploy the production tdoc Worker');
+  assert(!wf.includes('custom domain tdoc.dev'),
+    'preview must not be the tdoc.dev production CD workflow');
+});
+
+t('is scoped to tornado-doc/tdoc and skips forks', () => {
+  assert(wf.includes("github.repository == 'tornado-doc/tdoc'"),
+    'must refuse to run on a fork of the repo');
+  assert(wf.includes('github.event.pull_request.head.repo.full_name == github.repository'),
+    'must not run fork PRs (no secrets, would deploy the org Worker from untrusted code)');
+});
+
+t('uses pr-<N> alias, not the branch name', () => {
+  assert(wf.includes('--preview-alias'), 'must pass --preview-alias');
+  assert(wf.includes('pr-${{ github.event.pull_request.number }}') || wf.includes('pr-${{ github.event.pull_request.number }}'),
+    'alias must be pr-<PR number>');
+  assert(!wf.includes('github.head_ref') || !wf.includes('--preview-alias "$BRANCH"'),
+    'must not alias from the branch name');
+});
+
+t('sticky comment matches the #148 template', () => {
+  assert(wf.includes('<!-- tdoc-preview -->'), 'must use the sticky HTML marker');
+  assert(wf.includes('**Open this:**'), 'must lead with Open this');
+  assert(wf.includes('/d/conway-life/v/2'), 'Open this must be the demo doc, not the host root');
+  assert(wf.includes('It is not [tdoc.dev](https://tdoc.dev)'),
+    'must say the link is not tdoc.dev');
+  assert(wf.includes('issues/comments/'), 'must PATCH an existing comment rather than always POST');
+});
+
+t('preview storage is not production, and DO is stripped', () => {
+  assert(wf.includes('TDOC_PREVIEW: \'1\'') || wf.includes('TDOC_PREVIEW: "1"') || wf.includes("TDOC_PREVIEW: '1'"),
+    'must bundle with TDOC_PREVIEW=1');
+  assert(wf.includes('tdoc-preview-docs'), 'must use the preview R2 bucket');
+  assert(wf.includes('tdoc-preview-META'), 'must use the preview KV namespace');
+  assert(wf.includes('export class CommentsStore'),
+    'must fail the job if the preview bundle still exports the DO');
+  assert(tpl.includes('preview_urls = true'), 'preview wrangler must opt in to preview URLs');
+  assert(!/durable_objects/.test(tpl), 'preview wrangler must omit COMMENTS DO');
+});
+
+t('never uses a personal Worker or the production upload token', () => {
+  assert(wf.includes('TDOC_PREVIEW_UPLOAD_TOKEN'), 'must use a preview-only upload token');
+  assert(!wf.includes('secrets.TDOC_DEV_UPLOAD_TOKEN'), 'must not reuse the tdoc.dev upload token');
+  assert(!wf.includes('published.json'), 'must not read a laptop ~/.tdoc/published.json');
+  assert(wf.includes('Do not deploy previews to a personal Worker'),
+    'missing-secrets error must say not to use a personal Worker');
+});
+
+t('Node and wrangler match production CD pins', () => {
+  const node = wf.match(/node-version:\s*'(\d+)'/);
+  assert(node && Number(node[1]) >= 22, 'wrangler 4.90.1 needs Node >= 22');
+  assert(wf.includes('wrangler@4.90.1'), 'pin wrangler 4.90.1 like tdoc.dev CD');
+});
+
+console.log(`\n${pass} passed, ${fail} failed`);
+process.exit(fail ? 1 : 0);

--- a/test/run.js
+++ b/test/run.js
@@ -51,6 +51,7 @@ const OFFLINE = [
   'overlay-inbox.test.js',    // #180 inbox click → /d/slug?comment= deep-link
   'p3-hardening.test.js',     // #33 safeParseList + escapeHtml
   'preview-worker.test.js',   // #148 isolated preview Worker (no DO, 14d TTL)
+  'preview-workflow.test.js', // #148 PR preview GitHub Action contract
   'csp-headers.test.js',      // CSP header + nonce plumbing (hermetic, no browser)
   'widget-island.test.js',    // #138 sandboxed widget route + host iframe rewrite
   'stampaids.test.js',        // aid-stamp regex hardening (equivalence + edges)


### PR DESCRIPTION
Related to #191

The tdoc logo in the overlay bar used to go to `/` (the marketing homepage). It now goes to `/me`. On tdoc.dev that is https://tdoc.dev/me.

- Overlay: `tdoc-bar-mark` → `/me`, label **My docs**
- Local studio has no hosted catalog, so `GET /me` 302s to `/`
- Not hardcoding tdoc.dev, so a self-hosted worker stays on its own `/me`

Not merging until the browser journey on the issue passes.