### PR TITLE
Docs carry tdoc's own design system by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,18 @@ file and `.claude-plugin/plugin.json`.
 
 ### Added
 
+- **Docs now carry tdoc's own design system.** New
+  `authoring/style/default.md`, extracted from
+  `tdoc.dev/d/tdoc-design-tokens/v/1` and applied when a doc selects no
+  style -- which today is every doc. Nine `--td-*` color tokens (accent
+  reserved for links and the single primary action; red reserved for
+  destruction), a system-font type scale, and the principles that decide
+  what the tokens do not. **Newly generated docs are denser than before**
+  (body 15px rather than the overlay's 17px, h1 29px rather than 34px):
+  deliberate, so documents and product chrome are one system. Docs already
+  published are unaffected. `SKILL.md`'s blanket "don't write your own CSS"
+  rule is replaced -- the house style *is* CSS every doc carries; what
+  stays forbidden is inventing a scale or palette on top of it. `#197`.
 - **Every generated doc goes through a voice contract.** New `authoring/`
   directory, read at generation time. `authoring/voice.md` applies to
   `/tdoc new` and every `/tdoc edit` regeneration — a floor, not a

--- a/SKILL.md
+++ b/SKILL.md
@@ -223,29 +223,43 @@ sleep 1
 
 ## Authoring contract — read before writing any doc
 
-**`$SKILL_DIR/authoring/voice.md` is required reading before you write doc
-HTML**, on every `/tdoc new` and every regeneration in `/tdoc edit`.
+Two files are required reading before you write doc HTML, on every
+`/tdoc new` and every regeneration in `/tdoc edit`:
+
+| File | Governs | Selectable? |
+|---|---|---|
+| `$SKILL_DIR/authoring/voice.md` | how the prose reads | No. A floor — no switch, no doc exempt. |
+| `$SKILL_DIR/authoring/style/default.md` | what the page looks like | Only by naming another entry in `style/`. |
+
 `$SKILL_DIR` is the installed skill directory resolved in "Setup check"
 above (`~/.claude/skills/tdoc`, or `~/.codex/skills/tdoc` under Codex) —
-**not** the current working directory, which is the user's project. It is a floor, not
-a user-selectable option: there is no switch, and no doc is exempt.
+**not** the current working directory, which is the user's project.
 
-It carries tdoc's adaptation of the vendored `no-ai-slop` rule set
+`voice.md` carries tdoc's adaptation of the vendored `no-ai-slop` rule set
 (`$SKILL_DIR/authoring/vendor/no-ai-slop.md`) — which prose the rules govern, which
 spans they must never rewrite (code, identifiers, quotes, data), and whose
 voice is being preserved when the agent is the one writing.
 
-`$SKILL_DIR/authoring/style/` and `$SKILL_DIR/authoring/structure/` are reserved mount points and
-are **empty today**. Empty means no choice to make: use the overlay's
-default reading template, and derive the document's shape from the prompt.
+`style/default.md` is tdoc's own design system: nine `--td-*` color tokens,
+a system-font type scale, and the principles that decide what the tokens do
+not. **It is denser than the overlay's injected reading defaults on purpose**
+(body 15px rather than 17px) so that documents and product chrome are one
+system. Apply it unless the user names a different entry in
+`$SKILL_DIR/authoring/style/`.
+
+`$SKILL_DIR/authoring/structure/` is still an empty mount point. Empty means
+no choice to make: derive the document's shape from the prompt.
 
 ## Commands
 
 ### `/tdoc new <prompt>` — create a new doc
 
 1. Pick a slug from the prompt (kebab-case, ≤4 words).
-2. **Read `$SKILL_DIR/authoring/voice.md`** and hold it while you write. The prose
-   constraints apply as you generate, not as a later cleanup pass.
+2. **Read `$SKILL_DIR/authoring/voice.md` and `$SKILL_DIR/authoring/style/default.md`.**
+   Voice constrains the prose as you generate it, not as a later cleanup
+   pass. The style supplies the `--td-*` tokens and type scale to write into
+   the doc's `<style>` — apply it unless the user named another entry in
+   `$SKILL_DIR/authoring/style/`.
 3. Create `~/tdocs/<slug>/v1/index.html` — the host document:
    - All host CSS inline in `<style>`. **No JavaScript in the host** — those tags do not execute (CSP; see HTML generation rules). If the idea needs computation, also write `v1/widgets/<name>.html` and iframe it.
    - No external CDNs in the host unless requested. No build step.
@@ -336,6 +350,8 @@ silently is the #1 source of regression complaints.
 
 1. Read `~/tdocs/<slug>/comments.json` — filter to `status: "open"`.
 2. Read latest version's `index.html`, and re-read `$SKILL_DIR/authoring/voice.md`.
+   Keep whichever style the existing version already uses — a regeneration is
+   not the moment to restyle a doc the reader has been reading.
    A regeneration writes new prose, so the contract applies here exactly as
    it does on `/tdoc new`. Prose you carry over unchanged from the previous
    version stays as it is — do not re-edit untouched sections for voice.
@@ -712,9 +728,21 @@ the host document — it is inert under CSP. Two options:
 Download / Duplicate of a doc with islands is not supported in v1 (the
 downloaded file cannot fetch `/widget/` URLs; account copy is host HTML only).
 
-### Default styling — DO NOT re-style the doc
+### Default styling — apply the house style, invent nothing
 
-The overlay injects a complete default template modeled after the `conway-life` doc ("What if a doc could think?"): tight, readable, system fonts only. **Download** is a menu: **Download HTML** (`/export`, reader CSS inlined as `<style id="tdoc-reader">`) and **Download PDF** (print that same reading column; use the browser's Save as PDF). Neither includes overlay chrome (bar, comments).
+**The doc's look comes from `$SKILL_DIR/authoring/style/default.md`, not from
+your own judgment.** Write that style's `--td-*` tokens and type scale into
+the doc's `<style>`, and reference the tokens by name. "Do not re-style"
+means do not invent a scale or a palette — it does not mean write no CSS,
+because the house style is itself a CSS block every doc carries.
+
+The values below are what the **overlay** injects underneath, at `:where()`
+zero specificity. They are the floor a doc falls to for anything the house
+style does not set, and they are what `/export` and Download PDF inline.
+Where the two differ — body 17px here, 15px in the house style — **the house
+style wins**, deliberately, so documents and product chrome share one scale.
+
+The overlay's injected template is modeled after the `conway-life` doc ("What if a doc could think?"): tight, readable, system fonts only. **Download** is a menu: **Download HTML** (`/export`, reader CSS inlined as `<style id="tdoc-reader">`) and **Download PDF** (print that same reading column; use the browser's Save as PDF). Neither includes overlay chrome (bar, comments).
 
 - System font stack (`system-ui, -apple-system, "Segoe UI", Roboto, sans-serif`)
 - Body: 17px / line-height 1.65 / `#111` on white
@@ -726,7 +754,11 @@ The overlay injects a complete default template modeled after the `conway-life` 
 - pre: mono 15px, light gray background, left-rule, scrolling overflow
 - Code (inline): 0.92em mono, light-gray rounded chip
 
-**Don't write your own CSS for these unless the doc genuinely needs a different aesthetic** (a presentation, a landing page, a doc with custom widgets). Reading docs, essays, and reports should not override the template.
+**Beyond the house style, write CSS only for what the doc itself needs** — a
+custom widget, a chart, a simulation — and scope it tightly (`.my-slider { … }`),
+never as a global element rule. A presentation or landing page may warrant a
+larger departure; a reading doc, essay, or report should not invent its own
+typography on top of the house style.
 
 What to write:
 

--- a/authoring/style/README.md
+++ b/authoring/style/README.md
@@ -1,14 +1,19 @@
 # style/ — visual register
 
-**Empty. Reserved.**
+A style entry answers "what does this page look like": type family and size
+ramp, text and background color, line height and spacing, measure,
+heading-to-body contrast, how code and quotes are treated, whether there is
+any ornament.
 
-A style entry answers "what does this page look like": type family and
-size ramp, text and background color, line height and spacing, measure,
-heading-to-body contrast, how code and quotes are treated, whether there
-is any ornament.
+## Entries
 
-Until an entry exists here, docs use the overlay's default reading
-template and nothing needs to be chosen.
+| Entry | When it applies |
+|---|---|
+| `default.md` | **When a doc selects nothing.** tdoc's own design system, extracted from `tdoc.dev/d/tdoc-design-tokens/v/1`. |
+
+`default.md` is not a fallback of last resort — it is the house style, and
+today it is what every doc gets. A future entry is an *opt-out* of it, so
+it has to be different enough to be worth naming.
 
 ## Constraints any entry must satisfy
 
@@ -18,8 +23,8 @@ same stroke: it can also break the overlay's own chrome. tdoc has already
 shipped that bug once (#96 — `padding: 0 24px` on the content root wiped
 the overlay's top reading space).
 
-An entry here must obey the "Author HTML compatibility contract" in
-`SKILL.md`. The parts a visual style is most likely to violate:
+An entry must obey the "Author HTML compatibility contract" in `SKILL.md`.
+The parts a visual style is most likely to violate:
 
 - no `margin: 0 auto` and no top-level horizontal `padding` on the content
   container — the overlay owns those margins
@@ -30,11 +35,19 @@ An entry here must obey the "Author HTML compatibility contract" in
 
 Rule of thumb when evaluating a look to adapt: styles carried by type,
 scale, spacing, and restrained color adapt cleanly. Styles carried by
-full-bleed hero sections, sticky navigation, card shadows, or an edge-to-edge
-background color fight the overlay.
+full-bleed hero sections, sticky navigation, card shadows, or an
+edge-to-edge background color fight the overlay.
+
+## Adding an entry
+
+An entry is a markdown file naming its tokens, its type scale, and the
+judgment calls the tokens do not cover. Adding one is not just a new file:
+`SKILL.md` has to learn that the name is selectable, and
+`test/authoring.test.js` asserts the two stay in sync. A style the agent
+cannot be told to use is a file nobody reads.
 
 ## Dark mode
 
 `SKILL.md` currently states light mode only, and dark mode is in flight
-(`feat/dark-mode-switch`). Any entry added here needs a dark palette, or
-an explicit note that it is light-only and why.
+(`feat/dark-mode-switch`). Any entry needs a dark palette, or an explicit
+note that it is light-only and why.

--- a/authoring/style/default.md
+++ b/authoring/style/default.md
@@ -1,0 +1,86 @@
+# default — tdoc's own design system
+
+**Applied when a doc selects no style, which today is every doc.**
+
+Extracted from `tdoc.dev/d/tdoc-design-tokens/v/1`, the system already
+running in tdoc's product chrome. Adopting it here makes documents and
+product one system instead of two.
+
+## Color
+
+Nine tokens. Declare them on `:root` in the doc's `<style>` and reference
+them by name; do not inline the hex values.
+
+| Token | Value | Use |
+|---|---|---|
+| `--td-accent` | `#1652f0` | links, and the one primary button |
+| `--td-accent-hover` | `#1245d0` | primary hover |
+| `--td-ink` | `#111` | primary text |
+| `--td-muted` | `#666` | secondary / meta text |
+| `--td-line` | `#eee` | thin borders, dividers |
+| `--td-surface` | `#f7f7f7` | subtle fills |
+| `--td-danger` | `#b42318` | destructive only |
+| `--td-danger-tint` | `#fdeceb` | danger hover-fill |
+| `--td-ok` | `#087443` | success / confirmed |
+
+There is no token for decorative color, because there is no decorative
+color. A doc that needs a categorical palette (a chart with six series) is
+the one case to add local values — keep them out of `--td-*`, which names
+roles rather than colors.
+
+## Typography
+
+System fonts only. No web fonts, no `@font-face`, nothing to load.
+
+```
+body      15px / 1.6      system-ui, -apple-system, "Segoe UI", Roboto, sans-serif
+h1        29px / 700 / -.01em letter-spacing
+meta      12px            --td-muted
+mono      ui-monospace, "SF Mono", Menlo, monospace
+measure   max-width: 720px
+```
+
+Section labels — the small uppercase kind above a group — are `12px`,
+weight `700`, `letter-spacing: .06em`, uppercase, in `--td-muted`.
+
+**This is denser than the overlay's injected default** (body 17px, h1 34px).
+That is intended: it is the same scale the product chrome uses. Do not
+split the difference, and do not restore 17px for "long" docs — one scale
+or the system is pointless.
+
+## Principles
+
+These decide the cases the token table does not cover.
+
+- **Restraint.** The Notion / Linear / Google Docs lineage. When in doubt,
+  remove. Less is more.
+- **Ration the accent.** Blue is only for links and the single primary
+  action in a view. Everything else is ink and muted greys. Two blue
+  buttons on one screen means one of them is not primary.
+- **Quiet the dangerous.** Destructive actions are low-frequency, so the
+  less visible the better. Tuck them behind a `⋯`, grey at rest, and show
+  red only once revealed.
+- **Chrome never fights content.** Controls must not compete with the
+  reading surface. A list of docs should look like a list, not a control
+  panel.
+- **No framework.** system-ui plus a dozen CSS variables.
+
+## Staying inside the overlay's contract
+
+This style is safe by construction — it is carried by type scale, spacing,
+and restrained color, never by full-bleed backgrounds, sticky headers, or
+card shadows. Keeping it that way is a requirement, not an accident. The
+"Author HTML compatibility contract" in `SKILL.md` still governs:
+
+- no `margin: 0 auto` and no top-level horizontal padding on `.wrap` —
+  the overlay owns those margins
+- no global `button:hover` — scope it, or it overrides the overlay's
+  Comment control
+- nothing `position: fixed` at the top, no page footer
+- `tdoc-*` names stay reserved
+
+## Dark mode
+
+Light only. Every value here assumes a white ground. Dark mode is in
+flight (`feat/dark-mode-switch`); when it lands, this file needs a second
+palette rather than a filter over this one.

--- a/skills/tdoc/SKILL.md
+++ b/skills/tdoc/SKILL.md
@@ -223,29 +223,43 @@ sleep 1
 
 ## Authoring contract — read before writing any doc
 
-**`$SKILL_DIR/authoring/voice.md` is required reading before you write doc
-HTML**, on every `/tdoc new` and every regeneration in `/tdoc edit`.
+Two files are required reading before you write doc HTML, on every
+`/tdoc new` and every regeneration in `/tdoc edit`:
+
+| File | Governs | Selectable? |
+|---|---|---|
+| `$SKILL_DIR/authoring/voice.md` | how the prose reads | No. A floor — no switch, no doc exempt. |
+| `$SKILL_DIR/authoring/style/default.md` | what the page looks like | Only by naming another entry in `style/`. |
+
 `$SKILL_DIR` is the installed skill directory resolved in "Setup check"
 above (`~/.claude/skills/tdoc`, or `~/.codex/skills/tdoc` under Codex) —
-**not** the current working directory, which is the user's project. It is a floor, not
-a user-selectable option: there is no switch, and no doc is exempt.
+**not** the current working directory, which is the user's project.
 
-It carries tdoc's adaptation of the vendored `no-ai-slop` rule set
+`voice.md` carries tdoc's adaptation of the vendored `no-ai-slop` rule set
 (`$SKILL_DIR/authoring/vendor/no-ai-slop.md`) — which prose the rules govern, which
 spans they must never rewrite (code, identifiers, quotes, data), and whose
 voice is being preserved when the agent is the one writing.
 
-`$SKILL_DIR/authoring/style/` and `$SKILL_DIR/authoring/structure/` are reserved mount points and
-are **empty today**. Empty means no choice to make: use the overlay's
-default reading template, and derive the document's shape from the prompt.
+`style/default.md` is tdoc's own design system: nine `--td-*` color tokens,
+a system-font type scale, and the principles that decide what the tokens do
+not. **It is denser than the overlay's injected reading defaults on purpose**
+(body 15px rather than 17px) so that documents and product chrome are one
+system. Apply it unless the user names a different entry in
+`$SKILL_DIR/authoring/style/`.
+
+`$SKILL_DIR/authoring/structure/` is still an empty mount point. Empty means
+no choice to make: derive the document's shape from the prompt.
 
 ## Commands
 
 ### `/tdoc new <prompt>` — create a new doc
 
 1. Pick a slug from the prompt (kebab-case, ≤4 words).
-2. **Read `$SKILL_DIR/authoring/voice.md`** and hold it while you write. The prose
-   constraints apply as you generate, not as a later cleanup pass.
+2. **Read `$SKILL_DIR/authoring/voice.md` and `$SKILL_DIR/authoring/style/default.md`.**
+   Voice constrains the prose as you generate it, not as a later cleanup
+   pass. The style supplies the `--td-*` tokens and type scale to write into
+   the doc's `<style>` — apply it unless the user named another entry in
+   `$SKILL_DIR/authoring/style/`.
 3. Create `~/tdocs/<slug>/v1/index.html` — the host document:
    - All host CSS inline in `<style>`. **No JavaScript in the host** — those tags do not execute (CSP; see HTML generation rules). If the idea needs computation, also write `v1/widgets/<name>.html` and iframe it.
    - No external CDNs in the host unless requested. No build step.
@@ -336,6 +350,8 @@ silently is the #1 source of regression complaints.
 
 1. Read `~/tdocs/<slug>/comments.json` — filter to `status: "open"`.
 2. Read latest version's `index.html`, and re-read `$SKILL_DIR/authoring/voice.md`.
+   Keep whichever style the existing version already uses — a regeneration is
+   not the moment to restyle a doc the reader has been reading.
    A regeneration writes new prose, so the contract applies here exactly as
    it does on `/tdoc new`. Prose you carry over unchanged from the previous
    version stays as it is — do not re-edit untouched sections for voice.
@@ -712,9 +728,21 @@ the host document — it is inert under CSP. Two options:
 Download / Duplicate of a doc with islands is not supported in v1 (the
 downloaded file cannot fetch `/widget/` URLs; account copy is host HTML only).
 
-### Default styling — DO NOT re-style the doc
+### Default styling — apply the house style, invent nothing
 
-The overlay injects a complete default template modeled after the `conway-life` doc ("What if a doc could think?"): tight, readable, system fonts only. **Download** is a menu: **Download HTML** (`/export`, reader CSS inlined as `<style id="tdoc-reader">`) and **Download PDF** (print that same reading column; use the browser's Save as PDF). Neither includes overlay chrome (bar, comments).
+**The doc's look comes from `$SKILL_DIR/authoring/style/default.md`, not from
+your own judgment.** Write that style's `--td-*` tokens and type scale into
+the doc's `<style>`, and reference the tokens by name. "Do not re-style"
+means do not invent a scale or a palette — it does not mean write no CSS,
+because the house style is itself a CSS block every doc carries.
+
+The values below are what the **overlay** injects underneath, at `:where()`
+zero specificity. They are the floor a doc falls to for anything the house
+style does not set, and they are what `/export` and Download PDF inline.
+Where the two differ — body 17px here, 15px in the house style — **the house
+style wins**, deliberately, so documents and product chrome share one scale.
+
+The overlay's injected template is modeled after the `conway-life` doc ("What if a doc could think?"): tight, readable, system fonts only. **Download** is a menu: **Download HTML** (`/export`, reader CSS inlined as `<style id="tdoc-reader">`) and **Download PDF** (print that same reading column; use the browser's Save as PDF). Neither includes overlay chrome (bar, comments).
 
 - System font stack (`system-ui, -apple-system, "Segoe UI", Roboto, sans-serif`)
 - Body: 17px / line-height 1.65 / `#111` on white
@@ -726,7 +754,11 @@ The overlay injects a complete default template modeled after the `conway-life` 
 - pre: mono 15px, light gray background, left-rule, scrolling overflow
 - Code (inline): 0.92em mono, light-gray rounded chip
 
-**Don't write your own CSS for these unless the doc genuinely needs a different aesthetic** (a presentation, a landing page, a doc with custom widgets). Reading docs, essays, and reports should not override the template.
+**Beyond the house style, write CSS only for what the doc itself needs** — a
+custom widget, a chart, a simulation — and scope it tightly (`.my-slider { … }`),
+never as a global element rule. A presentation or landing page may warrant a
+larger departure; a reading doc, essay, or report should not invent its own
+typography on top of the house style.
 
 What to write:
 

--- a/test/authoring.test.js
+++ b/test/authoring.test.js
@@ -35,16 +35,58 @@ t('all three slots exist', () => {
   }
 });
 
-t('style/ and structure/ are still empty mount points', () => {
-  // Adding entries is fine — but it must be a deliberate change that also
+t('structure/ is still an empty mount point', () => {
+  // Adding entries is fine -- but it must be a deliberate change that also
   // teaches SKILL.md how to select one, not a stray file. This test is the
   // reminder to do both.
-  for (const dir of ['authoring/style', 'authoring/structure']) {
-    const entries = fs.readdirSync(path.join(root, dir));
-    assert(entries.length === 1 && entries[0] === 'README.md',
-      `${dir} gained ${entries.filter(e => e !== 'README.md').join(', ')} — ` +
-      `if that is intended, teach SKILL.md how a doc selects one, then update this test`);
+  const entries = fs.readdirSync(path.join(root, 'authoring/structure'));
+  assert(entries.length === 1 && entries[0] === 'README.md',
+    `authoring/structure gained ${entries.filter(e => e !== 'README.md').join(', ')} -- ` +
+    `if that is intended, teach SKILL.md how a doc selects one, then update this test`);
+});
+
+t('style/ ships a default entry', () => {
+  assert(exists('authoring/style/default.md'), 'authoring/style/default.md missing');
+  const d = read('authoring/style/default.md');
+  // The nine tokens are the entry's whole point. An emptied-out file that
+  // still exists would pass a mere existence check.
+  for (const tok of ['--td-accent', '--td-ink', '--td-muted', '--td-line',
+                     '--td-surface', '--td-danger', '--td-ok']) {
+    assert(d.includes(tok), `default.md no longer defines ${tok}`);
   }
+});
+
+// Single source of truth. Every entry in style/ must be selectable by name
+// from SKILL.md -- otherwise the agent is offered a style it cannot be told
+// to use, or worse, a user names one the agent has never heard of. Both fail
+// silently: the doc still generates, just with the wrong look.
+t('every style/ entry is selectable from SKILL.md', () => {
+  const s = read('SKILL.md');
+  const entries = fs.readdirSync(path.join(root, 'authoring/style'))
+    .filter(e => e.endsWith('.md') && e !== 'README.md');
+  assert(entries.length > 0, 'authoring/style has no entries at all');
+  const unreferenced = entries.filter(e => !s.includes(`authoring/style/${e}`));
+  assert(unreferenced.length === 0,
+    `style entries SKILL.md never mentions: ${unreferenced.join(', ')}\n` +
+    '    An entry the agent cannot be told to use is a file nobody reads.');
+});
+
+t('the default style is applied on the generation path, not merely listed', () => {
+  const s = read('SKILL.md');
+  const a = s.indexOf('### `/tdoc new');
+  const b = s.indexOf('### `bin/tdoc-new');
+  assert(a !== -1 && b !== -1, '/tdoc new section not found');
+  assert(s.slice(a, b).includes('authoring/style/default.md'),
+    '/tdoc new does not read authoring/style/default.md');
+});
+
+// SKILL.md used to say "Don't write your own CSS" while the house style IS a
+// CSS block every doc carries. Those two cannot both stand.
+t('SKILL.md no longer forbids the CSS the house style requires', () => {
+  const s = read('SKILL.md');
+  assert(!/\*\*Don't write your own CSS for these unless/.test(s),
+    'the old blanket "Don\'t write your own CSS" rule is back -- it contradicts ' +
+    'authoring/style/default.md, which every doc must write into its <style>');
 });
 
 t('SKILL.md makes voice.md required reading before generating', () => {


### PR DESCRIPTION
Refs #197. Follows #195, which shipped `authoring/style/` as an empty mount point.

## What

Extracts tdoc's own design system — documented and already in production at
`tdoc.dev/d/tdoc-design-tokens/v/1` — into `authoring/style/default.md`,
applied when a doc selects no style. Today that is every doc.

That page states its own status plainly: *"The hand-built minimal system
behind tdoc — no external template. This page uses the tokens it
documents."* So this is extraction, not invention.

**Nine color tokens, naming roles rather than colors:**

| Token | Value | Use |
|---|---|---|
| `--td-accent` | `#1652f0` | links + the one primary button |
| `--td-accent-hover` | `#1245d0` | primary hover |
| `--td-ink` | `#111` | primary text |
| `--td-muted` | `#666` | secondary / meta |
| `--td-line` | `#eee` | thin borders / dividers |
| `--td-surface` | `#f7f7f7` | subtle fills |
| `--td-danger` | `#b42318` | destructive only |
| `--td-danger-tint` | `#fdeceb` | danger hover-fill |
| `--td-ok` | `#087443` | success / confirmed |

Plus a system-font type scale and the five principles that decide what the
tokens do not: restraint, ration the accent, quiet the dangerous, chrome
never fights content, no framework.

## The density change is the part to look at

| | Before (overlay default) | After (house style) |
|---|---|---|
| body | 17px / 1.6 | **15px** / 1.6 |
| h1 | 34px | **29px** |

Newly generated docs get denser. That is deliberate — it is the scale the
product chrome already uses, and one system beats two. Flagging it because
the diff looks like a small number change and it is not: it applies to every
future doc.

**Docs already published are unaffected.** Their HTML is a build artifact
written under the old defaults.

## A contradiction this forced

`SKILL.md` said **"Don't write your own CSS for these"** while the house
style *is* a CSS block every doc carries. Both could not stand.

The rule is now: apply the house style's tokens, invent no scale or palette
of your own, and scope any doc-specific CSS tightly. A test asserts the old
blanket rule cannot come back.

## Deliberately not touched

Nothing in `server/overlay.js` or the worker. The overlay's injected
defaults remain the floor a doc falls to for anything the house style does
not set; this only changes what the agent *writes into* the doc. That keeps
a hot file — currently edited across several open PRs and one other working
session — entirely out of this change.

## Tests

Four new guards in `test/authoring.test.js`, each negative-verified by
breaking it and watching it fail:

| Guard | Broken by | Fails with |
|---|---|---|
| Every `style/` entry is selectable from `SKILL.md` | adding `editorial.md` unreferenced | `style entries SKILL.md never mentions: editorial.md` |
| `default.md` still defines its tokens | emptying the file | `default.md no longer defines --td-accent` |
| The default is read on the generation path | — | `/tdoc new does not read authoring/style/default.md` |
| The old CSS ban stays gone | re-adding the sentence | `the old blanket "Don't write your own CSS" rule is back` |

The first is the one that matters longer-term: it is the single-source-of-truth
guard. A style entry the agent cannot be told to use, or a name a user picks
that the agent never heard of, both fail **silently** — the doc still
generates, just with the wrong look. Same failure shape as the bare-path bug
in #195.

## Checklist

- [x] `node test/run.js` — PASS, all 43 suites green
- [x] All four new guards negative-verified
- [x] `skills/tdoc/SKILL.md` re-synced with root
- [x] `AGENTS.md` untouched
- [x] `server/overlay.js` and `worker/` untouched
- [x] No unrelated changes
