### PR TITLE
Docs carry a research-note house style by default

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -223,29 +223,44 @@ sleep 1
 
 ## Authoring contract — read before writing any doc
 
-**`$SKILL_DIR/authoring/voice.md` is required reading before you write doc
-HTML**, on every `/tdoc new` and every regeneration in `/tdoc edit`.
+Two files are required reading before you write doc HTML, on every
+`/tdoc new` and every regeneration in `/tdoc edit`:
+
+| File | Governs | Selectable? |
+|---|---|---|
+| `$SKILL_DIR/authoring/voice.md` | how the prose reads | No. A floor — no switch, no doc exempt. |
+| `$SKILL_DIR/authoring/style/default.md` | what the page looks like | Only by naming another entry in `style/`. |
+
 `$SKILL_DIR` is the installed skill directory resolved in "Setup check"
 above (`~/.claude/skills/tdoc`, or `~/.codex/skills/tdoc` under Codex) —
-**not** the current working directory, which is the user's project. It is a floor, not
-a user-selectable option: there is no switch, and no doc is exempt.
+**not** the current working directory, which is the user's project.
 
-It carries tdoc's adaptation of the vendored `no-ai-slop` rule set
+`voice.md` carries tdoc's adaptation of the vendored `no-ai-slop` rule set
 (`$SKILL_DIR/authoring/vendor/no-ai-slop.md`) — which prose the rules govern, which
 spans they must never rewrite (code, identifiers, quotes, data), and whose
 voice is being preserved when the agent is the one writing.
 
-`$SKILL_DIR/authoring/style/` and `$SKILL_DIR/authoring/structure/` are reserved mount points and
-are **empty today**. Empty means no choice to make: use the overlay's
-default reading template, and derive the document's shape from the prompt.
+`style/default.md` is the research-note style: it **trusts the overlay's
+reading typography** — no custom body size, no custom heading scale — and
+adds a small set of semantic components (a risk block, a positive-finding
+block, a leveled block, a metadata pill, a scrollable diagram box) with a
+two-hue palette where orange means risk and green means a key finding. Apply
+it unless the user names a different entry in `$SKILL_DIR/authoring/style/`.
+
+`$SKILL_DIR/authoring/structure/` is still an empty mount point. Empty means
+no choice to make: derive the document's shape from the prompt.
 
 ## Commands
 
 ### `/tdoc new <prompt>` — create a new doc
 
 1. Pick a slug from the prompt (kebab-case, ≤4 words).
-2. **Read `$SKILL_DIR/authoring/voice.md`** and hold it while you write. The prose
-   constraints apply as you generate, not as a later cleanup pass.
+2. **Read `$SKILL_DIR/authoring/voice.md` and `$SKILL_DIR/authoring/style/default.md`.**
+   Voice constrains the prose as you generate it, not as a later cleanup
+   pass. The style tells you which components to reach for and its palette —
+   apply it unless the user named another entry in `$SKILL_DIR/authoring/style/`.
+   The default style does not override reading typography, so do not set your
+   own body or heading sizes.
 3. Create `~/tdocs/<slug>/v1/index.html` — the host document:
    - All host CSS inline in `<style>`. **No JavaScript in the host** — those tags do not execute (CSP; see HTML generation rules). If the idea needs computation, also write `v1/widgets/<name>.html` and iframe it.
    - No external CDNs in the host unless requested. No build step.
@@ -338,7 +353,9 @@ silently is the #1 source of regression complaints.
 2. Read latest version's `index.html`, and re-read `$SKILL_DIR/authoring/voice.md`.
    A regeneration writes new prose, so the contract applies here exactly as
    it does on `/tdoc new`. Prose you carry over unchanged from the previous
-   version stays as it is — do not re-edit untouched sections for voice.
+   version stays as it is — do not re-edit untouched sections for voice, and
+   keep whichever style the existing version already uses rather than
+   restyling a doc the reader has been reading.
 3. For EACH open comment, decide one of three outcomes BEFORE writing:
    - **applied** — the comment is clear and you can act on it.
    - **partial** — you applied part of it but couldn't fully address it
