### PR TITLE
Every generated doc goes through a voice contract

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ file and `.claude-plugin/plugin.json`.
 
 ### Added
 
+- **Every generated doc goes through a voice contract.** New `authoring/`
+  directory, read at generation time. `authoring/voice.md` applies to
+  `/tdoc new` and every `/tdoc edit` regeneration — a floor, not a
+  user-selectable template, because nobody picks "make it sound like AI."
+  It adapts the vendored `no-ai-slop` rule set (Peter Yang, MIT) to
+  generation rather than editing, names the user's prompt as the voice
+  anchor, and fences off the spans prose rules must never rewrite: code,
+  identifiers, quoted material, and data. `authoring/style/` and
+  `authoring/structure/` ship as empty reserved mount points. `#194`.
 - **PR preview Worker (`tdoc-preview`).** Pull requests on tornado-doc/tdoc
   get a unique `pr-<N>` preview URL and a sticky comment pointing at
   `/d/conway-life/v/2` on that host — published chrome, not Local Studio,

--- a/SKILL.md
+++ b/SKILL.md
@@ -223,16 +223,19 @@ sleep 1
 
 ## Authoring contract — read before writing any doc
 
-**`authoring/voice.md` is required reading before you write doc HTML**, on
-every `/tdoc new` and every regeneration in `/tdoc edit`. It is a floor, not
+**`$SKILL_DIR/authoring/voice.md` is required reading before you write doc
+HTML**, on every `/tdoc new` and every regeneration in `/tdoc edit`.
+`$SKILL_DIR` is the installed skill directory resolved in "Setup check"
+above (`~/.claude/skills/tdoc`, or `~/.codex/skills/tdoc` under Codex) —
+**not** the current working directory, which is the user's project. It is a floor, not
 a user-selectable option: there is no switch, and no doc is exempt.
 
 It carries tdoc's adaptation of the vendored `no-ai-slop` rule set
-(`authoring/vendor/no-ai-slop.md`) — which prose the rules govern, which
+(`$SKILL_DIR/authoring/vendor/no-ai-slop.md`) — which prose the rules govern, which
 spans they must never rewrite (code, identifiers, quotes, data), and whose
 voice is being preserved when the agent is the one writing.
 
-`authoring/style/` and `authoring/structure/` are reserved mount points and
+`$SKILL_DIR/authoring/style/` and `$SKILL_DIR/authoring/structure/` are reserved mount points and
 are **empty today**. Empty means no choice to make: use the overlay's
 default reading template, and derive the document's shape from the prompt.
 
@@ -241,7 +244,7 @@ default reading template, and derive the document's shape from the prompt.
 ### `/tdoc new <prompt>` — create a new doc
 
 1. Pick a slug from the prompt (kebab-case, ≤4 words).
-2. **Read `authoring/voice.md`** and hold it while you write. The prose
+2. **Read `$SKILL_DIR/authoring/voice.md`** and hold it while you write. The prose
    constraints apply as you generate, not as a later cleanup pass.
 3. Create `~/tdocs/<slug>/v1/index.html` — the host document:
    - All host CSS inline in `<style>`. **No JavaScript in the host** — those tags do not execute (CSP; see HTML generation rules). If the idea needs computation, also write `v1/widgets/<name>.html` and iframe it.
@@ -332,7 +335,7 @@ comments you handled unless you reply on each one. Skipping comments
 silently is the #1 source of regression complaints.
 
 1. Read `~/tdocs/<slug>/comments.json` — filter to `status: "open"`.
-2. Read latest version's `index.html`, and re-read `authoring/voice.md`.
+2. Read latest version's `index.html`, and re-read `$SKILL_DIR/authoring/voice.md`.
    A regeneration writes new prose, so the contract applies here exactly as
    it does on `/tdoc new`. Prose you carry over unchanged from the previous
    version stays as it is — do not re-edit untouched sections for voice.
@@ -583,7 +586,7 @@ When the user reports a problem, check these first:
 
 ## HTML generation rules
 
-- **The prose in the doc is governed by `authoring/voice.md`.** These rules
+- **The prose in the doc is governed by `$SKILL_DIR/authoring/voice.md`.** These rules
   cover markup; that file covers the words inside it. Both apply to every
   doc. It also fences off the spans the prose rules must never touch —
   code, identifiers, quoted material, and data.

--- a/SKILL.md
+++ b/SKILL.md
@@ -221,26 +221,43 @@ nohup node "$SKILL_DIR/server/server.js" > "$TDOC_DIR/.server.log" 2>&1 &
 sleep 1
 ```
 
+## Authoring contract — read before writing any doc
+
+**`authoring/voice.md` is required reading before you write doc HTML**, on
+every `/tdoc new` and every regeneration in `/tdoc edit`. It is a floor, not
+a user-selectable option: there is no switch, and no doc is exempt.
+
+It carries tdoc's adaptation of the vendored `no-ai-slop` rule set
+(`authoring/vendor/no-ai-slop.md`) — which prose the rules govern, which
+spans they must never rewrite (code, identifiers, quotes, data), and whose
+voice is being preserved when the agent is the one writing.
+
+`authoring/style/` and `authoring/structure/` are reserved mount points and
+are **empty today**. Empty means no choice to make: use the overlay's
+default reading template, and derive the document's shape from the prompt.
+
 ## Commands
 
 ### `/tdoc new <prompt>` — create a new doc
 
 1. Pick a slug from the prompt (kebab-case, ≤4 words).
-2. Create `~/tdocs/<slug>/v1/index.html` — the host document:
+2. **Read `authoring/voice.md`** and hold it while you write. The prose
+   constraints apply as you generate, not as a later cleanup pass.
+3. Create `~/tdocs/<slug>/v1/index.html` — the host document:
    - All host CSS inline in `<style>`. **No JavaScript in the host** — those tags do not execute (CSP; see HTML generation rules). If the idea needs computation, also write `v1/widgets/<name>.html` and iframe it.
    - No external CDNs in the host unless requested. No build step.
    - Clean reading-typography (system font stack, generous line-height, max-width ~720px for prose) UNLESS the doc is primarily a diagram, in which case go full-bleed.
    - Interactive: if the prompt implies a model or diagram, build it with the CSS-only techniques in "Interactivity: CSS only" — `:checked` toggles, CSS keyframes, `<style>` inside the `<svg>`. If the idea genuinely needs computation, emit a sandboxed widget island (see that section); do NOT put `<script>` in the host document.
-3. Write `meta.json`:
+4. Write `meta.json`:
    ```json
    { "title": "...", "slug": "...", "created": "<iso>", "versions": [{ "n": 1, "created": "<iso>", "prompt": "..." }] }
    ```
-4. Init `comments.json` as `[]`.
-5. Open `http://localhost:7878/d/<slug>/v/1` in the browser:
+5. Init `comments.json` as `[]`.
+6. Open `http://localhost:7878/d/<slug>/v/1` in the browser:
    ```bash
    open "http://localhost:7878/d/<slug>/v/1"
    ```
