### PR TITLE
PR preview serves the homepage and /start

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -119,18 +119,19 @@ jobs:
           fi
 
       - name: Create tdoc-preview Worker if missing
-        working-directory: worker
-        run: |
-          set -euo pipefail
-          if ! wrangler deployments list --name tdoc-preview >/dev/null 2>&1; then
-            wrangler deploy --name tdoc-preview -c wrangler.preview.toml
-          fi
-
-      - name: Put preview-only upload token (never production)
         env:
           TDOC_PREVIEW_UPLOAD_TOKEN: ${{ secrets.TDOC_PREVIEW_UPLOAD_TOKEN }}
         working-directory: worker
         run: |
+          set -euo pipefail
+          if wrangler deployments list --name tdoc-preview >/dev/null 2>&1; then
+            exit 0
+          fi
+          wrangler deploy --name tdoc-preview -c wrangler.preview.toml
+          # secret put only works while the latest version is the live deploy.
+          # Later PRs use versions upload (preview aliases), which leaves latest
+          # undeployed — wrangler secret put then refuses. The token is already
+          # on the Worker; new versions inherit it. Do not put on every run.
           printf '%s' "$TDOC_PREVIEW_UPLOAD_TOKEN" | wrangler secret put TDOC_UPLOAD_TOKEN --name tdoc-preview
 
       - name: Upload version with pr-N alias

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -1,8 +1,15 @@
 name: PR preview
 
-# Isolated preview Worker (tdoc-preview) for published-chrome checks (#148).
+# Isolated preview Worker (tdoc-preview) for published-chrome checks (#148 #199).
 # Not tdoc.dev, not anyone's BYOK Worker. Own KV + R2, no Durable Object
 # (Cloudflare will not mint preview URLs for a Worker that implements a DO).
+#
+# After the pr-N alias is up, seed the same docs production serves:
+#   tornado-doc — tdoc-landing-release collapse to v1, so `/` is landingResponse
+#   tdoc-start  — /start tutorial
+#   conway-life — overlay demo fixture
+# Preview KV is shared across aliases; the most recent seed is what `/` shows.
+# Do not publish as a side slug (tdoc-home): that leaves `/` on the fallback.
 #
 # Required GitHub secrets (same Cloudflare account as tdoc.dev CD):
 #   CLOUDFLARE_API_TOKEN
@@ -146,7 +153,7 @@ jobs:
           echo "host=$HOST" >> "$GITHUB_OUTPUT"
           echo "Preview host: $HOST"
 
-      - name: Seed demo doc conway-life v1 + v2
+      - name: Seed homepage, tutorial, and overlay demo
         env:
           TDOC_PREVIEW_UPLOAD_TOKEN: ${{ secrets.TDOC_PREVIEW_UPLOAD_TOKEN }}
           PREVIEW_HOST: ${{ steps.upload.outputs.host }}
@@ -165,7 +172,41 @@ jobs:
             echo "preview host never answered /api/ping: $BASE" >&2
             exit 1
           fi