@@ -712,9 +729,20 @@ the host document — it is inert under CSP. Two options:
 Download / Duplicate of a doc with islands is not supported in v1 (the
 downloaded file cannot fetch `/widget/` URLs; account copy is host HTML only).
 
-### Default styling — DO NOT re-style the doc
+### Default styling — trust the reading template, add components on top
 
-The overlay injects a complete default template modeled after the `conway-life` doc ("What if a doc could think?"): tight, readable, system fonts only. **Download** is a menu: **Download HTML** (`/export`, reader CSS inlined as `<style id="tdoc-reader">`) and **Download PDF** (print that same reading column; use the browser's Save as PDF). Neither includes overlay chrome (bar, comments).
+**The house style (`$SKILL_DIR/authoring/style/default.md`) deliberately does
+not touch reading typography.** It trusts the overlay's injected template for
+body size, headings, and measure, and adds only semantic components (risk /
+positive / leveled block / pill / diagram box). So "do not re-style" and the
+house style agree: write component CSS and doc-specific CSS, but do not set
+your own `font-size` on `p`, `h1`, `h2` — the overlay already did.
+
+The values below are what the overlay injects, at `:where()` zero
+specificity, and what `/export` and Download PDF inline. The house style
+sits on top of them rather than replacing them.
+
+The overlay's template is modeled after the `conway-life` doc ("What if a doc could think?"): tight, readable, system fonts only. **Download** is a menu: **Download HTML** (`/export`, reader CSS inlined as `<style id="tdoc-reader">`) and **Download PDF** (print that same reading column; use the browser's Save as PDF). Neither includes overlay chrome (bar, comments).
 
 - System font stack (`system-ui, -apple-system, "Segoe UI", Roboto, sans-serif`)
 - Body: 17px / line-height 1.65 / `#111` on white
@@ -726,7 +754,11 @@ The overlay injects a complete default template modeled after the `conway-life` 
 - pre: mono 15px, light gray background, left-rule, scrolling overflow
 - Code (inline): 0.92em mono, light-gray rounded chip
 
-**Don't write your own CSS for these unless the doc genuinely needs a different aesthetic** (a presentation, a landing page, a doc with custom widgets). Reading docs, essays, and reports should not override the template.
+**Write CSS for the house style's components and for what the doc itself
+needs** — a chart, a diagram, a custom widget — and scope it tightly
+(`.risk { … }`, `.my-slider { … }`), never as a global element rule. A
+presentation or landing page may warrant overriding the reading typography
+itself; a reading doc, essay, or report should not.
 
 What to write:
 

--- a/authoring/style/README.md
+++ b/authoring/style/README.md
@@ -1,25 +1,37 @@
 # style/ — visual register
 
-**Empty. Reserved.**
+A style entry answers "what does this page look like": which components a
+doc reaches for, what the accent colors mean, and — the axis that most
+separates styles — whether it overrides the overlay's reading typography or
+trusts it.
 
-A style entry answers "what does this page look like": type family and
-size ramp, text and background color, line height and spacing, measure,
-heading-to-body contrast, how code and quotes are treated, whether there
-is any ornament.
+## Entries
 
-Until an entry exists here, docs use the overlay's default reading
-template and nothing needs to be chosen.
+| Entry | When it applies |
+|---|---|
+| `default.md` | **When a doc selects nothing.** The research-note style, extracted from `tdoc.dev/d/avgraph-auto-research/v/1`. Trusts the overlay's reading typography; adds semantic components (risk / positive / leveled block / pill / diagram) on top. |
+
+`default.md` is the house style — today every doc gets it. A future entry is
+an *opt-out*, so it has to be different enough to be worth naming.
+
+## The axis that matters most
+
+A style either **trusts** the overlay's reading typography or **overrides**
+it. The default trusts it, which is why it stays calm and collides with the
+overlay the least. A style that overrides typography (a presentation, a
+landing page) takes on the full weight of the "Author HTML compatibility
+contract" below, because it is now fighting the overlay for the same
+properties.
 
 ## Constraints any entry must satisfy
 
 The overlay injects its defaults at `:where()` zero specificity, so author