-6. Report the URL to the user.
+7. Report the URL to the user.
 
 ### `bin/tdoc-new` — programmatic entry for agents in other skills
 
@@ -315,7 +332,10 @@ comments you handled unless you reply on each one. Skipping comments
 silently is the #1 source of regression complaints.
 
 1. Read `~/tdocs/<slug>/comments.json` — filter to `status: "open"`.
-2. Read latest version's `index.html`.
+2. Read latest version's `index.html`, and re-read `authoring/voice.md`.
+   A regeneration writes new prose, so the contract applies here exactly as
+   it does on `/tdoc new`. Prose you carry over unchanged from the previous
+   version stays as it is — do not re-edit untouched sections for voice.
 3. For EACH open comment, decide one of three outcomes BEFORE writing:
    - **applied** — the comment is clear and you can act on it.
    - **partial** — you applied part of it but couldn't fully address it
@@ -563,6 +583,10 @@ When the user reports a problem, check these first:
 
 ## HTML generation rules
 
+- **The prose in the doc is governed by `authoring/voice.md`.** These rules
+  cover markup; that file covers the words inside it. Both apply to every
+  doc. It also fences off the spans the prose rules must never touch —
+  code, identifiers, quoted material, and data.
 - **Host HTML does not run author JavaScript.** Every host document is served under a nonce-based CSP (`script-src 'nonce-<n>' 'strict-dynamic'; object-src 'none'; base-uri 'none';`) and the nonce is stamped onto the two injected overlay scripts *only*. Host `<script>` tags (inline or `src`), `onclick=`/`onchange=` attributes, and `javascript:` URLs have no nonce, so the browser refuses them: no error in the page, no visible failure — just a control that never does anything. This is true on **both** the local server (`server/server.js` → `cspHeader`, `injectOverlay`) and published docs (`worker/worker.js` → `cspHeader`, `injectOverlayCfg`).
   **Exception — sandboxed island:** if the doc needs computation, write `v<n>/widgets/<name>.html` and embed `<iframe sandbox="allow-scripts" src="/d/<slug>/v/<n>/widget/<name>">`. Inline `<script>` in that widget file **does** run. Never put author JS in the host document. See "When the prompt wants something CSS can't express" below.
 - Host document is one HTML file (no imports). Optional islands are extra files under `v<n>/widgets/`. External `<script src>` in the host is blocked by the same CSP, so a CDN library (D3, Chart.js, …) will not load in the host — put it in a widget island or say so rather than shipping a dead reference.