-          seed() {
+
+          # Same collapse production uses: latest landing version -> v1, thread stripped.
+          # Upload as slug tornado-doc so this host's `/` is landingResponse, not a side slug.
+          node bin/tdoc-landing-release
+
+          upload_doc () {
+            local slug="$1" dir="$2" ver="$3"
+            local widgets='{}'
+            if [ -d "$dir/v$ver/widgets" ]; then
+              for wf in "$dir"/v$ver/widgets/*.html; do
+                [ -f "$wf" ] || continue
+                widgets="$(jq -n --argjson acc "$widgets" \
+                  --arg name "$(basename "$wf" .html)" --rawfile html "$wf" \
+                  '$acc + {($name): $html}')"
+              done
+            fi
+            jq -n --arg slug "$slug" --argjson version "$ver" \
+              --rawfile html "$dir/v$ver/index.html" \
+              --slurpfile meta "$dir/meta.json" \
+              --argjson widgets "$widgets" \
+              '{slug:$slug, version:$version, html:$html, meta:$meta[0]}
+               + (if $widgets == {} then {} else {widgets:$widgets} end)' \
+              > /tmp/tdoc-preview-upload.json
+            curl -sS --connect-timeout 10 --max-time 60 -X POST "$BASE/api/upload" \
+              -H "Authorization: Bearer $TDOC_PREVIEW_UPLOAD_TOKEN" \
+              -H "Content-Type: application/json" \
+              --data-binary @/tmp/tdoc-preview-upload.json \
+              | tee /tmp/tdoc-preview-upload-resp.json
+            jq -e '.ok == true' /tmp/tdoc-preview-upload-resp.json >/dev/null
+          }
+
+          upload_doc tornado-doc .release/tornado-doc 1
+          upload_doc tdoc-start landing/tdoc-start 1
+
+          seed_fixture() {
             local v="$1" html="$2"
             jq -n \
               --arg slug conway-life \
@@ -181,8 +222,23 @@ jobs:
               | tee /tmp/tdoc-preview-upload-resp.json
             jq -e '.ok == true' /tmp/tdoc-preview-upload-resp.json >/dev/null
           }
-          seed 1 test/fixtures/tdocs/sample-doc/v1/index.html
-          seed 2 test/fixtures/tdocs/sample-doc/v2/index.html
+          seed_fixture 1 test/fixtures/tdocs/sample-doc/v1/index.html
+          seed_fixture 2 test/fixtures/tdocs/sample-doc/v2/index.html
+
+          for i in 1 2 3 4 5 6 7 8; do
+            home=$(curl -sS --max-time 15 "$BASE/" || true)
+            tour=$(curl -sS --max-time 15 "$BASE/start" || true)
+            if [[ "$home" == *'"slug":"tornado-doc"'* \
+              && "$home" == *'"isLanding":true'* \
+              && "$tour" == *'"slug":"tdoc-start"'* ]]; then
+              echo "preview / and /start are serving the landing docs"
+              exit 0
+            fi
+            echo "attempt $i: landing not both live yet" >&2
+            sleep 3
+          done
+          echo "preview host is not serving tornado-doc on / (or tdoc-start on /start)" >&2
+          exit 1
 
       - name: Sticky preview comment
         env:
@@ -194,7 +250,10 @@ jobs:
           BODY=$(cat <<EOF
           <!-- tdoc-preview -->
           ### Preview
-          **Open this:** https://${PREVIEW_HOST}/d/conway-life/v/2
+          **Open this:** https://${PREVIEW_HOST}/
+
+          - Tutorial: https://${PREVIEW_HOST}/start
+          - Overlay demo: https://${PREVIEW_HOST}/d/conway-life/v/2
 
           This link is unique to this PR. New commits update the same URL. It is not [tdoc.dev](https://tdoc.dev).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,10 +18,12 @@ file and `.claude-plugin/plugin.json`.
   identifiers, quoted material, and data. `authoring/style/` and
   `authoring/structure/` ship as empty reserved mount points. `#194`.
 - **PR preview Worker (`tdoc-preview`).** Pull requests on tornado-doc/tdoc
-  get a unique `pr-<N>` preview URL and a sticky comment pointing at
-  `/d/conway-life/v/2` on that host — published chrome, not Local Studio,
-  not tdoc.dev, not a personal Worker. Own R2 + KV, no Durable Object
-  (Cloudflare will not mint preview URLs for a DO Worker). `#148`.
+  get a unique `pr-<N>` preview URL. The sticky comment opens that host's
+  `/` (homepage from `tornado-doc` via the same `tdoc-landing-release`
+  payload production uses), plus `/start` and `/d/conway-life/v/2`.
+  Published chrome, not Local Studio, not tdoc.dev, not a personal Worker.
+  Own R2 + KV, no Durable Object (Cloudflare will not mint preview URLs
+  for a DO Worker). `#148` `#199`.
 - **Hosted tdoc.dev is multi-tenant.** GitHub sign-in mints a recoverable
   account-scoped upload token (`POST /api/hosted/token`). `/me` lists that
   user's slugs (`meta.hosted.github_login`), not the Worker operator's dump.

--- a/test/preview-workflow.test.js
+++ b/test/preview-workflow.test.js
@@ -41,13 +41,31 @@ t('uses pr-<N> alias, not the branch name', () => {
     'must not alias from the branch name');
 });
 
-t('sticky comment matches the #148 template', () => {
+t('sticky comment opens the preview homepage, not only the overlay demo', () => {
   assert(wf.includes('<!-- tdoc-preview -->'), 'must use the sticky HTML marker');
-  assert(wf.includes('**Open this:**'), 'must lead with Open this');
-  assert(wf.includes('/d/conway-life/v/2'), 'Open this must be the demo doc, not the host root');
+  assert(wf.includes('**Open this:** https://${PREVIEW_HOST}/'),
+    'Open this must be the preview host root (homepage)');
+  assert(!/\*\*Open this:\*\* https:\/\/\$\{PREVIEW_HOST\}\/d\//.test(wf),
+    'Open this must not be a doc path; / is landingResponse after seed');
+  assert(wf.includes('/start'), 'must link the tutorial');
+  assert(wf.includes('/d/conway-life/v/2'), 'must still link the overlay demo');
   assert(wf.includes('It is not [tdoc.dev](https://tdoc.dev)'),
     'must say the link is not tdoc.dev');
   assert(wf.includes('issues/comments/'), 'must PATCH an existing comment rather than always POST');
+});
+
+t('seeds homepage as tornado-doc, plus /start, not a side slug', () => {
+  assert(/^\s+node bin\/tdoc-landing-release\s*$/m.test(wf),
+    'must collapse landing via tdoc-landing-release with the default tornado-doc slug');
+  assert(wf.includes('upload_doc tornado-doc .release/tornado-doc 1'),
+    'must upload the release payload as tornado-doc so / is landingResponse');
+  assert(wf.includes('upload_doc tdoc-start landing/tdoc-start 1'),
+    'must upload the tutorial');
+  assert(wf.includes('"slug":"tornado-doc"'), 'verify / is tornado-doc');
+  assert(wf.includes('"isLanding":true'), 'verify / is landingResponse');
+  assert(wf.includes('"slug":"tdoc-start"'), 'verify /start is tdoc-start');
+  assert(!/upload_doc tdoc-home/.test(wf) && !/tdoc-landing-release tdoc-home/.test(wf),
+    'must not upload as tdoc-home; that leaves / on the fallback');
 });
 
 t('preview storage is not production, and DO is stripped', () => {

--- a/test/preview-workflow.test.js
+++ b/test/preview-workflow.test.js
@@ -85,6 +85,9 @@ t('never uses a personal Worker or the production upload token', () => {
   assert(!wf.includes('published.json'), 'must not read a laptop ~/.tdoc/published.json');
   assert(wf.includes('Do not deploy previews to a personal Worker'),
     'missing-secrets error must say not to use a personal Worker');
+  const afterUpload = wf.split('Upload version with pr-N alias')[1] || '';
+  assert(!/wrangler secret put/.test(afterUpload),
+    'must not wrangler-secret-put after versions exist (latest version is undeployed)');
 });
 
 t('Node and wrangler match production CD pins', () => {


### PR DESCRIPTION
Related to #199

PR preview already minted a `pr-<N>` host (#148) but `/` was the empty branded fallback — nothing seeded `tornado-doc`. Reviewing the homepage meant waiting for merge, or uploading to a personal Worker.

Each preview job now uploads the same payload production uses:

- `node bin/tdoc-landing-release` → slug **tornado-doc** so `/` is `landingResponse` (not a side slug like `tdoc-home`)
- `tdoc-start` as `/start`
- existing `conway-life` fixture for overlay chrome

Sticky **Open this** is the preview host root. Tutorial and overlay demo are extra links. Not tdoc.dev, not a personal Worker.

Preview KV is shared across aliases: the most recent seed is what `/` shows. The **code** (overlay) is still unique to this PR.

Verified on this PR's own preview:
- https://pr-200-tdoc-preview.jyshi1107.workers.dev/ — `tornado-doc`, `isLanding`, published chrome
- https://pr-200-tdoc-preview.jyshi1107.workers.dev/start — tutorial
- https://pr-200-tdoc-preview.jyshi1107.workers.dev/d/conway-life/v/2 — overlay demo

Use the `pr-200-` host, not the un-aliased `tdoc-preview.jyshi1107.workers.dev`.

Not merging until you say so.