-CSS always wins. That makes a style entry powerful and dangerous in the
-same stroke: it can also break the overlay's own chrome. tdoc has already
-shipped that bug once (#96 — `padding: 0 24px` on the content root wiped
-the overlay's top reading space).
+CSS always wins. That makes a style entry powerful and dangerous in the same
+stroke: it can also break the overlay's own chrome. tdoc has already shipped
+that bug once (#96 — `padding: 0 24px` on the content root wiped the
+overlay's top reading space).
 
-An entry here must obey the "Author HTML compatibility contract" in
-`SKILL.md`. The parts a visual style is most likely to violate:
+An entry must obey the "Author HTML compatibility contract" in `SKILL.md`:
 
 - no `margin: 0 auto` and no top-level horizontal `padding` on the content
   container — the overlay owns those margins
@@ -28,13 +40,21 @@ An entry here must obey the "Author HTML compatibility contract" in
 - no page footer — the overlay injects its own
 - `tdoc-*` classes and ids stay reserved
 
-Rule of thumb when evaluating a look to adapt: styles carried by type,
-scale, spacing, and restrained color adapt cleanly. Styles carried by
-full-bleed hero sections, sticky navigation, card shadows, or an edge-to-edge
-background color fight the overlay.
+Rule of thumb: styles carried by left rules, pale fills, chips, type scale,
+and restrained color adapt cleanly. Styles carried by full-bleed hero
+sections, sticky navigation, card shadows, or an edge-to-edge background
+fight the overlay.
+
+## Adding an entry
+
+An entry is a markdown file naming its components, its palette, and the
+judgment calls they do not cover. Adding one is not just a new file:
+`SKILL.md` has to learn that the name is selectable, and
+`test/authoring.test.js` asserts the two stay in sync. A style the agent
+cannot be told to use is a file nobody reads.
 
 ## Dark mode
 
 `SKILL.md` currently states light mode only, and dark mode is in flight
-(`feat/dark-mode-switch`). Any entry added here needs a dark palette, or
-an explicit note that it is light-only and why.
+(`feat/dark-mode-switch`). Any entry needs a dark palette, or an explicit
+note that it is light-only and why.

--- a/authoring/style/default.md
+++ b/authoring/style/default.md
@@ -1,0 +1,71 @@
+# default — the research-note style
+
+The feel of a considered analysis memo, not a marketing page. Extracted from
+`tdoc.dev/d/avgraph-auto-research/v/1`.
+
+**The one thing that defines it: trust the overlay's reading typography.**
+Don't set your own body size, heading scale, or content `max-width` — the
+overlay already gives a comfortable reading column. Everything else here is
+a starting kit, not a rulebook. Reach for what the doc needs; extend it when
+the content genuinely calls for something the kit doesn't have.
+
+**Tables are part of that — don't style them either.** Plain `<table><tr><td>`
+inherits the overlay's default: rounded grey cells separated by white gaps
+(`border-spacing`, per-cell `border-radius`, `--td-surface` fill), which is
+the look this style is known for. Writing your own `border-collapse` or
+`border-bottom` overrides it into a flat ruled grid and breaks the family
+resemblance. Only wrap a wide table in `<div class="tdoc-table-scroll">` so
+it scrolls on a phone; never restyle the cells.
+
+## A starting kit
+
+```css
+/* metadata chip — a short label beside a heading or item */
+.pill { display:inline-block; font-size:13px; padding:2px 10px;
+  border-radius:999px; background:#f0f1f4; margin-right:6px; }
+
+/* leveled / layered block — a thin left rule */
+.lvl  { border-left:3px solid #111; padding:2px 0 2px 16px; margin:24px 0; }
+
+/* a risk, cost, or failure mode — warm orange */
+.risk { background:#fdf6f0; border-left:3px solid #c97b3d; padding:12px 16px; margin:16px 0; }
+
+/* a key observation or good outcome — green */
+.good { background:#f0f7f1; border-left:3px solid #4a8f5d; padding:12px 16px; margin:16px 0; }
+
+/* wrap a wide SVG so it scrolls instead of overflowing on a phone */
+.diagram-box { max-width:100%; overflow-x:auto; margin:20px 0; }
+```
+
+For diagrams, orange (`#c97b3d`) marks the part under discussion, plain grey
+(`#f5f6f8` / `#999`) the rest, a dashed orange edge a weaker or proposed link.
+
+Orange reads as risk, green as a win — that meaning is what matters, not a
+color count. Add more hues when the content earns them (a third category, a
+chart with several series); just keep each one meaningful and let plain
+paragraphs carry most of the doc, so the accents still stand out when they
+appear.
+
+## Link generously
+
+A research note earns trust by being checkable. When the doc names a source,
+a repo, a commit, a spec, a prior doc, an issue, or a page it draws on, make
+it a real hyperlink — `<a href>` in the doc's own accent, which the overlay
+already styles. Prefer an inline link on the noun itself over a bare URL, and
+gather a short "References" or "Sources" list at the end when there are
+several. A claim the reader can follow to its source beats one they have to
+take on faith.
+
+## Style is visual only
+
+The kit decides how the page *looks*. It says nothing about section
+numbering, language, tone, or how the doc is organized — those follow the
+content and the prompt, never the style. (A style pulled from a Chinese doc
+does not make an English doc number its sections 一、二、三.)
+
+## Fits the overlay
+
+Carried by left rules, pale fills, and chips — nothing full-bleed, sticky,
+or shadowed — so it stays inside the "Author HTML compatibility contract" in
+`SKILL.md` without effort. Light mode only for now; the pale fills assume a
+white ground.

--- a/authoring/voice.md
+++ b/authoring/voice.md
@@ -7,6 +7,16 @@ The full rule set is `vendor/no-ai-slop.md` (no-ai-slop by Peter Yang, MIT).
 Read it. This file only records how it applies to tdoc, because tdoc
 differs from the drafts that skill was written for in two ways.
 
+## No bullshit. Keep it efficient.
+
+Above every specific rule below, this is the stance: say the thing, then
+stop. Every sentence carries a fact, a mechanism, a number, or a judgment the
+reader can act on. If a sentence would survive being deleted, delete it.
+Don't pad to sound thorough, don't restate the point in different words, and
+don't warm up before getting to it. A shorter doc that a reader finishes
+beats a longer one they skim. This holds for every doc, by default — there is
+no version of a tdoc doc that is exempt from it.
+
 ## Apply at generation, not as a cleanup pass
 
 Upstream is written as an editor: a human pastes a draft, it gets fixed.

--- a/skills/tdoc/SKILL.md
+++ b/skills/tdoc/SKILL.md
@@ -223,29 +223,44 @@ sleep 1
 
 ## Authoring contract — read before writing any doc
 
-**`$SKILL_DIR/authoring/voice.md` is required reading before you write doc
-HTML**, on every `/tdoc new` and every regeneration in `/tdoc edit`.
+Two files are required reading before you write doc HTML, on every
+`/tdoc new` and every regeneration in `/tdoc edit`:
+
+| File | Governs | Selectable? |
+|---|---|---|
+| `$SKILL_DIR/authoring/voice.md` | how the prose reads | No. A floor — no switch, no doc exempt. |
+| `$SKILL_DIR/authoring/style/default.md` | what the page looks like | Only by naming another entry in `style/`. |
+
 `$SKILL_DIR` is the installed skill directory resolved in "Setup check"
 above (`~/.claude/skills/tdoc`, or `~/.codex/skills/tdoc` under Codex) —
-**not** the current working directory, which is the user's project. It is a floor, not
-a user-selectable option: there is no switch, and no doc is exempt.
+**not** the current working directory, which is the user's project.
 
-It carries tdoc's adaptation of the vendored `no-ai-slop` rule set
+`voice.md` carries tdoc's adaptation of the vendored `no-ai-slop` rule set
 (`$SKILL_DIR/authoring/vendor/no-ai-slop.md`) — which prose the rules govern, which
 spans they must never rewrite (code, identifiers, quotes, data), and whose
 voice is being preserved when the agent is the one writing.
 
-`$SKILL_DIR/authoring/style/` and `$SKILL_DIR/authoring/structure/` are reserved mount points and
-are **empty today**. Empty means no choice to make: use the overlay's
-default reading template, and derive the document's shape from the prompt.
+`style/default.md` is the research-note style: it **trusts the overlay's
+reading typography** — no custom body size, no custom heading scale — and
+adds a small set of semantic components (a risk block, a positive-finding
+block, a leveled block, a metadata pill, a scrollable diagram box) with a
+two-hue palette where orange means risk and green means a key finding. Apply
+it unless the user names a different entry in `$SKILL_DIR/authoring/style/`.
+
+`$SKILL_DIR/authoring/structure/` is still an empty mount point. Empty means
+no choice to make: derive the document's shape from the prompt.
 
 ## Commands
 
 ### `/tdoc new <prompt>` — create a new doc
 
 1. Pick a slug from the prompt (kebab-case, ≤4 words).
-2. **Read `$SKILL_DIR/authoring/voice.md`** and hold it while you write. The prose
-   constraints apply as you generate, not as a later cleanup pass.
+2. **Read `$SKILL_DIR/authoring/voice.md` and `$SKILL_DIR/authoring/style/default.md`.**
+   Voice constrains the prose as you generate it, not as a later cleanup
+   pass. The style tells you which components to reach for and its palette —
+   apply it unless the user named another entry in `$SKILL_DIR/authoring/style/`.
+   The default style does not override reading typography, so do not set your
+   own body or heading sizes.
 3. Create `~/tdocs/<slug>/v1/index.html` — the host document:
    - All host CSS inline in `<style>`. **No JavaScript in the host** — those tags do not execute (CSP; see HTML generation rules). If the idea needs computation, also write `v1/widgets/<name>.html` and iframe it.
    - No external CDNs in the host unless requested. No build step.
@@ -338,7 +353,9 @@ silently is the #1 source of regression complaints.
 2. Read latest version's `index.html`, and re-read `$SKILL_DIR/authoring/voice.md`.
    A regeneration writes new prose, so the contract applies here exactly as
    it does on `/tdoc new`. Prose you carry over unchanged from the previous
-   version stays as it is — do not re-edit untouched sections for voice.
+   version stays as it is — do not re-edit untouched sections for voice, and
+   keep whichever style the existing version already uses rather than
+   restyling a doc the reader has been reading.
 3. For EACH open comment, decide one of three outcomes BEFORE writing:
    - **applied** — the comment is clear and you can act on it.
    - **partial** — you applied part of it but couldn't fully address it
@@ -712,9 +729,20 @@ the host document — it is inert under CSP. Two options:
 Download / Duplicate of a doc with islands is not supported in v1 (the
 downloaded file cannot fetch `/widget/` URLs; account copy is host HTML only).
 
-### Default styling — DO NOT re-style the doc
+### Default styling — trust the reading template, add components on top
 
-The overlay injects a complete default template modeled after the `conway-life` doc ("What if a doc could think?"): tight, readable, system fonts only. **Download** is a menu: **Download HTML** (`/export`, reader CSS inlined as `<style id="tdoc-reader">`) and **Download PDF** (print that same reading column; use the browser's Save as PDF). Neither includes overlay chrome (bar, comments).
+**The house style (`$SKILL_DIR/authoring/style/default.md`) deliberately does
+not touch reading typography.** It trusts the overlay's injected template for
+body size, headings, and measure, and adds only semantic components (risk /
+positive / leveled block / pill / diagram box). So "do not re-style" and the
+house style agree: write component CSS and doc-specific CSS, but do not set
+your own `font-size` on `p`, `h1`, `h2` — the overlay already did.
+
+The values below are what the overlay injects, at `:where()` zero
+specificity, and what `/export` and Download PDF inline. The house style
+sits on top of them rather than replacing them.
+
+The overlay's template is modeled after the `conway-life` doc ("What if a doc could think?"): tight, readable, system fonts only. **Download** is a menu: **Download HTML** (`/export`, reader CSS inlined as `<style id="tdoc-reader">`) and **Download PDF** (print that same reading column; use the browser's Save as PDF). Neither includes overlay chrome (bar, comments).
 
 - System font stack (`system-ui, -apple-system, "Segoe UI", Roboto, sans-serif`)
 - Body: 17px / line-height 1.65 / `#111` on white
@@ -726,7 +754,11 @@ The overlay injects a complete default template modeled after the `conway-life` 
 - pre: mono 15px, light gray background, left-rule, scrolling overflow
 - Code (inline): 0.92em mono, light-gray rounded chip
 
-**Don't write your own CSS for these unless the doc genuinely needs a different aesthetic** (a presentation, a landing page, a doc with custom widgets). Reading docs, essays, and reports should not override the template.
+**Write CSS for the house style's components and for what the doc itself
+needs** — a chart, a diagram, a custom widget — and scope it tightly
+(`.risk { … }`, `.my-slider { … }`), never as a global element rule. A
+presentation or landing page may warrant overriding the reading typography
+itself; a reading doc, essay, or report should not.
 
 What to write:
 

--- a/test/authoring.test.js
+++ b/test/authoring.test.js
@@ -35,16 +35,60 @@ t('all three slots exist', () => {
   }
 });
 
-t('style/ and structure/ are still empty mount points', () => {
+t('structure/ is still an empty mount point', () => {
   // Adding entries is fine — but it must be a deliberate change that also
   // teaches SKILL.md how to select one, not a stray file. This test is the
   // reminder to do both.
-  for (const dir of ['authoring/style', 'authoring/structure']) {
-    const entries = fs.readdirSync(path.join(root, dir));
-    assert(entries.length === 1 && entries[0] === 'README.md',
-      `${dir} gained ${entries.filter(e => e !== 'README.md').join(', ')} — ` +
-      `if that is intended, teach SKILL.md how a doc selects one, then update this test`);
+  const entries = fs.readdirSync(path.join(root, 'authoring/structure'));
+  assert(entries.length === 1 && entries[0] === 'README.md',
+    `authoring/structure gained ${entries.filter(e => e !== 'README.md').join(', ')} — ` +
+    `if that is intended, teach SKILL.md how a doc selects one, then update this test`);
+});
+
+t('style/ ships a default entry with its components', () => {
+  assert(exists('authoring/style/default.md'), 'authoring/style/default.md missing');
+  const d = read('authoring/style/default.md');
+  // The components and their two-hue palette are the entry's whole point. An
+  // emptied-out file that still exists would pass a mere existence check.
+  for (const cls of ['.risk', '.good', '.lvl', '.pill', '.diagram-box']) {
+    assert(d.includes(cls), `default.md no longer defines the ${cls} component`);
   }
+  for (const hex of ['#c97b3d', '#4a8f5d']) {
+    assert(d.includes(hex), `default.md no longer carries the ${hex} accent`);
+  }
+});
+
+t('the default style does NOT override reading typography', () => {
+  // The defining property of this style. If default.md starts setting a body
+  // font-size, it has stopped being the research-note style and the whole
+  // "trust the overlay" contract is broken.
+  const d = read('authoring/style/default.md');
+  assert(/does not (touch|override)|trusts? the overlay|do not override/i.test(d),
+    'default.md no longer states that it trusts the overlay reading typography');
+});
+
+// Single source of truth. Every entry in style/ must be selectable by name
+// from SKILL.md — otherwise the agent is offered a style it cannot be told
+// to use, or a user names one the agent has never heard of. Both fail
+// silently: the doc still generates, just with the wrong look.
+t('every style/ entry is selectable from SKILL.md', () => {
+  const s = read('SKILL.md');
+  const entries = fs.readdirSync(path.join(root, 'authoring/style'))
+    .filter(e => e.endsWith('.md') && e !== 'README.md');
+  assert(entries.length > 0, 'authoring/style has no entries at all');
+  const unreferenced = entries.filter(e => !s.includes(`authoring/style/${e}`));
+  assert(unreferenced.length === 0,
+    `style entries SKILL.md never mentions: ${unreferenced.join(', ')}\n` +
+    '    An entry the agent cannot be told to use is a file nobody reads.');
+});
+
+t('the default style is applied on the generation path, not merely listed', () => {
+  const s = read('SKILL.md');
+  const a = s.indexOf('### `/tdoc new');
+  const b = s.indexOf('### `bin/tdoc-new');
+  assert(a !== -1 && b !== -1, '/tdoc new section not found');
+  assert(s.slice(a, b).includes('authoring/style/default.md'),
+    '/tdoc new does not read authoring/style/default.md');
 });
 
 t('SKILL.md makes voice.md required reading before generating', () => {
@@ -122,6 +166,16 @@ t('voice.md defers to the vendored rule set instead of forking it', () => {
   // voice.md would drift from upstream the first time it is updated.
   assert(!/^Banned outright:/m.test(v),
     'voice.md duplicates the banned-word list — it must cite vendor/no-ai-slop.md as the authority');
+});
+
+t('voice.md carries the no-bullshit / efficiency stance as a default', () => {
+  const v = read('authoring/voice.md');
+  assert(/no bullshit/i.test(v) || /keep it efficient/i.test(v),
+    'voice.md lost the explicit no-bullshit / keep-it-efficient stance');
+  // It was asked to be a DEFAULT on every doc — assert it says so, not just
+  // that the words appear once in passing.
+  assert(/every doc|no doc.*exempt|by default/i.test(v),
+    'the efficiency stance is present but not stated as applying to every doc by default');
 });
 
 t('voice.md fences off spans the prose rules must not rewrite', () => {


### PR DESCRIPTION
Refs #194. Replaces the closed #198 (which extracted the 15px design-token style — not the right default).

## What

Fills the empty `authoring/style/` mount point from #195 with the house style, and tightens the voice contract at the same time.

**The style** is extracted from `tdoc.dev/d/avgraph-auto-research/v/1`. Its defining choice: **it does not restyle the page.** It trusts the overlay's reading typography and its default table rendering (rounded grey cells with white gaps), and adds only semantic components:

| Component | Meaning |
|---|---|
| `.risk` | a risk, cost, or failure mode — warm orange `#c97b3d` |
| `.good` | a key observation or good outcome — green `#4a8f5d` |
| `.lvl` | a leveled / layered block — thin left rule |
| `.pill` | a short metadata chip |
| `.diagram-box` | wraps a wide SVG so it scrolls on a phone |

It is **a starting kit, not a rulebook**: the color count is not fixed, and a doc adds hues when the content earns them.

## Two lessons baked into the file so they aren't relearned

- **Style is visual only.** Section numbering, language, and tone follow the content, never the style. (Caught live: a style pulled from a Chinese source doc had made an English doc number its sections 一、二、三.)
- **Tables are part of "don't restyle."** Writing your own `border-collapse` overrides the overlay's rounded-cell default into a flat ruled grid. (Also caught live — the generated docs looked wrong next to the sample.)
- **Link generously.** A research note earns trust by being checkable; name a source, make it a real hyperlink.

## Voice

`voice.md` gains a top-line stance above every specific rule:

> **No bullshit. Keep it efficient.** Say the thing, then stop. If a sentence would survive being deleted, delete it. This holds for every doc, by default — there is no exempt version.

## Tests

`test/authoring.test.js`, now 17 assertions, each negative-verified by breaking it and watching it fail:

- the default ships with its components and palette (emptying the file fails)
- it does not override reading typography (making it set a body size fails)
- every `style/` entry is selectable from `SKILL.md` (an unreferenced entry fails)
- the no-bullshit stance is present **and** stated as a default (deleting it fails)

## Scope

- `server/overlay.js` and `worker/` untouched — this only governs what the agent writes into a doc, not what the overlay injects around it. Keeps a hot file (edited across several open PRs) entirely out of this change.
- `skills/tdoc/SKILL.md` re-synced with root; `AGENTS.md` untouched.

## Checklist

- [x] `node test/run.js` — PASS, all 43 suites green
- [x] All new guards negative-verified
- [x] `skills/tdoc/SKILL.md` re-synced with root
- [x] No unrelated changes