--- a/authoring/README.md
+++ b/authoring/README.md
@@ -1,0 +1,50 @@
+# authoring/
+
+What every generated doc must go through, and where the optional
+choices live. Read by the agent at generation time, not by the reader.
+
+Three slots, deliberately separate because they answer different questions:
+
+| Slot | Question it answers | Status |
+|---|---|---|
+| `voice.md` | How does the prose read? | **Always applied.** Not a choice. |
+| `style/` | What does the page look like? | Empty — reserved. |
+| `structure/` | Which sections does this kind of doc have? | Empty — reserved. |
+
+## voice.md is a floor, not an option
+
+Nobody picks "make it sound like AI." So voice is not a template a user
+browses and selects — it applies to every doc, and the user never sees a
+switch for it. `/tdoc new` and `/tdoc edit` both read it before writing
+HTML.
+
+This matters more for tdoc than for a hand-written site: the whole product
+generates prose with a model, so the AI-slop failure mode is the house
+default unless something pushes back on it.
+
+## style/ and structure/ are empty on purpose
+
+Both are reserved mount points. The directory layout and the way a doc
+names its choice are settled here so adding entries later is additive,
+but no entries ship yet.
+
+- **style/** — visual register: type, color, density, measure. Author CSS
+  always wins over the overlay (`:where()` zero-specificity), so a style
+  entry can also break overlay chrome. Anything added here has to respect
+  the "Author HTML compatibility contract" in `SKILL.md`.
+- **structure/** — section skeletons per document kind. Default is empty,
+  meaning the agent picks the shape from the prompt, exactly as today.
+
+## Vendored upstream
+
+`vendor/no-ai-slop.md` is a verbatim copy of the `no-ai-slop` skill by
+Peter Yang (MIT), pinned at `d30eddb9e04562234f2070b5ee63ca4649d9a05e`.
+
+Content sha256 of that file: `16719efd6dc6fe5978be7f6db41a474ca246970e5014acc057e29d7bfbd63b0e`
+
+Kept verbatim so `test/authoring.test.js` can detect drift against
+upstream. tdoc-specific adaptation lives in `voice.md` instead, never by
+editing the vendored copy.
+
+To update: re-copy from https://github.com/petergyang/no-ai-slop, update
+the pin above, and re-read `voice.md` for rules that need adjusting.

--- a/authoring/structure/README.md
+++ b/authoring/structure/README.md
@@ -1,0 +1,29 @@
+# structure/ — section skeletons
+
+**Empty. Reserved. The default is no structure at all.**
+
+A structure entry answers "which sections does this kind of doc have":
+a post-mortem is timeline, blast radius, root cause, action items; a PRD
+is problem, user, non-goals, success measures.
+
+With this directory empty, the agent derives the shape from the prompt,
+exactly as it does today. Nothing changes until entries are added, and
+adding one must stay additive.
+
+## Structure is the half that saves work
+
+Recorded here so the reasoning is not lost: across the first 39 docs
+written with tdoc, the strongest signal was repetition of a single kind.
+Six separate docs across five near-duplicate slugs were all the same
+launch post, restarted from scratch each time. Other kinds show the cost
+as version depth instead — an explainer at v19, a user-feedback report at
+v10.
+
+Neither cost is a styling problem. Both are "what should this contain and
+in what order," which is what an entry here would answer.
+
+## Not a fill-in-the-blanks form
+
+An entry should describe what a section is *for* and what makes it good,
+so the agent can judge whether the material fits. A doc that emits empty
+headings the writer then has to fill in is worse than no template.

--- a/authoring/style/README.md
+++ b/authoring/style/README.md
@@ -1,0 +1,40 @@
+# style/ — visual register
+
+**Empty. Reserved.**
+
+A style entry answers "what does this page look like": type family and
+size ramp, text and background color, line height and spacing, measure,
+heading-to-body contrast, how code and quotes are treated, whether there
+is any ornament.
+
+Until an entry exists here, docs use the overlay's default reading
+template and nothing needs to be chosen.
+
+## Constraints any entry must satisfy
+
+The overlay injects its defaults at `:where()` zero specificity, so author
+CSS always wins. That makes a style entry powerful and dangerous in the
+same stroke: it can also break the overlay's own chrome. tdoc has already
+shipped that bug once (#96 — `padding: 0 24px` on the content root wiped
+the overlay's top reading space).
+
+An entry here must obey the "Author HTML compatibility contract" in
+`SKILL.md`. The parts a visual style is most likely to violate:
+
+- no `margin: 0 auto` and no top-level horizontal `padding` on the content
+  container — the overlay owns those margins
+- no global `button:hover` — it overrides the overlay's Comment control
+- nothing `position: fixed` at the top — that band is the overlay's bar
+- no page footer — the overlay injects its own
+- `tdoc-*` classes and ids stay reserved
+
+Rule of thumb when evaluating a look to adapt: styles carried by type,
+scale, spacing, and restrained color adapt cleanly. Styles carried by
+full-bleed hero sections, sticky navigation, card shadows, or an edge-to-edge
+background color fight the overlay.
+
+## Dark mode
+
+`SKILL.md` currently states light mode only, and dark mode is in flight
+(`feat/dark-mode-switch`). Any entry added here needs a dark palette, or
+an explicit note that it is light-only and why.

--- a/authoring/vendor/LICENSE-no-ai-slop
+++ b/authoring/vendor/LICENSE-no-ai-slop
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Peter Yang
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/authoring/vendor/no-ai-slop.md
+++ b/authoring/vendor/no-ai-slop.md
@@ -1,0 +1,97 @@
+---
+name: no-ai-slop
+description: Edit drafts into sharper, more human writing while preserving the writer's personal voice, or detect AI-slop patterns without rewriting. Use when the user wants a draft clearer, more direct, more opinionated, or less AI-sounding, or asks whether writing reads as AI.
+---
+
+# No AI slop
+
+You are a sharp human editor. Preserve the user's point and personal voice while making the writing clearer and more alive. Remove AI patterns without turning distinctive writing into generic polished prose.
+
+## Two jobs
+
+**Edit (default).** The user shares a draft to fix. Make the minimum effective edit with the rules below and return the edited draft plus a What changed section.
+
+**Detect.** The user asks whether a piece is AI slop, or asks to audit, scan, or flag a draft without rewriting. Name each pattern from this skill that appears, quote the line, and give the fix in a few words. Do not rewrite, score the draft, or guess whether AI wrote it. AI detectors guess. Named patterns are evidence the user can check. Offer to edit the draft after.
+
+## What to ask for
+
+If the user has not provided a draft, ask them to paste it.
+
+If the audience or format is unclear, ask one question: Who is this for and where will it be published?
+
+If the goal is unclear, ask what the reader should think, feel, or do after reading it.
+
+## Editing principles
+
+- **Preserve the writer's real voice.** First notice the draft's vocabulary, cadence, bluntness, humor, uncertainty, digressions, and level of polish. Keep the traits that feel personal to the writer. Do not make every paragraph equally tidy or rewrite distinctive lines merely for consistency.
+- **Make the minimum effective edit.** Fix AI patterns, errors, repetition, and unclear passages. Leave strong human sentences alone. A rough draft with a real voice should still sound like the same person after editing.
+- **Lead with the point when the setup adds nothing.** Cut generic throat-clearing. Keep a personal aside, story, or admission when it creates context, tension, or character.
+- **Front-load only when it improves clarity.** Put conclusions early when that helps the reader. Do not force every section and paragraph into the same point-detail-background shape.
+- **Keep the user's meaning.** Don't invent claims, examples, stats, or opinions. If something is unclear, ask.
+- **Open it up, don't dumb it down.** Keep the substance, nuance, and precision. Strip out only what makes it hard to read: jargon, long sentences, abstract nouns, and tangled structure.
+- **Use active voice.** "The team shipped it Tuesday" beats "the decision emerged." Never let inanimate things do human verbs.
+- **Make every sentence earn its place.** Cut empty qualifiers and throat-clearing. Keep phrases such as "I think," "maybe," or "to be honest" when they express real uncertainty, self-awareness, or the writer's spoken rhythm.
+- **Untangle sentences without flattening the cadence.** Split sentences and paragraphs when they are genuinely hard to follow. Keep longer spoken sentences, fragments, and changes in pace when they are clear and characteristic of the writer.
+- **Be concrete and specific.** Abstraction is where writing goes to die. "The integration improved efficiency" becomes "The integration cut deploy time from 40 minutes to 4." Names, numbers, dates, mechanisms, and examples beat abstractions.
+- **Use the portability test.** If a sentence could move unchanged to another person, company, country, or product, it is probably filler. Cut it or replace it with a fact, example, mechanism, consequence, or judgment specific to this subject.
+- **Always show, don't tell the reader what to think.** Make facts, actions, examples, and consequences carry the emphasis. Cut commentary that labels a point important, surprising, subtle, or obvious instead of demonstrating why. If the surrounding prose already shows the point, trust the reader and delete the commentary.
+- **Protect the specific fact.** Don't smooth a useful detail into generic importance. "The tool significantly improves engineering productivity" becomes "The tool cut review time from 30 minutes to 8."
+- **Make verbs do the work.** Replace weak verb phrases with direct verbs. "Made a decision" becomes "decided." "Has the ability to" becomes "can."
+- **Know the job.** Before structure or word choice, know what the piece is trying to do and who it is for.
+- **Preserve useful edge and character.** Keep strong opinions, blunt language, humor, profanity, self-interruptions, and honest admissions when they belong to the writer. Don't replace them with safer or more professional wording.
+- **Keep structure unless it's hurting the piece.** Preserve the writer's progression and detours when they carry personality. If you reorganize, say why in the What changed section.
+
+## Words to cut
+
+Banned outright: delve, foster, leverage, utilize, facilitate, empower, streamline, robust, cutting-edge, paradigm shift, game changer, this is huge, this changes everything, tapestry, realm, beacon, multifaceted, meticulous, intricate, paramount, transformative, elevate, embark, supercharge, harness, ever-evolving.
+
+Often-empty adverbs: just, literally, honestly, simply, actually, truly, fundamentally, importantly, crucially, inherently, inevitably. Cut them when they add nothing. Keep them when they carry emphasis, uncertainty, contrast, or the writer's natural spoken rhythm.
+
+Often-empty phrases: it's worth noting, it's important to note, at the end of the day, when it comes to, at its core, in today's world, in the age of, in the world of, the reality is, the truth is, in terms of, with regard to, in order to, going forward, in this article, let's dive in. Cut them when they delay the point. Keep an occasional phrase when it is part of the writer's recognizable voice and the sentence still earns its place.
+
+## Patterns to cut
+
+**Binary contrasts.** "This is not X. It's Y." / "The question isn't X, it's Y." / "It's not just X but Y." State Y directly. "The question isn't the model. It's the eval." becomes "The eval matters more than the model."
+
+**Throat-clearing openers.** "Here's the thing," "Here's what I mean," "Let me be clear," "I'll be honest," "The uncomfortable truth is." Cut them and state the point.
+
+**Faux-insight setups.** "This is the part most people skip," "What most people get wrong," "Here's what nobody tells you," "The part everyone misses." These flatter the writer as the lone expert. Cut the setup and make the claim stand on its own. "The part everyone misses: distribution is the real moat" becomes "Distribution is the moat."
+
+**Colon reveals.** A noun phrase, a colon, then a lowercase dramatic reveal: "The detail that makes it work: a separate agent grades it." "The best part: it learns." Rewrite as a plain sentence ("A separate agent does the grading, which is what makes it work"). Use colons for lists, labels, and quotes, not fake drama. Prefer sentence case after a colon unless grammar, a proper noun, a title, or code requires otherwise.
+
+**Superficial analysis.** Cut trailing `-ing` clauses that pretend to explain meaning: "highlighting," "underscoring," "reflecting," "showcasing." "The launch adds file search, highlighting the team's commitment to better workflows" becomes "The launch adds file search, so users can find old drafts without leaving the editor."
+
+**Importance puffery.** "Stands as a testament," "marks a pivotal moment," "plays a vital role," "solidifies its position," "underscores its significance." State the fact and let the reader judge whether it matters. "The launch marks a pivotal moment for the company" becomes "The launch is the company's first paid product."
+
+**Interpretive metadiscourse.** Cut lines that step outside the subject to tell the reader what to notice, how much weight to give it, or how to interpret the prose: "That last part matters more than it sounds," "The key point is," "As you can see," "This distinction matters," and redundant "In other words." If the point is clear, delete the aside. Otherwise, replace it with support or facts already in the content.
+
+**Weasel attribution.** "Experts agree," "industry reports suggest," "many argue," "widely regarded as," "studies show." Name the source or cut the claim. If the user has no source, ask instead of inventing one.
+
+**Fake-strong verbs.** Prefer "is" and "has" when they are clearer. "The app serves as a centralized hub for sponsor management" becomes "The app tracks sponsors, drafts, due dates, and approvals in one place."
+
+**Synonym cycling.** If the clear word is right, repeat it. Don't rotate terms for style. "The agent reviews the draft. The assistant scores the piece. The tool suggests fixes" becomes "The agent reviews the draft, scores it, and suggests fixes."
+
+**Negative listing.** "Not a X. Not a Y. A Z." Just say Z.
+
+**Dramatic fragmentation.** "X. And Y. And Z." or "That's it. That's the whole thing." Use complete sentences.
+
+**Robotic rhythm.** Avoid repeated sentence shapes, identical paragraph structures, and stacked punchy fragments. Vary the shape only when it helps the point.
+
+**Rhetorical setups.** "What if I told you...", "Think about it:", "Plot twist:", and self-answered "Question? Answer." pairs. Drop them and make the point.
+
+**Fake-profound kickers.** Cut the final "deep" line when it turns the point into a cute metaphor, aphorism, or mic-drop sentence. Do not rewrite it into a better metaphor. Do not preserve the rhythm. Delete it, then end on the clearest concrete sentence already in the draft. If the ending needs more closure, add a plain takeaway or next action.
+
+**Summary-recap endings.** "In conclusion," "Ultimately," "Overall," or a final paragraph that restates the piece. The reader was just there. End on the last concrete point, takeaway, or next action instead.
+
+**Formatting slop.** Emoji in headings, bold sprinkled mid-sentence for emphasis, bullet lists where two sentences of prose would read better, and headers over two-sentence sections. Format should follow the content, not decorate it.
+
+**Em dashes.** Do not use them as a default rhythm crutch. In short copy, use none. In longer drafts, 1-2 are fine if they clearly beat commas, periods, or parentheses. Remove clusters and decorative dashes.
+
+## Workflow
+
+1. Read the full draft before editing.
+2. Identify the core point and 3-5 voice signals to preserve, such as vocabulary, cadence, bluntness, humor, uncertainty, or digressions. Keep this note internal. If you cannot identify the core point, ask the user.
+3. For a detect request, return the findings report described in Two jobs and stop.
+4. For an edit, make the minimum effective changes, then check the edited draft against `eval.md` yourself.
+5. If any check fails, fix the draft and run the checks again.
+6. Output the full edited draft and a short **What changed** section.

--- a/authoring/voice.md
+++ b/authoring/voice.md
@@ -1,0 +1,77 @@
+# Voice — required for every generated doc
+
+**Read this before writing doc HTML.** Applies to `/tdoc new` and to every
+regeneration in `/tdoc edit`. There is no opt-out and no user-facing switch.
+
+The full rule set is `vendor/no-ai-slop.md` (no-ai-slop by Peter Yang, MIT).
+Read it. This file only records how it applies to tdoc, because tdoc
+differs from the drafts that skill was written for in two ways.
+
+## Apply at generation, not as a cleanup pass
+
+Upstream is written as an editor: a human pastes a draft, it gets fixed.
+tdoc has no draft — the agent is writing the prose in the first place. So
+these are constraints on what you write, not a second pass over what you
+already wrote. Do not generate slop and then clean it.
+
+Never ask the reader to paste a draft, and never emit a "What changed"
+section into a doc. Those upstream behaviors belong to the editing flow,
+not to generation.
+
+## What the rules govern, and what they must not touch
+
+They govern prose: headings, paragraphs, list items, captions, callouts,
+table cell text, and any narration around a figure.
+
+They must not rewrite:
+
+- code inside `<pre>` / `<code>`, including comments and string literals
+- identifiers, API names, CLI flags, file paths, error strings
+- quoted material — if the doc quotes a person, an issue, a log line, or a
+  commit message, the quote is evidence and stays verbatim, slop or not
+- data: table values, axis labels, legends, numbers
+- text inside SVG that labels a diagram part rather than narrating it
+
+A rule that improves a sentence will corrupt an error string. When a span
+is a name, a value, or a quotation, leave it alone.
+
+## Whose voice is being preserved
+
+Upstream spends much of its length protecting a writer's personal voice:
+their bluntness, humor, hedges, digressions. A generated doc has no such
+writer, so that half has no object and cannot be followed literally.
+
+It does have an anchor: **the user's own prompt.** When the user's request
+carries specific wording, a stance, a metaphor, or a level of bluntness,
+that is the voice to carry into the doc. Prefer their nouns over synonyms
+you find more elegant. If they were blunt, do not make the doc diplomatic.
+
+Absent any signal, default to plain and direct rather than inventing a
+personality.
+
+## The failures that actually show up in generated docs
+
+The whole upstream list applies. These are the ones a model reaches for
+hardest when generating from a prompt, so they are worth naming twice:
+
+- **Binary contrasts.** "It's not X, it's Y." State Y.
+- **Faux-insight setups.** "What most people miss," "here's the thing."
+- **Colon reveals.** A noun phrase, a colon, a dramatic lowercase reveal.
+- **Importance puffery.** Telling the reader a fact is pivotal or vital
+  instead of giving them the fact and letting them judge.
+- **Interpretive metadiscourse.** "This distinction matters." If it does,
+  the surrounding prose already showed it.
+- **Trailing `-ing` clauses that fake analysis.** "..., highlighting the
+  team's commitment to quality."
+- **Portability test.** If a sentence could move unchanged to another
+  company or product, it is filler. Replace it with a fact, a mechanism, a
+  number, or a judgment specific to this subject.
+
+Banned words and phrases: see the lists in `vendor/no-ai-slop.md`. They are
+the authority; do not maintain a second copy here.
+
+## When a rule fights the document
+
+Correctness wins over voice. If following a rule would make a technical
+statement wrong, ambiguous, or unsearchable, keep the accurate wording.
+Prose rules never justify changing what the doc claims.

--- a/skills/tdoc/SKILL.md
+++ b/skills/tdoc/SKILL.md
@@ -223,16 +223,19 @@ sleep 1
 
 ## Authoring contract — read before writing any doc
 
-**`authoring/voice.md` is required reading before you write doc HTML**, on
-every `/tdoc new` and every regeneration in `/tdoc edit`. It is a floor, not
+**`$SKILL_DIR/authoring/voice.md` is required reading before you write doc
+HTML**, on every `/tdoc new` and every regeneration in `/tdoc edit`.
+`$SKILL_DIR` is the installed skill directory resolved in "Setup check"
+above (`~/.claude/skills/tdoc`, or `~/.codex/skills/tdoc` under Codex) —
+**not** the current working directory, which is the user's project. It is a floor, not
 a user-selectable option: there is no switch, and no doc is exempt.
 
 It carries tdoc's adaptation of the vendored `no-ai-slop` rule set
-(`authoring/vendor/no-ai-slop.md`) — which prose the rules govern, which
+(`$SKILL_DIR/authoring/vendor/no-ai-slop.md`) — which prose the rules govern, which
 spans they must never rewrite (code, identifiers, quotes, data), and whose
 voice is being preserved when the agent is the one writing.
 
-`authoring/style/` and `authoring/structure/` are reserved mount points and
+`$SKILL_DIR/authoring/style/` and `$SKILL_DIR/authoring/structure/` are reserved mount points and
 are **empty today**. Empty means no choice to make: use the overlay's
 default reading template, and derive the document's shape from the prompt.
 
@@ -241,7 +244,7 @@ default reading template, and derive the document's shape from the prompt.
 ### `/tdoc new <prompt>` — create a new doc
 
 1. Pick a slug from the prompt (kebab-case, ≤4 words).
-2. **Read `authoring/voice.md`** and hold it while you write. The prose
+2. **Read `$SKILL_DIR/authoring/voice.md`** and hold it while you write. The prose
    constraints apply as you generate, not as a later cleanup pass.
 3. Create `~/tdocs/<slug>/v1/index.html` — the host document:
    - All host CSS inline in `<style>`. **No JavaScript in the host** — those tags do not execute (CSP; see HTML generation rules). If the idea needs computation, also write `v1/widgets/<name>.html` and iframe it.
@@ -332,7 +335,7 @@ comments you handled unless you reply on each one. Skipping comments
 silently is the #1 source of regression complaints.
 
 1. Read `~/tdocs/<slug>/comments.json` — filter to `status: "open"`.
-2. Read latest version's `index.html`, and re-read `authoring/voice.md`.
+2. Read latest version's `index.html`, and re-read `$SKILL_DIR/authoring/voice.md`.
    A regeneration writes new prose, so the contract applies here exactly as
    it does on `/tdoc new`. Prose you carry over unchanged from the previous
    version stays as it is — do not re-edit untouched sections for voice.
@@ -583,7 +586,7 @@ When the user reports a problem, check these first:
 
 ## HTML generation rules
 
-- **The prose in the doc is governed by `authoring/voice.md`.** These rules
+- **The prose in the doc is governed by `$SKILL_DIR/authoring/voice.md`.** These rules
   cover markup; that file covers the words inside it. Both apply to every
   doc. It also fences off the spans the prose rules must never touch —
   code, identifiers, quoted material, and data.

--- a/skills/tdoc/SKILL.md
+++ b/skills/tdoc/SKILL.md
@@ -221,26 +221,43 @@ nohup node "$SKILL_DIR/server/server.js" > "$TDOC_DIR/.server.log" 2>&1 &
 sleep 1
 ```
 
+## Authoring contract — read before writing any doc
+
+**`authoring/voice.md` is required reading before you write doc HTML**, on
+every `/tdoc new` and every regeneration in `/tdoc edit`. It is a floor, not
+a user-selectable option: there is no switch, and no doc is exempt.
+
+It carries tdoc's adaptation of the vendored `no-ai-slop` rule set
+(`authoring/vendor/no-ai-slop.md`) — which prose the rules govern, which
+spans they must never rewrite (code, identifiers, quotes, data), and whose
+voice is being preserved when the agent is the one writing.
+
+`authoring/style/` and `authoring/structure/` are reserved mount points and
+are **empty today**. Empty means no choice to make: use the overlay's
+default reading template, and derive the document's shape from the prompt.
+
 ## Commands
 
 ### `/tdoc new <prompt>` — create a new doc
 
 1. Pick a slug from the prompt (kebab-case, ≤4 words).
-2. Create `~/tdocs/<slug>/v1/index.html` — the host document:
+2. **Read `authoring/voice.md`** and hold it while you write. The prose
+   constraints apply as you generate, not as a later cleanup pass.
+3. Create `~/tdocs/<slug>/v1/index.html` — the host document:
    - All host CSS inline in `<style>`. **No JavaScript in the host** — those tags do not execute (CSP; see HTML generation rules). If the idea needs computation, also write `v1/widgets/<name>.html` and iframe it.
    - No external CDNs in the host unless requested. No build step.
    - Clean reading-typography (system font stack, generous line-height, max-width ~720px for prose) UNLESS the doc is primarily a diagram, in which case go full-bleed.
    - Interactive: if the prompt implies a model or diagram, build it with the CSS-only techniques in "Interactivity: CSS only" — `:checked` toggles, CSS keyframes, `<style>` inside the `<svg>`. If the idea genuinely needs computation, emit a sandboxed widget island (see that section); do NOT put `<script>` in the host document.
-3. Write `meta.json`:
+4. Write `meta.json`:
    ```json
    { "title": "...", "slug": "...", "created": "<iso>", "versions": [{ "n": 1, "created": "<iso>", "prompt": "..." }] }
    ```
-4. Init `comments.json` as `[]`.
-5. Open `http://localhost:7878/d/<slug>/v/1` in the browser:
+5. Init `comments.json` as `[]`.
+6. Open `http://localhost:7878/d/<slug>/v/1` in the browser:
    ```bash
    open "http://localhost:7878/d/<slug>/v/1"
    ```
-6. Report the URL to the user.
+7. Report the URL to the user.
 
 ### `bin/tdoc-new` — programmatic entry for agents in other skills
 
@@ -315,7 +332,10 @@ comments you handled unless you reply on each one. Skipping comments
 silently is the #1 source of regression complaints.
 
 1. Read `~/tdocs/<slug>/comments.json` — filter to `status: "open"`.
-2. Read latest version's `index.html`.
+2. Read latest version's `index.html`, and re-read `authoring/voice.md`.
+   A regeneration writes new prose, so the contract applies here exactly as
+   it does on `/tdoc new`. Prose you carry over unchanged from the previous
+   version stays as it is — do not re-edit untouched sections for voice.
 3. For EACH open comment, decide one of three outcomes BEFORE writing:
    - **applied** — the comment is clear and you can act on it.
    - **partial** — you applied part of it but couldn't fully address it
@@ -563,6 +583,10 @@ When the user reports a problem, check these first:
 
 ## HTML generation rules
 
+- **The prose in the doc is governed by `authoring/voice.md`.** These rules
+  cover markup; that file covers the words inside it. Both apply to every
+  doc. It also fences off the spans the prose rules must never touch —
+  code, identifiers, quoted material, and data.
 - **Host HTML does not run author JavaScript.** Every host document is served under a nonce-based CSP (`script-src 'nonce-<n>' 'strict-dynamic'; object-src 'none'; base-uri 'none';`) and the nonce is stamped onto the two injected overlay scripts *only*. Host `<script>` tags (inline or `src`), `onclick=`/`onchange=` attributes, and `javascript:` URLs have no nonce, so the browser refuses them: no error in the page, no visible failure — just a control that never does anything. This is true on **both** the local server (`server/server.js` → `cspHeader`, `injectOverlay`) and published docs (`worker/worker.js` → `cspHeader`, `injectOverlayCfg`).
   **Exception — sandboxed island:** if the doc needs computation, write `v<n>/widgets/<name>.html` and embed `<iframe sandbox="allow-scripts" src="/d/<slug>/v/<n>/widget/<name>">`. Inline `<script>` in that widget file **does** run. Never put author JS in the host document. See "When the prompt wants something CSS can't express" below.
 - Host document is one HTML file (no imports). Optional islands are extra files under `v<n>/widgets/`. External `<script src>` in the host is blocked by the same CSP, so a CDN library (D3, Chart.js, …) will not load in the host — put it in a widget island or say so rather than shipping a dead reference.

--- a/test/authoring.test.js
+++ b/test/authoring.test.js
@@ -53,6 +53,45 @@ t('SKILL.md makes voice.md required reading before generating', () => {
   assert(/## Authoring contract/.test(s), 'SKILL.md lost the top-level Authoring contract section');
 });
 
+// The agent's cwd is the USER'S project, not the skill install. A bare
+// relative path like `authoring/voice.md` resolves to nothing there, so the
+// agent silently reads no contract and generation looks fine while being
+// completely ungoverned. Every reference must carry $SKILL_DIR.
+t('every authoring/ reference is $SKILL_DIR-anchored, never a bare relative path', () => {
+  const s = read('SKILL.md');
+  // Only real file paths -- not the prose phrase "Local skill is
+  // authoring/scaffold" in the source-of-truth line.
+  const PATHS = ['authoring/voice.md', 'authoring/style/',
+                 'authoring/structure/', 'authoring/vendor/'];
+  const bare = [];
+  for (const ref of PATHS) {
+    let i = 0;
+    while ((i = s.indexOf(ref, i)) !== -1) {
+      const prefix = s.slice(Math.max(0, i - 11), i);
+      if (!prefix.endsWith('$SKILL_DIR/')) {
+        const line = s.slice(0, i).split('\n').length;
+        bare.push(`${ref} (line ${line})`);
+      }
+      i += ref.length;
+    }
+  }
+  assert(bare.length === 0,
+    `bare authoring/ paths in SKILL.md: ${bare.join(', ')}\n` +
+    '    The agent runs in the user\'s project directory, so these resolve to nothing.\n' +
+    '    Prefix with $SKILL_DIR/ (resolved in the Setup check section).');
+});
+
+t('SKILL.md says what $SKILL_DIR is, so the variable is not dangling', () => {
+  const s = read('SKILL.md');
+  const i = s.indexOf('## Authoring contract');
+  assert(i !== -1, 'Authoring contract section missing');
+  const sect = s.slice(i, s.indexOf('\n## ', i + 10));
+  assert(/\.claude\/skills\/tdoc/.test(sect),
+    'the Authoring contract section never says where $SKILL_DIR points');
+  assert(/not.*working directory/i.test(sect),
+    'the section does not warn that $SKILL_DIR is not the cwd');
+});
+
 t('the reference sits on BOTH generation paths (/tdoc new and /tdoc edit)', () => {
   const s = read('SKILL.md');
   const section = (start, end) => {

--- a/test/authoring.test.js
+++ b/test/authoring.test.js
@@ -1,0 +1,124 @@
+// authoring/ contract guard.
+//
+// The point of authoring/ is that generation cannot quietly stop going
+// through it. A prose rule set that nothing references is a file nobody
+// reads, and that failure is silent: docs keep generating, just without
+// the contract. These tests convert "the reference was dropped" and "the
+// vendored copy was edited in place" into build failures.
+//
+// What this CANNOT test: whether a model actually obeys voice.md at
+// generation time. The offline suite has no model. It tests that the
+// contract is wired in and intact — necessary, not sufficient.
+//
+// Run with: node test/authoring.test.js
+
+const fs = require('fs');
+const path = require('path');
+const crypto = require('crypto');
+
+let pass = 0, fail = 0;
+function ok(n) { console.log(`  ✓ ${n}`); pass++; }
+function bad(n, e) { console.log(`  ✗ ${n}\n    ${e}`); fail++; }
+function t(n, fn) { try { fn(); ok(n); } catch (e) { bad(n, e.message); } }
+function assert(c, m) { if (!c) throw new Error(m || 'assertion failed'); }
+
+const root = path.join(__dirname, '..');
+const read = (p) => fs.readFileSync(path.join(root, p), 'utf8');
+const exists = (p) => fs.existsSync(path.join(root, p));
+
+console.log('authoring/ contract');
+
+t('all three slots exist', () => {
+  for (const p of ['authoring/README.md', 'authoring/voice.md',
+                   'authoring/style/README.md', 'authoring/structure/README.md']) {
+    assert(exists(p), `missing ${p}`);
+  }
+});
+
+t('style/ and structure/ are still empty mount points', () => {
+  // Adding entries is fine — but it must be a deliberate change that also
+  // teaches SKILL.md how to select one, not a stray file. This test is the
+  // reminder to do both.
+  for (const dir of ['authoring/style', 'authoring/structure']) {
+    const entries = fs.readdirSync(path.join(root, dir));
+    assert(entries.length === 1 && entries[0] === 'README.md',
+      `${dir} gained ${entries.filter(e => e !== 'README.md').join(', ')} — ` +
+      `if that is intended, teach SKILL.md how a doc selects one, then update this test`);
+  }
+});
+
+t('SKILL.md makes voice.md required reading before generating', () => {
+  const s = read('SKILL.md');
+  assert(/authoring\/voice\.md/.test(s), 'SKILL.md never references authoring/voice.md');
+  assert(/## Authoring contract/.test(s), 'SKILL.md lost the top-level Authoring contract section');
+});
+
+t('the reference sits on BOTH generation paths (/tdoc new and /tdoc edit)', () => {
+  const s = read('SKILL.md');
+  const section = (start, end) => {
+    const a = s.indexOf(start);
+    assert(a !== -1, `section not found: ${start}`);
+    const b = end ? s.indexOf(end, a) : s.length;
+    return s.slice(a, b === -1 ? s.length : b);
+  };
+  const nw = section('### `/tdoc new', '### `bin/tdoc-new');
+  const ed = section('### `/tdoc edit', '### `/tdoc fork');
+  assert(/authoring\/voice\.md/.test(nw), '/tdoc new no longer reads authoring/voice.md');
+  assert(/authoring\/voice\.md/.test(ed), '/tdoc edit no longer reads authoring/voice.md');
+});
+
+t('HTML generation rules point at the prose contract', () => {
+  const s = read('SKILL.md');
+  const i = s.indexOf('## HTML generation rules');
+  assert(i !== -1, 'HTML generation rules section is gone');
+  const sect = s.slice(i, s.indexOf('\n## ', i + 10));
+  assert(/authoring\/voice\.md/.test(sect),
+    'HTML generation rules no longer reference authoring/voice.md');
+});
+
+t('voice.md defers to the vendored rule set instead of forking it', () => {
+  const v = read('authoring/voice.md');
+  assert(/vendor\/no-ai-slop\.md/.test(v), 'voice.md does not point at the vendored rules');
+  // The banned-word lists must have exactly one home. A second copy in
+  // voice.md would drift from upstream the first time it is updated.
+  assert(!/^Banned outright:/m.test(v),
+    'voice.md duplicates the banned-word list — it must cite vendor/no-ai-slop.md as the authority');
+});
+
+t('voice.md fences off spans the prose rules must not rewrite', () => {
+  const v = read('authoring/voice.md');
+  // A prose rule applied to an error string or an API name corrupts it.
+  for (const term of ['code', 'identifiers', 'quoted', 'data']) {
+    assert(new RegExp(term, 'i').test(v), `voice.md does not fence off ${term}`);
+  }
+});
+
+t('vendored no-ai-slop copy is present and unmodified', () => {
+  assert(exists('authoring/vendor/no-ai-slop.md'), 'vendored copy missing');
+  const body = read('authoring/vendor/no-ai-slop.md');
+  assert(body.length > 2000, 'vendored copy looks truncated');
+  const actual = crypto.createHash('sha256').update(body).digest('hex');
+  const readme = read('authoring/README.md');
+  const m = /Content sha256 of that file: `([0-9a-f]{64})`/.exec(readme);
+  assert(m, 'authoring/README.md does not record the vendored sha256');
+  assert(actual === m[1],
+    `vendored copy was edited in place (sha ${actual.slice(0, 12)} vs recorded ${m[1].slice(0, 12)}).\n` +
+    '    Adapt tdoc behavior in authoring/voice.md, not by editing the vendored file.\n' +
+    '    If this is a genuine upstream refresh, update the sha and the pinned commit in README.');
+});
+
+t('MIT attribution ships with the vendored copy', () => {
+  assert(exists('authoring/vendor/LICENSE-no-ai-slop'), 'upstream LICENSE not vendored');
+  const lic = read('authoring/vendor/LICENSE-no-ai-slop');
+  assert(/MIT License/.test(lic), 'vendored LICENSE is not the MIT text');
+  assert(/Copyright \(c\)/.test(lic), 'vendored LICENSE has no copyright line');
+  assert(/upstream|no-ai-slop/i.test(read('authoring/README.md')), 'README does not credit upstream');
+});
+
+t('upstream commit is pinned so a refresh is a deliberate diff', () => {
+  const readme = read('authoring/README.md');
+  assert(/\b[0-9a-f]{40}\b/.test(readme), 'README does not pin an upstream commit sha');
+});
+
+console.log(`\n${pass} passed, ${fail} failed`);
+process.exit(fail ? 1 : 0);

--- a/test/run.js
+++ b/test/run.js
@@ -16,6 +16,7 @@ const path = require('path');
 
 const OFFLINE = [
   'agent-md.test.js',          // AGENTS.md one-line SoT rule; no ARCHITECTURE.md
+  'authoring.test.js',        // authoring/ contract: voice floor wired into both generation paths
   'manifest.test.js',         // plugin.json / marketplace.json schema (#36, #42)
   'comment-history.test.js',  // event-log fold + cross-version pull
   'event-convergence.test.js',// eid dedup convergence + fold ordering


### PR DESCRIPTION
Refs #194.

## What

`SKILL.md` has extensive rules for the markup and none for the words inside
it. Since every tdoc doc is model-written, AI-slop phrasing was the house
default with nothing pushing back on it.

Adds `authoring/`, read at generation time, with three slots answering three
different questions:

| Slot | Question | Ships as |
|---|---|---|
| `voice.md` | How does the prose read? | **Always applied** |
| `style/` | What does the page look like? | Empty, reserved |
| `structure/` | Which sections does this kind of doc have? | Empty, reserved |

**Voice is a floor, not a template.** Nobody picks "make it sound like AI,"
so it never appears as something a user browses or selects. `style/` and
`structure/` are mount points only — the layout is settled so adding entries
later is additive, but no entry ships here.

## Why vendor instead of writing our own list

`no-ai-slop` (Peter Yang, MIT, ~5.5k stars) is 20+ named patterns, each with
a concrete rewrite. A from-scratch list would be worse. The copy stays
verbatim under `authoring/vendor/` with its MIT LICENSE, pinned to commit
`d30eddb` **and** to a content sha256, so a local edit and a genuine upstream
refresh are distinguishable. tdoc-specific adaptation goes in `voice.md`,
never by editing the vendored file.

## Two adaptations that mattered

**Upstream is an editor. tdoc generates.** It assumes a human pastes a draft
to be fixed. tdoc has no draft, so the constraints apply as the prose is
written, not as a cleanup pass. `voice.md` also suppresses two upstream
behaviors that belong to editing: asking the reader to paste a draft, and
emitting a "What changed" section.

**"Preserve the writer's voice" has no object.** Much of upstream protects a
human writer's bluntness, humor, and hedges. A generated doc has no such
writer, so that half cannot be followed literally. The available anchor is
the user's own prompt: their nouns, their stance, their level of bluntness.

## The hazard the contract has to fence off

The rules are written for prose, but a tdoc doc is full of non-prose: code
blocks, identifiers, CLI flags, error strings, quoted material, table values,
SVG labels. **A rule that improves a sentence corrupts an error string.**
`voice.md` names those spans as off-limits, and a test asserts it still does.

## Wiring

`voice.md` is referenced from three places, each independently asserted:

- the new top-level **Authoring contract** section in `SKILL.md`
- step 2 of `/tdoc new`
- step 2 of `/tdoc edit` (a regeneration writes new prose, so it applies
  there too — but prose carried over unchanged is left alone)
- the first bullet of **HTML generation rules**

`skills/tdoc/SKILL.md` re-synced, since `agent-md.test.js` asserts the plugin
copy matches. `AGENTS.md` deliberately untouched — it is guarded as an exact
string.

## Tests

`test/authoring.test.js`, 10 assertions, registered in `test/run.js`. It fails
the build if the reference is dropped from either generation path, if the
vendored copy is edited in place, if `voice.md` forks the banned-word list
instead of citing it, or if `style/`/`structure/` gain entries without
`SKILL.md` learning how to select one.

**Negative-verified, not just green:** deleting the `/tdoc new` reference
produced `✗ the reference sits on BOTH generation paths`, and appending one
byte to the vendored file produced `✗ vendored copy was edited in place
(sha 19997d4158f4 vs recorded 16719efd6dc6)`. Both went back to green on
restore. A guard nobody has watched fail is not a guard.

## What this cannot verify

The offline suite has no model, so **no test here proves an agent actually
obeys `voice.md` at generation time.** These tests prove the contract is
wired in and intact — necessary, not sufficient. Behavioral confidence has to
come from generating docs and reading them, which is the natural next step
before this gets leaned on.

## Checklist

- [x] `node test/run.js` — PASS, all 43 suites green
- [x] Negative tests confirm the guards actually fail on breakage
- [x] `skills/tdoc/SKILL.md` re-synced with root
- [x] Upstream MIT LICENSE vendored and credited
- [x] `AGENTS.md` untouched
- [x] No unrelated changes
