### PR TITLE
landing: redesign tdoc.dev homepage — clear value prop + refined static demo

### DIFF
--- a/landing/tornado-doc/meta.json
+++ b/landing/tornado-doc/meta.json
@@ -212,6 +212,11 @@
       "n": 42,
       "created": "2026-08-18T14:30:00Z",
       "prompt": "Docs that act on your comments: work-angle landing page with four real demo tabs"
+    },
+    {
+      "n": 43,
+      "created": "2026-08-20T00:00:00Z",
+      "prompt": "Redesign: clear value prop (agent writes, you comment, AI updates all), star to top, single CTA, drop font picker + fluff"
     }
   ],
   "access": {

--- a/landing/tornado-doc/v43/index.html
+++ b/landing/tornado-doc/v43/index.html
@@ -1,0 +1,1100 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>tdoc &#8212; docs that act on your comments</title>
+<link rel="canonical" href="https://tdoc.dev/">
+  <meta name="description" content="Like Google Docs, but your agent turns comments into changes. Reports, research, design docs and plans. Open source and free.">
+  <link rel="icon" type="image/png" href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAALQAAAC0CAYAAAA9zQYyAAAABGdBTUEAALGPC/xhBQAAACBjSFJNAAB6JgAAgIQAAPoAAACA6AAAdTAAAOpgAAA6mAAAF3CculE8AAAAeGVYSWZNTQAqAAAACAAEARoABQAAAAEAAAA+ARsABQAAAAEAAABGASgAAwAAAAEAAgAAh2kABAAAAAEAAABOAAAAAAAAAEgAAAABAAAASAAAAAEAA6ABAAMAAAABAAEAAKACAAQAAAABAAAAtKADAAQAAAABAAAAtAAAAABlWqJOAAAACXBIWXMAAAsTAAALEwEAmpwYAAABWWlUWHRYTUw6Y29tLmFkb2JlLnhtcAAAAAAAPHg6eG1wbWV0YSB4bWxuczp4PSJhZG9iZTpuczptZXRhLyIgeDp4bXB0az0iWE1QIENvcmUgNi4wLjAiPgogICA8cmRmOlJERiB4bWxuczpyZGY9Imh0dHA6Ly93d3cudzMub3JnLzE5OTkvMDIvMjItcmRmLXN5bnRheC1ucyMiPgogICAgICA8cmRmOkRlc2NyaXB0aW9uIHJkZjphYm91dD0iIgogICAgICAgICAgICB4bWxuczp4bXA9Imh0dHA6Ly9ucy5hZG9iZS5jb20veGFwLzEuMC8iPgogICAgICAgICA8eG1wOkNyZWF0b3JUb29sPkZpZ21hPC94bXA6Q3JlYXRvclRvb2w+CiAgICAgIDwvcmRmOkRlc2NyaXB0aW9uPgogICA8L3JkZjpSREY+CjwveDp4bXBtZXRhPgoE/1zIAAAXpElEQVR4Ae2dBfQctRPHUyju7u7ubsXd3Xl4KVAo0oc93N3d5eFuRYs7FHeKuxR38p/PtNn/3XXvfqf93SWT9+63+9vNZpPJdyeTmcmkh5fkLBkFIqHASJG0w5phFFAKGKANCFFRwAAdVXdaYwzQhoGoKGCAjqo7rTEGaMNAVBQwQEfVndYYA7RhICoKGKCj6k5rjAHaMBAVBQzQUXWnNcYAbRiIigIG6Ki60xpjgDYMREUBA3RU3WmNMUAbBqKigAE6qu60xhigDQNRUcAAHVV3WmMM0IaBqChggI6qO60xBmjDQFQUMEBH1Z3WGAO0YSAqChigo+pOa4wB2jAQFQUM0FF1pzXGAG0YiIoCBuioutMaY4A2DERFAQN0VN1pjTFAGwaiooABOqrutMYYoA0DUVHAAB1Vd1pjDNCGgagoYICOqjutMQZow0BUFDBAR9Wd1hgDtGEgKgoYoKPqTmuMAdowEBUFDNBRdac1xgBtGIiKAgboqLrTGmOANgxERQEDdFTdaY0xQBsGoqKAATqq7rTGGKANA1FRwAAdVXdaYwzQhoGoKGCAjqo7rTE9O50Ef/zxh/v111/dv//+60YbbTQ33njjdXqTrP4NUKAjAf3DDz+4AQMGuLvvvtsNGjTIff311+6ff/5xY445ppt11lndSiut5DbeeGM300wzNUAae7QTKdDDS+qUisOJL7jgAnf22We7999/P6s2nJnf77//7v7++2+9PsEEE7g+ffq4/v37u7HHHjvLaydxU6BtAf3VV1+5gQMHutdff919//33bvTRR3dPPvmke+qpp7RHZpxxRrfOOuu4FVZYQTkxoP3xxx/dm2++6W6++Wb9Ae5ll13WXX755W766aePuyetdUMpAIdupySysD/11FP9NNNMw8gx3G/yySfX+999913Fagv4/ZJLLqnPzzXXXP6dd96pmN9uxkGBtuLQ//33n+vXr587/fTT9WtbZJFFlAMLiN1vv/2mk79tttnGzTbbbFXxo59++sntsssu7tprr3ULLrigu+eee9ykk05a1bOWqUMp0E7f5RVXXKEcVcQLL3Ky//PPPxuunmhB/CabbKLlbrrppp4RwFK8FOhWDo2cPHjwYPfpp5+6jz76yJ155pl6PPLII93BBx/cNBaBbI3m4/nnn3dXX32122KLLZpWthXUXhQYoYD+66+/3NNPP+3uvfde98QTT7g33njDffvtt0UUQbx47bXX3EQTTeQQGQ477DA3ZMgQB8inmmqqory1/PPMM8+4Xr16uWmnndY999xzbtxxx63lccvbKRQYEYOPaBv8pZde6hdddNGiSZ5oJvzcc8/tRVvh99xzT3/88cf7hx9+OKvSZZddluU/4IADsuv1nvTu3VvLu/jii+stwp5rcwq4VtdPdMce2VU+cP2J+szvtttu/qabbvIffPCBF91x2So8+uijHtD37NnTX3nllWXzVXtDRgSPfL7UUkt5McRU+5jl6yAKtBzQe++9twJ5kkkm8SIj+67UbaW0e+mll7yIJ6WX6/5/rbXW0g9ELIx1l2EPti8FWgroZ5991osFz4u86h977LG2oELQpBx++OFtUR+rRHMp0FJvu7POOsuJ6s2JiOGWXnrptphWrLzyyg6zONbEYCZvi4pZJZpCgZYB+rPPPnN33nmn+lHsuOOOTalsMwpBi7LGGmu4l19+2cmo0YwiqyoDDQ/GoV9++cX9/PPPesRTEGOSpeZRoGXedjKhUx8MwNNuXm877LCDu+aaa9yhhx7qllhiCTfGGGPUTVFGILz/ZG7gvvnmG9Wj4/33xRdf6A/VYwAwgMYrEFfXkUceWf1TUB9OOOGEqqaceuqp3ZRTTummmGIKx/k444yj6kXy4MvCMyON1DIeVDcN2unBlgFa1G/azlVXXbXu9iISoIMea6yx1DW07oJKHlxuueXcRhtt5G644Qa39dZbuxNOOMHh7JSXACCGGUCLAQig4un3ySefZEYhgAygRRrMK0KvjTLKKOoRCCh79OiheSkbLg3A8xL5ADM+3tAAB6zxxx8/+x+Q42UYyuZ81FFHVeCLZkjfE46l5fMMHwf3+XEePhjOw498lMmP8nHRpR68O1yjbtS1HVJLDCsMr3A+fJXxkFtsscVqbitAFpO1e+WVV7QTV1llFbfffvs5cVqquay8Bz7//HO37rrrqvUQDrn44ou7GWaYQTsKN1RADFABMuITR66XJsAgGhw32WST6U/Ukg6xBi4Lt4XL8qPTGQkCkAA/3B2uzbsQRfAq/Pjjj9W/mw/nyy+/1A+a+3B63GcrfQCldWvV/wHktIePDSMYNKTt/PBJZ1SGnrR9RKaWAJqOmHPOObXzcOeksdUkOhlRBSDA8fgoAAwEw0yOUxIORhCqGQnR4DCxRGIOBzDlEmCkDVgqeffMM8+sHB2rI6IB9+Cc1LXZCZrwIQUw8xEAav7nY+DH/zARRjS4PXI5x3Ae6sSIUG4UCRNkniVfOIb3UQfOw0cIvfjQYDzhnOcKE/TBwYyJOL9yo2DhM42etwTQcDYADZHhsNNNN13ZeiJfMowx3MHN8V9mSONLZ+K22mqrKeDE0uj23Xdft+WWWzoxsjR1iBMDj74LMQJwMJxSB7guYMVDDy4MsKmnpaEUAMD0MWAPc4gPP/zQvfvuu0pPXBjee+89zUwfr7/++upNiedjy5J8sU1Pwhm8LIFSg8rqq6/uH3/8cS/Dqb5HhlYvsqiey1Du55hjDi+OQ178K/xxxx2nz0jj9SiN9uLDkdUPE7kAzctwnF2zk/alAH394osv+pNPPlmts/Qn/XfOOed4GQFaUvGWGVbkK/XzzDNPBkx8NuTr9TvvvLPHaojfRgAwDRW5zAtH1PwQ4L777vOihfCvvvqq/oRbexFBvHBMLyNAS4hhhbaOAjLy+XPPPdfDrOhnEVda8rKWAZraAjxWn4hWQYEq8pSfeOKJM5ADZH4At1evXtl1kbu1sTKkeTHIeJlxZ/cOOuiglhDCCm0eBeg3RlFZLufPO+88L2pSP//883uZIGo/9u3bt2V+6S2RoQWkRQk5GS0FrqMkJmLIp/g/M+F76KGH9Lp416laDPl7oYUW0pUm4mXnxEtPrXuylModffTRKuPqA/anWynAxBHNDBN25iG4AyM3y6jqkKWZNJKYLM8yyyzaj2FFPirAVqQRAmgqzmJXJnzMvGk4mgxUVcIXVLXDBIOGH3vsse7AAw9UrQETtNlnn92JDK4TslYQwMrsmgL0E6Dlhw6eH30IiFmgAahDQjeNJgjVHZM/GJPMk1Td2ioQh3dzHGGA5mVwaNRMrNQuTCKWqOZiww03dPh/8OUzcyYv5nM0HZZaSwFAy2KLsHoI7QQ/QMtqIlScQbVHTdAvw5QALmpMQAsXBszo4UcEePMoMkIBnVcBrm2++eYqXoT7d9xxh+qcIaL4LofLekR8wQoJ10a3yRDWLlaqooq26T/ojAEtnBUbAaDlCGgxIDFShoThBD07P2wAgBXQYtxCJ49Ks7uAG+pYeux2QPPVYx5nvR+K+HnnnVe5daG+FzGF+7IowN16662q5wwNAdB77LGHE/WgGnLCdTs6NXgAXPT5oj5TmwDgxfAVEoDEqollD04LcLEBYDuA0+KZ2IivS3jPCDs2b25bX0kSBEZnvtttt50X7ls0+xXuoVqSEF9DiKJ50XyI/0Wm6+Y6q1AGDhxYthLMuvfZZx/ViZfN1OE30PvK2knV+6633npeOGumHZJRzAvD8MI8vLgQ+EsuucQTu0QA70W06/CW/7/6LVXb/f815c+22morL1zAi6+EZhKLk5c4Gl6sSpmaB8AK99COoMNQC4XEIgKJ1aEdt/baa4fLRUcRXbz4amieQw45pOhep/+Dwer2229X/b6YljMAQ9Pll1/esxZTfL/9W2+9pQyj09vbVf27HdAADD0zRxbKFkZMolNEvva33XZbl4p4UfUpaEstUIA/rGlkFGiVQr8rQufdZ72liFA1G4poI9x199139zIxUxDDgVmEjJ7+gQce8KKRyHtl9Ne6HdDiP+FFbs44Cx2DIYZAM6LLrLoDMMzIpGW44fPGG2/UskVlWHFBbtUvamLGW265ResmasqqShW/CeW2cN4gfmE9xXglatEica2qAiPM1Hz3MKF0LYkZ9P3336+TPRTx6KoxpNSiuUAvyuwd1RPOMmESw4TzlFNO0cmimNrbziCDAxQJQ0RXiVgmxCbBgQsfaZa1bbvttm7hhRc2p/9C4nXqR4ooITrqIllblPoemTqkF154QcUZUe+FS211xD9F+kKDSparmPhHe/Ew1HwCZA83ZyJnKZ8C3S5y5Fer8lW0GWKcyYZdnF2Qk3F8IUxBmDRK0EfNc8YZZ1QusIq7yLu77rqrb0ZZ4XWICQAaH5dS2Z88TPbCnEK4sUVQDYSrcOwoQItzuZeYd+qZBxBEye9PO+20zJ30iCOOUICI37Q2Gc8+8lVS51WgTdEtHK3wEhT9uE66im7W+U/g0KghCxPgPvHEEz3zCdERe1kqVnjbzitQoGMAzYQILgVAES0AdvCxxv8aUeOoo47Se+QhLxNB3FKJmBQSulo8wETuDpeqPsrCWn2/mHubokUQi6eWh844JNSXoZ3o1t9+++1wy45VUKBjAH3SSSdp56PKE9O4Nk0mff7CCy/04gCj9wAyHBRZk3N+subNY6AJSfZl0etEdKonIXZQriyuzRUTailTvAu1LLF06mOIICH+30477dRWKsZa2tWdeTsC0Fj5xAyrQ3CIcQeHDXK0LI3ym222mScII4YXAIyOFk4uGg8vLo0ZjRnKAWS9BhY4KL69lNFo0EcmeJRz0UUXedFiqEhDncVBK6uvndRGgY4AtGwUpB2PCEESDzAvbqV6DWNJue0mGLIBSODQiBusnMGQ00hoMj4alhKJL7fqf2sj+dDcyMksPQPQWEUZWcSHwotveD3F2TPDKNARgA6mbTgZ/h5oBQACy7jKJdYowrkRR1j+QyKeHc+xzhFxpZHEZJSy+Mjq8YVgXWXh6h1ZAFGTIamRusf8bEcAOiy4xalGfKMVSPvvv3/ZfpGYG36++ebTfPiFkDAxi2eZag1Yp9hoQjUowWr0HUxQa01BfpYV5upvIf7ftRZh+XMo0BGADhFD4Yj8ZCMgj9YjLyFvB++8MNlijSIyOM+uueaaHtGjGYlJHJNONCkS26OmIkOYYRb9ysKHmp61zOUp0BGARi131VVXebiyBJop2xq86pCbAa4EiFSxAtVeEFHCB7HAAguoT0SeMaNs4QU3+JiYnBauaqdsWT5WtT+FONR7LJg8h367Gbrygiome9oRgK6mdxABZDOgIjDzIaD9ADRw7UKZlWsA6q677qpJnuaDWmaZZbRMNCgYcQBjULdhpq42zALzAdR/AdR40FlqjALRAJpI/2gK0BxgUSQRHgGw4FoK9w6TQuTWQq4NVz///PM9XLNcQrOBNoLy+PHxSFSoLDt+3Ph2cw/vwWrBCbfffvvt9TlZJVJkBMoKt5OqKRANoPEBBkxBbmYPFwCOIQaNB0k88rwEjtR8siBXnZvQeASQYpBB24COmpU01113nVoVmfzxEZCPFR9Y+PISIgxBclAVkh+dd/i48vKHa2hhgs82Om4+Pkv1USAaQDPMo8dFVYfBA64MAJG9CxMajhChaa+99lKZF8AzSZP1dBm4A8gLj2hJquG8bHYUfLzxXcbrr6vEwgP8wHkfpvBqPoSuykzxfjSApvNw4oErBxCi7stLhBmTaKGaD78JZFkS+mTAzXq7/v37q3cdHJ//Me5gkEFUCfnzyg7XmIwGTQayNuJP8D0JeUqPLGgIy6j42CzVToGoAE3zWT/H2kIAgVxbLsmiAi9L8RXUWA9Z2dJVQl3IxyKRn7rKmt1/8MEHM18TrJs4OJVTOfIQ3D34ovC+aieY2QsTP4kO0LX0J55sgD9wdNk+o6JOGNkWDopYQ0TVahN6b2TroGXBXRTtClqYvMTSrABqFgcji7PItVz+vDJSvZY0oOl0JnLXX3995nCEnIy4UU48YKLIB4Cfcq0GEUQKRg5EEMpAZmZEybMSsjdjUAWSl8ULaGNwaKpGjjdAp0qBYe1GLibWB5Y7AITpPM9RiA/gmGOO0Tyo2QbXsRwK/+w+ffoop+ddTCBZFFyq3WCVDCZy9OVYJMnLD1ke2b+dVrC3C3yS59ClHQHYWMYFcFC/EXA9z5GJ6+RBN12vKEAMbcIOhFAEcH04MNdLE9wdvxQMMSEsLVtM12vtLC0/lv8N0Dk9idWR0ADIyoB2gw028BI+qygnedBZcx8deCOJiR9alCBi4JoKsMv5nCDqYC5Hzg67ITTy/pieNUBX6E0mfkGfjf8HzkiFCY0E6/4wdzcjMRLg6L/iiivqh4LlMW904F0hEHw5X/Bm1KcTyzBAd9Fr7AMTrInIzIUTQdRvOCixMhsrZLMS3B99NyNE6cjAO4iKBIdGA1KOizerLp1Wjm1LKjJDpUQMZNFRO3afJeQseyeKi6o+wn59IiY49jzk16wkMrnGxhbNRm5EVSKwipjiROVogeBLiG6ALiFI3r8Aq3fv3rqlm3DEov252VoDABKgvVmJOM2iPdF4zGxsWZh4j+wipdGhxKmp8JadCwUM0FXCQFaLK3BFd6zBvsNjAEzUaFn4sXC9kaOINcqhCfMlpvyiokRvrfGexZnJiYWz6J79Y4CuCgMi0+oOtmRmmC9M7DUClyZoeLMSe5CTCOZemNhzRsI56MfTr1+/wlt2HijQaUJ/d9QX7QbuoBg3CiOiMjnDECN7hjetWngDYkkkWHmptRLPQek3XY3TtBdGVpCJHOHLrnAUByPdMpm9x9k2IyRx+tcdoMTdM1xq+CjhzFQeF5WdbgcRChR3UsfmSsjzxp0DVYY/dns43eGr1F5XhEuqloNaiQWxKMyvLL1SGVeWdzVcaSaBYlxxiBuEGJZAOUVlspej+FU7gM6OU5bKUCCyEadpzUGvTNyP4J+MGbwwzhyrTFgQQNyPcsaPaiozZMgQFSGCdx2iDSEXShO+3RhxbDFtKWWK/zfDSjE99D/ZcSszQwsfUOMJgWUK/SZwXOJepWA3OUUXXWJVCqtTKEc2HdXFt8TeK03scgDgMeKEoDmleez/oRQwQJcgYcCAAWqFA2RscYG3G15vpUkMLGrJIyxZvYnN3HkPlsZHHnmkrJNTcFnFrdVSZQoYoAvow8ru4D6Kx105xx/iOsNRif1RbyLoo+wNqOWEaKrlymIzJYBPAHRLlSlgk0JBCgktgjjfq9ZCopo68U9Ws7Is4+Kj1zzs+8K5+EOrMaVv3756vZ4/Et9D98xmTxnZcs4VvieUF943aNAgnYyyDbGlyhQwQA+jj0zsMn8M1HFsvI5JOy/JRE61EI1Y6kQe16Jl9Ynulx3+z3sfmymhMhTnqLzbdq2AAgboYcRgRyqJy+wkwqly68CVC2iVncrkzEmAxuz/ek5Ea6FbFMtSq2wEyCuHeqDGkxXkbbeLV159u/tat+/13d0EsPfHRQGzFMbVn8m3xgCdPATiIoABOq7+TL41BujkIRAXAQzQcfVn8q0xQCcPgbgIYICOqz+Tb40BOnkIxEUAA3Rc/Zl8awzQyUMgLgIYoOPqz+RbY4BOHgJxEcAAHVd/Jt8aA3TyEIiLAAbouPoz+dYYoJOHQFwEMEDH1Z/Jt8YAnTwE4iKAATqu/ky+NQbo5CEQFwEM0HH1Z/KtMUAnD4G4CGCAjqs/k2+NATp5CMRFAAN0XP2ZfGsM0MlDIC4CGKDj6s/kW2OATh4CcRHAAB1XfybfGgN08hCIiwAG6Lj6M/nWGKCTh0BcBDBAx9WfybfGAJ08BOIigAE6rv5MvjUG6OQhEBcBDNBx9WfyrTFAJw+BuAhggI6rP5NvjQE6eQjERQADdFz9mXxrDNDJQyAuAhig4+rP5FtjgE4eAnERwAAdV38m3xoDdPIQiIsABui4+jP51higk4dAXAQwQMfVn8m3xgCdPATiIoABOq7+TL41BujkIRAXAQzQcfVn8q0xQCcPgbgI8D9lu4gyaLxczAAAAABJRU5ErkJggg==">
+  <link rel="apple-touch-icon" href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAALQAAAC0CAYAAAA9zQYyAAAABGdBTUEAALGPC/xhBQAAACBjSFJNAAB6JgAAgIQAAPoAAACA6AAAdTAAAOpgAAA6mAAAF3CculE8AAAAeGVYSWZNTQAqAAAACAAEARoABQAAAAEAAAA+ARsABQAAAAEAAABGASgAAwAAAAEAAgAAh2kABAAAAAEAAABOAAAAAAAAAEgAAAABAAAASAAAAAEAA6ABAAMAAAABAAEAAKACAAQAAAABAAAAtKADAAQAAAABAAAAtAAAAABlWqJOAAAACXBIWXMAAAsTAAALEwEAmpwYAAABWWlUWHRYTUw6Y29tLmFkb2JlLnhtcAAAAAAAPHg6eG1wbWV0YSB4bWxuczp4PSJhZG9iZTpuczptZXRhLyIgeDp4bXB0az0iWE1QIENvcmUgNi4wLjAiPgogICA8cmRmOlJERiB4bWxuczpyZGY9Imh0dHA6Ly93d3cudzMub3JnLzE5OTkvMDIvMjItcmRmLXN5bnRheC1ucyMiPgogICAgICA8cmRmOkRlc2NyaXB0aW9uIHJkZjphYm91dD0iIgogICAgICAgICAgICB4bWxuczp4bXA9Imh0dHA6Ly9ucy5hZG9iZS5jb20veGFwLzEuMC8iPgogICAgICAgICA8eG1wOkNyZWF0b3JUb29sPkZpZ21hPC94bXA6Q3JlYXRvclRvb2w+CiAgICAgIDwvcmRmOkRlc2NyaXB0aW9uPgogICA8L3JkZjpSREY+CjwveDp4bXBtZXRhPgoE/1zIAAAXpElEQVR4Ae2dBfQctRPHUyju7u7ubsXd3Xl4KVAo0oc93N3d5eFuRYs7FHeKuxR38p/PtNn/3XXvfqf93SWT9+63+9vNZpPJdyeTmcmkh5fkLBkFIqHASJG0w5phFFAKGKANCFFRwAAdVXdaYwzQhoGoKGCAjqo7rTEGaMNAVBQwQEfVndYYA7RhICoKGKCj6k5rjAHaMBAVBQzQUXWnNcYAbRiIigIG6Ki60xpjgDYMREUBA3RU3WmNMUAbBqKigAE6qu60xhigDQNRUcAAHVV3WmMM0IaBqChggI6qO60xBmjDQFQUMEBH1Z3WGAO0YSAqChigo+pOa4wB2jAQFQUM0FF1pzXGAG0YiIoCBuioutMaY4A2DERFAQN0VN1pjTFAGwaiooABOqrutMYYoA0DUVHAAB1Vd1pjDNCGgagoYICOqjutMQZow0BUFDBAR9Wd1hgDtGEgKgoYoKPqTmuMAdowEBUFDNBRdac1xgBtGIiKAgboqLrTGmOANgxERQEDdFTdaY0xQBsGoqKAATqq7rTGGKANA1FRwAAdVXdaYwzQhoGoKGCAjqo7rTE9O50Ef/zxh/v111/dv//+60YbbTQ33njjdXqTrP4NUKAjAf3DDz+4AQMGuLvvvtsNGjTIff311+6ff/5xY445ppt11lndSiut5DbeeGM300wzNUAae7QTKdDDS+qUisOJL7jgAnf22We7999/P6s2nJnf77//7v7++2+9PsEEE7g+ffq4/v37u7HHHjvLaydxU6BtAf3VV1+5gQMHutdff919//33bvTRR3dPPvmke+qpp7RHZpxxRrfOOuu4FVZYQTkxoP3xxx/dm2++6W6++Wb9Ae5ll13WXX755W766aePuyetdUMpAIdupySysD/11FP9NNNMw8gx3G/yySfX+999913Fagv4/ZJLLqnPzzXXXP6dd96pmN9uxkGBtuLQ//33n+vXr587/fTT9WtbZJFFlAMLiN1vv/2mk79tttnGzTbbbFXxo59++sntsssu7tprr3ULLrigu+eee9ykk05a1bOWqUMp0E7f5RVXXKEcVcQLL3Ky//PPPxuunmhB/CabbKLlbrrppp4RwFK8FOhWDo2cPHjwYPfpp5+6jz76yJ155pl6PPLII93BBx/cNBaBbI3m4/nnn3dXX32122KLLZpWthXUXhQYoYD+66+/3NNPP+3uvfde98QTT7g33njDffvtt0UUQbx47bXX3EQTTeQQGQ477DA3ZMgQB8inmmqqory1/PPMM8+4Xr16uWmnndY999xzbtxxx63lccvbKRQYEYOPaBv8pZde6hdddNGiSZ5oJvzcc8/tRVvh99xzT3/88cf7hx9+OKvSZZddluU/4IADsuv1nvTu3VvLu/jii+stwp5rcwq4VtdPdMce2VU+cP2J+szvtttu/qabbvIffPCBF91x2So8+uijHtD37NnTX3nllWXzVXtDRgSPfL7UUkt5McRU+5jl6yAKtBzQe++9twJ5kkkm8SIj+67UbaW0e+mll7yIJ6WX6/5/rbXW0g9ELIx1l2EPti8FWgroZ5991osFz4u86h977LG2oELQpBx++OFtUR+rRHMp0FJvu7POOsuJ6s2JiOGWXnrptphWrLzyyg6zONbEYCZvi4pZJZpCgZYB+rPPPnN33nmn+lHsuOOOTalsMwpBi7LGGmu4l19+2cmo0YwiqyoDDQ/GoV9++cX9/PPPesRTEGOSpeZRoGXedjKhUx8MwNNuXm877LCDu+aaa9yhhx7qllhiCTfGGGPUTVFGILz/ZG7gvvnmG9Wj4/33xRdf6A/VYwAwgMYrEFfXkUceWf1TUB9OOOGEqqaceuqp3ZRTTummmGIKx/k444yj6kXy4MvCMyON1DIeVDcN2unBlgFa1G/azlVXXbXu9iISoIMea6yx1DW07oJKHlxuueXcRhtt5G644Qa39dZbuxNOOMHh7JSXACCGGUCLAQig4un3ySefZEYhgAygRRrMK0KvjTLKKOoRCCh79OiheSkbLg3A8xL5ADM+3tAAB6zxxx8/+x+Q42UYyuZ81FFHVeCLZkjfE46l5fMMHwf3+XEePhjOw498lMmP8nHRpR68O1yjbtS1HVJLDCsMr3A+fJXxkFtsscVqbitAFpO1e+WVV7QTV1llFbfffvs5cVqquay8Bz7//HO37rrrqvUQDrn44ou7GWaYQTsKN1RADFABMuITR66XJsAgGhw32WST6U/Ukg6xBi4Lt4XL8qPTGQkCkAA/3B2uzbsQRfAq/Pjjj9W/mw/nyy+/1A+a+3B63GcrfQCldWvV/wHktIePDSMYNKTt/PBJZ1SGnrR9RKaWAJqOmHPOObXzcOeksdUkOhlRBSDA8fgoAAwEw0yOUxIORhCqGQnR4DCxRGIOBzDlEmCkDVgqeffMM8+sHB2rI6IB9+Cc1LXZCZrwIQUw8xEAav7nY+DH/zARRjS4PXI5x3Ae6sSIUG4UCRNkniVfOIb3UQfOw0cIvfjQYDzhnOcKE/TBwYyJOL9yo2DhM42etwTQcDYADZHhsNNNN13ZeiJfMowx3MHN8V9mSONLZ+K22mqrKeDE0uj23Xdft+WWWzoxsjR1iBMDj74LMQJwMJxSB7guYMVDDy4MsKmnpaEUAMD0MWAPc4gPP/zQvfvuu0pPXBjee+89zUwfr7/++upNiedjy5J8sU1Pwhm8LIFSg8rqq6/uH3/8cS/Dqb5HhlYvsqiey1Du55hjDi+OQ178K/xxxx2nz0jj9SiN9uLDkdUPE7kAzctwnF2zk/alAH394osv+pNPPlmts/Qn/XfOOed4GQFaUvGWGVbkK/XzzDNPBkx8NuTr9TvvvLPHaojfRgAwDRW5zAtH1PwQ4L777vOihfCvvvqq/oRbexFBvHBMLyNAS4hhhbaOAjLy+XPPPdfDrOhnEVda8rKWAZraAjxWn4hWQYEq8pSfeOKJM5ADZH4At1evXtl1kbu1sTKkeTHIeJlxZ/cOOuiglhDCCm0eBeg3RlFZLufPO+88L2pSP//883uZIGo/9u3bt2V+6S2RoQWkRQk5GS0FrqMkJmLIp/g/M+F76KGH9Lp416laDPl7oYUW0pUm4mXnxEtPrXuylModffTRKuPqA/anWynAxBHNDBN25iG4AyM3y6jqkKWZNJKYLM8yyyzaj2FFPirAVqQRAmgqzmJXJnzMvGk4mgxUVcIXVLXDBIOGH3vsse7AAw9UrQETtNlnn92JDK4TslYQwMrsmgL0E6Dlhw6eH30IiFmgAahDQjeNJgjVHZM/GJPMk1Td2ioQh3dzHGGA5mVwaNRMrNQuTCKWqOZiww03dPh/8OUzcyYv5nM0HZZaSwFAy2KLsHoI7QQ/QMtqIlScQbVHTdAvw5QALmpMQAsXBszo4UcEePMoMkIBnVcBrm2++eYqXoT7d9xxh+qcIaL4LofLekR8wQoJ10a3yRDWLlaqooq26T/ojAEtnBUbAaDlCGgxIDFShoThBD07P2wAgBXQYtxCJ49Ks7uAG+pYeux2QPPVYx5nvR+K+HnnnVe5daG+FzGF+7IowN16662q5wwNAdB77LGHE/WgGnLCdTs6NXgAXPT5oj5TmwDgxfAVEoDEqollD04LcLEBYDuA0+KZ2IivS3jPCDs2b25bX0kSBEZnvtttt50X7ls0+xXuoVqSEF9DiKJ50XyI/0Wm6+Y6q1AGDhxYthLMuvfZZx/ViZfN1OE30PvK2knV+6633npeOGumHZJRzAvD8MI8vLgQ+EsuucQTu0QA70W06/CW/7/6LVXb/f815c+22morL1zAi6+EZhKLk5c4Gl6sSpmaB8AK99COoMNQC4XEIgKJ1aEdt/baa4fLRUcRXbz4amieQw45pOhep/+Dwer2229X/b6YljMAQ9Pll1/esxZTfL/9W2+9pQyj09vbVf27HdAADD0zRxbKFkZMolNEvva33XZbl4p4UfUpaEstUIA/rGlkFGiVQr8rQufdZ72liFA1G4poI9x199139zIxUxDDgVmEjJ7+gQce8KKRyHtl9Ne6HdDiP+FFbs44Cx2DIYZAM6LLrLoDMMzIpGW44fPGG2/UskVlWHFBbtUvamLGW265ResmasqqShW/CeW2cN4gfmE9xXglatEica2qAiPM1Hz3MKF0LYkZ9P3336+TPRTx6KoxpNSiuUAvyuwd1RPOMmESw4TzlFNO0cmimNrbziCDAxQJQ0RXiVgmxCbBgQsfaZa1bbvttm7hhRc2p/9C4nXqR4ooITrqIllblPoemTqkF154QcUZUe+FS211xD9F+kKDSparmPhHe/Ew1HwCZA83ZyJnKZ8C3S5y5Fer8lW0GWKcyYZdnF2Qk3F8IUxBmDRK0EfNc8YZZ1QusIq7yLu77rqrb0ZZ4XWICQAaH5dS2Z88TPbCnEK4sUVQDYSrcOwoQItzuZeYd+qZBxBEye9PO+20zJ30iCOOUICI37Q2Gc8+8lVS51WgTdEtHK3wEhT9uE66im7W+U/g0KghCxPgPvHEEz3zCdERe1kqVnjbzitQoGMAzYQILgVAES0AdvCxxv8aUeOoo47Se+QhLxNB3FKJmBQSulo8wETuDpeqPsrCWn2/mHubokUQi6eWh844JNSXoZ3o1t9+++1wy45VUKBjAH3SSSdp56PKE9O4Nk0mff7CCy/04gCj9wAyHBRZk3N+subNY6AJSfZl0etEdKonIXZQriyuzRUTailTvAu1LLF06mOIICH+30477dRWKsZa2tWdeTsC0Fj5xAyrQ3CIcQeHDXK0LI3ym222mScII4YXAIyOFk4uGg8vLo0ZjRnKAWS9BhY4KL69lNFo0EcmeJRz0UUXedFiqEhDncVBK6uvndRGgY4AtGwUpB2PCEESDzAvbqV6DWNJue0mGLIBSODQiBusnMGQ00hoMj4alhKJL7fqf2sj+dDcyMksPQPQWEUZWcSHwotveD3F2TPDKNARgA6mbTgZ/h5oBQACy7jKJdYowrkRR1j+QyKeHc+xzhFxpZHEZJSy+Mjq8YVgXWXh6h1ZAFGTIamRusf8bEcAOiy4xalGfKMVSPvvv3/ZfpGYG36++ebTfPiFkDAxi2eZag1Yp9hoQjUowWr0HUxQa01BfpYV5upvIf7ftRZh+XMo0BGADhFD4Yj8ZCMgj9YjLyFvB++8MNlijSIyOM+uueaaHtGjGYlJHJNONCkS26OmIkOYYRb9ysKHmp61zOUp0BGARi131VVXebiyBJop2xq86pCbAa4EiFSxAtVeEFHCB7HAAguoT0SeMaNs4QU3+JiYnBauaqdsWT5WtT+FONR7LJg8h367Gbrygiome9oRgK6mdxABZDOgIjDzIaD9ADRw7UKZlWsA6q677qpJnuaDWmaZZbRMNCgYcQBjULdhpq42zALzAdR/AdR40FlqjALRAJpI/2gK0BxgUSQRHgGw4FoK9w6TQuTWQq4NVz///PM9XLNcQrOBNoLy+PHxSFSoLDt+3Ph2cw/vwWrBCbfffvvt9TlZJVJkBMoKt5OqKRANoPEBBkxBbmYPFwCOIQaNB0k88rwEjtR8siBXnZvQeASQYpBB24COmpU01113nVoVmfzxEZCPFR9Y+PISIgxBclAVkh+dd/i48vKHa2hhgs82Om4+Pkv1USAaQDPMo8dFVYfBA64MAJG9CxMajhChaa+99lKZF8AzSZP1dBm4A8gLj2hJquG8bHYUfLzxXcbrr6vEwgP8wHkfpvBqPoSuykzxfjSApvNw4oErBxCi7stLhBmTaKGaD78JZFkS+mTAzXq7/v37q3cdHJ//Me5gkEFUCfnzyg7XmIwGTQayNuJP8D0JeUqPLGgIy6j42CzVToGoAE3zWT/H2kIAgVxbLsmiAi9L8RXUWA9Z2dJVQl3IxyKRn7rKmt1/8MEHM18TrJs4OJVTOfIQ3D34ovC+aieY2QsTP4kO0LX0J55sgD9wdNk+o6JOGNkWDopYQ0TVahN6b2TroGXBXRTtClqYvMTSrABqFgcji7PItVz+vDJSvZY0oOl0JnLXX3995nCEnIy4UU48YKLIB4Cfcq0GEUQKRg5EEMpAZmZEybMSsjdjUAWSl8ULaGNwaKpGjjdAp0qBYe1GLibWB5Y7AITpPM9RiA/gmGOO0Tyo2QbXsRwK/+w+ffoop+ddTCBZFFyq3WCVDCZy9OVYJMnLD1ke2b+dVrC3C3yS59ClHQHYWMYFcFC/EXA9z5GJ6+RBN12vKEAMbcIOhFAEcH04MNdLE9wdvxQMMSEsLVtM12vtLC0/lv8N0Dk9idWR0ADIyoB2gw028BI+qygnedBZcx8deCOJiR9alCBi4JoKsMv5nCDqYC5Hzg67ITTy/pieNUBX6E0mfkGfjf8HzkiFCY0E6/4wdzcjMRLg6L/iiivqh4LlMW904F0hEHw5X/Bm1KcTyzBAd9Fr7AMTrInIzIUTQdRvOCixMhsrZLMS3B99NyNE6cjAO4iKBIdGA1KOizerLp1Wjm1LKjJDpUQMZNFRO3afJeQseyeKi6o+wn59IiY49jzk16wkMrnGxhbNRm5EVSKwipjiROVogeBLiG6ALiFI3r8Aq3fv3rqlm3DEov252VoDABKgvVmJOM2iPdF4zGxsWZh4j+wipdGhxKmp8JadCwUM0FXCQFaLK3BFd6zBvsNjAEzUaFn4sXC9kaOINcqhCfMlpvyiokRvrfGexZnJiYWz6J79Y4CuCgMi0+oOtmRmmC9M7DUClyZoeLMSe5CTCOZemNhzRsI56MfTr1+/wlt2HijQaUJ/d9QX7QbuoBg3CiOiMjnDECN7hjetWngDYkkkWHmptRLPQek3XY3TtBdGVpCJHOHLrnAUByPdMpm9x9k2IyRx+tcdoMTdM1xq+CjhzFQeF5WdbgcRChR3UsfmSsjzxp0DVYY/dns43eGr1F5XhEuqloNaiQWxKMyvLL1SGVeWdzVcaSaBYlxxiBuEGJZAOUVlspej+FU7gM6OU5bKUCCyEadpzUGvTNyP4J+MGbwwzhyrTFgQQNyPcsaPaiozZMgQFSGCdx2iDSEXShO+3RhxbDFtKWWK/zfDSjE99D/ZcSszQwsfUOMJgWUK/SZwXOJepWA3OUUXXWJVCqtTKEc2HdXFt8TeK03scgDgMeKEoDmleez/oRQwQJcgYcCAAWqFA2RscYG3G15vpUkMLGrJIyxZvYnN3HkPlsZHHnmkrJNTcFnFrdVSZQoYoAvow8ru4D6Kx105xx/iOsNRif1RbyLoo+wNqOWEaKrlymIzJYBPAHRLlSlgk0JBCgktgjjfq9ZCopo68U9Ws7Is4+Kj1zzs+8K5+EOrMaVv3756vZ4/Et9D98xmTxnZcs4VvieUF943aNAgnYyyDbGlyhQwQA+jj0zsMn8M1HFsvI5JOy/JRE61EI1Y6kQe16Jl9Ynulx3+z3sfmymhMhTnqLzbdq2AAgboYcRgRyqJy+wkwqly68CVC2iVncrkzEmAxuz/ek5Ea6FbFMtSq2wEyCuHeqDGkxXkbbeLV159u/tat+/13d0EsPfHRQGzFMbVn8m3xgCdPATiIoABOq7+TL41BujkIRAXAQzQcfVn8q0xQCcPgbgIYICOqz+Tb40BOnkIxEUAA3Rc/Zl8awzQyUMgLgIYoOPqz+RbY4BOHgJxEcAAHVd/Jt8aA3TyEIiLAAbouPoz+dYYoJOHQFwEMEDH1Z/Jt8YAnTwE4iKAATqu/ky+NQbo5CEQFwEM0HH1Z/KtMUAnD4G4CGCAjqs/k2+NATp5CMRFAAN0XP2ZfGsM0MlDIC4CGKDj6s/kW2OATh4CcRHAAB1XfybfGgN08hCIiwAG6Lj6M/nWGKCTh0BcBDBAx9WfybfGAJ08BOIigAE6rv5MvjUG6OQhEBcBDNBx9WfyrTFAJw+BuAhggI6rP5NvjQE6eQjERQADdFz9mXxrDNDJQyAuAhig4+rP5FtjgE4eAnERwAAdV38m3xoDdPIQiIsABui4+jP51higk4dAXAQwQMfVn8m3xgCdPATiIoABOq7+TL41BujkIRAXAQzQcfVn8q0xQCcPgbgI8D9lu4gyaLxczAAAAABJRU5ErkJggg==">
+  
+
+  <meta property="og:type" content="website">
+  <meta property="og:site_name" content="tdoc">
+  <meta property="og:url" content="https://tdoc.dev/">
+  <meta property="og:title" content="tdoc, a doc that answers its own comments">
+  <meta property="og:description" content="Stop being the middleman. Your next report, spec, or deck collects its own feedback and fixes itself.">
+  <meta property="og:image" content="https://tdoc.dev/tdoc_logo.png">
+  <meta name="twitter:card" content="summary">
+  <meta name="twitter:title" content="tdoc, a doc that answers its own comments">
+  <meta name="twitter:description" content="Stop being the middleman. Your next report, spec, or deck collects its own feedback and fixes itself.">
+  <meta name="twitter:image" content="https://tdoc.dev/tdoc_logo.png">
+
+  <style>
+    /* No author JavaScript anywhere, on purpose: published tdocs run under a
+       nonce-only CSP, so author scripts never execute. Every moving thing on
+       this page is CSS, the same technique the Conway doc uses. See #138. */
+    :root {
+      --ink: #10121a;
+      --body: #454a58;
+      --muted: #767c8b;
+      --accent: #1652f0;
+      --soft: #eef3ff;
+      --rule: #e4e7ee;
+      --wash: #f7f8fb;
+      --good: #1a7340;
+      --cell: #1652f0;
+    }
+    * { box-sizing: border-box; }
+    body { background:#fff; color:var(--body); font:16px/1.6 system-ui,-apple-system,"Segoe UI",sans-serif; margin:0; -webkit-font-smoothing:antialiased; }
+    .wrap { max-width: 960px; margin: 0 auto; padding: 0 24px; }
+    h1,h2,h3 { color:var(--ink); letter-spacing:-.022em; }
+    h2 { font-size:32px; line-height:1.15; margin:0 0 8px; }
+    h3 { font-size:17px; margin:0 0 5px; }
+    p { margin:0 0 13px; }
+    a { color:var(--accent); }
+    section { padding:78px 0; border-top:1px solid var(--rule); }
+    .eyebrow { font-size:11px; font-weight:700; letter-spacing:.12em; text-transform:uppercase; color:var(--muted); margin:0 0 9px; }
+    .sec-head { max-width:560px; margin:0 0 34px; }
+    .sec-head p { font-size:16px; margin:0; color:var(--muted); }
+    .sec-head p span { display:block; }
+    .ctr { margin-left:auto; margin-right:auto; text-align:center; }
+
+    /* icons */
+    .i { width:1em; height:1em; fill:currentColor; flex:none; vertical-align:-.125em; }
+
+    /* hero */
+    .hero { padding:56px 0 70px; border-top:0; }
+    .brand { display:flex; align-items:center; gap:10px; margin:0 0 40px; }
+    img.brand-mark { width:76px; height:76px; display:block !important; margin:0 !important; }
+    .brand-name { font-weight:700; color:var(--ink); font-size:26px; letter-spacing:-.02em; }
+    h1.tagline { font-size:56px; line-height:1.05; font-weight:700; color:var(--ink); margin:0 0 12px; letter-spacing:-.04em; }
+    .sub span { display:block; }
+    .sub { font-size:19px; max-width:680px; margin:0 0 40px; color:var(--body); }
+    .cta { display:grid; grid-template-columns:232px; gap:12px; justify-content:start; }
+    .btn { display:flex; align-items:center; justify-content:center; gap:9px; width:100%; height:52px; padding:0 18px; border-radius:999px; font-weight:650; font-size:15px; white-space:nowrap; text-decoration:none; letter-spacing:-.01em; transition:transform .12s, box-shadow .12s; }
+    .btn:hover { transform:translateY(-1px); }
+    .btn-primary:hover { box-shadow:0 8px 20px rgba(22,82,240,.28); }
+    .btn-primary { background:var(--accent); color:#fff; }
+    .btn-ghost { border:1px solid #d8dce5; color:var(--ink); background:#fff; }
+    .btn-ghost:hover { border-color:#b9c0cd; }
+    .btn-label { white-space:nowrap; }
+    /* One child to centre. With the icon, label and pill as direct flex
+       children, any stray node between them became an anonymous item and
+       collected its own gap, which pushed the row off centre on phones. */
+    .btn-in { display:inline-flex; align-items:center; gap:9px; }
+    .pill { background:rgba(16,18,26,.06); border-radius:999px; padding:1px 8px; font-size:12.5px; font-weight:700; }
+    .trustline { display:flex; flex-wrap:wrap; gap:20px; align-items:center; margin:0 0 12px; font-size:11.5px; font-weight:700; letter-spacing:.1em; text-transform:uppercase; color:var(--muted); }
+    .trustline span { display:inline-flex; align-items:center; gap:7px; }
+    .trustline svg { width:14px; height:14px; }
+
+    /* browser chrome */
+    .browser { min-width:0; border:1px solid var(--rule); border-radius:13px; background:#fff; overflow:hidden; box-shadow:0 12px 34px rgba(16,18,26,.07); }
+    .chrome { display:flex; align-items:center; gap:6px; padding:10px 13px; border-bottom:1px solid var(--rule); background:var(--wash); }
+    .dot { width:9px; height:9px; border-radius:50%; background:#d6dae3; }
+    .addr { margin-left:8px; font:11.5px ui-monospace,SFMono-Regular,Menlo,monospace; color:var(--muted); }
+    /* The reader's real bar: a plain wordmark, the slug, and a grey version
+       pill. Blue is this site's CTA colour, so the demo does not spend it. */
+    .tbar { display:flex; align-items:center; gap:6px; padding:4px 13px; border-bottom:1px solid var(--rule); background:#fff; }
+    .tbar-mark { color:#555; font-size:13px; padding:6px 8px; }
+    .tbar-crumb { color:#555; font-weight:500; font-size:13px; padding:4px 6px; }
+    .tbar-sep { color:#c0c0c4; }
+    .tbar-v { font:12px ui-monospace,SFMono-Regular,Menlo,monospace; background:#f0f1f4; color:#1a1a1a; border-radius:999px; padding:3px 10px; }
+
+    /* the real conway doc */
+    .doc { padding:26px 30px 22px; }
+    .doc h4 { font-size:23px; line-height:1.2; margin:0 0 12px; color:var(--ink); letter-spacing:-.02em; }
+    .doc p { font-size:14px; margin:0 0 11px; color:var(--body); }
+    .rules { background:var(--wash); border-left:3px solid var(--ink); padding:11px 15px; margin:15px 0; font:12px/1.6 ui-monospace,SFMono-Regular,Menlo,monospace; white-space:pre-wrap; color:var(--ink); }
+    /* The board is a widget island now: a separate document framed with
+       sandbox="allow-scripts", so it runs a real generation loop while the
+       host page still executes none of its own script. */
+    /* The island keeps the artifact card. The ring that marks it as the
+       anchored artifact is drawn inside, around the board alone, so the play
+       control below reads as a control and not as part of what the comment
+       points at. The card also has to stay opaque: dark mode inverts the page
+       and inverts iframes back, so a transparent island would come back as a
+       bare white slab. */
+    iframe.life { width:100%; aspect-ratio:16/10; display:block; border:1px solid var(--rule);  background:#fff; }
+
+    /* Use-case switcher. CSS only: this page is a published tdoc, so its own
+       author JS never runs. Radio + sibling selectors do the switching, and the
+       comment threads are plain static markup — nothing here animates except
+       the artifacts, which are sandboxed islands that may. */
+    .usecases input[name="uc"] { position:absolute; opacity:0; pointer-events:none; }
+    /* A macOS Safari window, separate-tab-bar layout: toolbar with the
+       address field on top, tab bar underneath. The accent colour belongs to
+       the CTA, so the chrome stays grey and the active tab reads as focused
+       by being lighter, not by being coloured. */
+    /* macOS Safari, compact tab layout. Traffic lights at their real sizes and
+       colours, the sidebar and back/forward glyphs, tabs sharing the row, and
+       the focused tab carrying the URL — domain in ink, path muted — the way
+       Safari merges the address field into the active tab. */
+    .chrome { background:#e9e9eb; border-bottom:1px solid #d3d3d7; padding:6px 11px; gap:0; align-items:center; }
+    .tl { width:12px; height:12px; border-radius:50%; margin-right:8px; flex:none; }
+    .tl.r { background:#ff5f57; } .tl.y { background:#febc2e; } .tl.g { background:#28c840; }
+    .sfside { color:#7c7c82; font-size:13px; margin:0 10px 0 6px; }
+    .sfnav { color:#a8a8ae; font-size:15px; letter-spacing:6px; margin-right:10px; }
+    .sfnav i { font-style:normal; color:#c8c8cd; }
+    .sfbar { display:flex; align-items:stretch; gap:0; flex:1; min-width:0; }
+    .sft { flex:1 1 0; min-width:0; display:flex; align-items:center; gap:6px; cursor:pointer;
+      padding:4px 10px; min-height:28px; box-sizing:border-box; border-radius:7px;
+      font-size:12.5px; color:#5f5f66; position:relative; background:transparent; }
+    /* Unfocused tabs are separated by hairlines, not borders. */
+    .sft + .sft:before { content:""; position:absolute; left:0; top:5px; bottom:5px; width:1px; background:#cdcdd2; }
+    .sft:hover { background:rgba(255,255,255,.55); }
+    .sft.on { background:#fff; color:#1d1d1f; box-shadow:0 1px 2px rgba(0,0,0,.14); }
+    .sft.on:before, .sft.on + .sft:before { display:none; }
+    .sfico { width:13px; height:13px; flex:none; display:block !important; margin:0 !important; border-radius:0; }
+    .sfnm { flex:1; min-width:0; overflow:hidden; text-overflow:ellipsis; white-space:nowrap;
+      font:12.5px system-ui,-apple-system,sans-serif; }
+    .sfx { color:#8a8a90; font-size:9px; flex:none; }
+    .sfplus { color:#7c7c82; font-size:15px; padding-left:11px; flex:none; }
+    /* Four equal boxes at 320 gave every tab 42px, which renders as "G L. D
+       F." — four tabs you cannot tell apart. Safari solves this by feeding
+       the frontmost tab and starving the rest, so do the same: the open doc
+       keeps a readable name, the others keep enough letters to aim at. */
+    @media (max-width:520px) {
+      /* Sharing ~170px between four names gives each one 9px of text — a
+         single letter. Safari compresses to favicon-only long before that,
+         so do the same: the open doc keeps its whole name and the rest
+         stay tappable icons. */
+      .sft:not(.on) .sfnm { display:none; }
+      .sft:not(.on) { flex:0 0 auto; padding:4px 6px; }
+      .sft.on { flex:1 1 auto; padding:4px 8px; gap:5px; }
+      .sfnm { font-size:10.5px; }
+      .tl { width:11px; height:11px; margin-right:6px; }
+    }
+    /* The touch floor applies where there is a finger, not on a desk. */
+    @media (pointer: coarse) { .sft { min-height:40px; } }
+    /* All four stack in one grid cell, so the container is as tall as the
+       tallest and nothing has to be positioned absolutely. Rotation animates
+       opacity and visibility, which animate reliably — `display` in keyframes
+       did not apply here and left every panel hidden. */
+    /* minmax(0,1fr), not the default min-content: the Safari chrome's own
+       minimum is ~412px, and an auto track refuses to go below it, which made
+       the whole page scroll sideways on every phone. */
+    .uc-panels { display:grid; grid-template-columns:minmax(0,1fr); }
+    .uc-panel { grid-area:1 / 1; min-width:0; opacity:0; visibility:hidden; }
+    /* Untouched, the window cycles all four, six seconds each: one demo on a
+       loop only ever sells one use case. Clicking a tab stops it where it was
+       put. Pure CSS, because a published tdoc runs no author JS of its own. */
+    @keyframes cyc1 { 0% { opacity:1; visibility:visible } 33.33% { opacity:0; visibility:hidden } }
+    @keyframes cyc2 { 0% { opacity:0; visibility:hidden } 33.33% { opacity:1; visibility:visible } 66.66% { opacity:0; visibility:hidden } }
+    @keyframes cyc3 { 0% { opacity:0; visibility:hidden } 66.66% { opacity:1; visibility:visible } }
+    .usecases:not(:has(input:checked)) .p-rep { animation:cyc1 18s steps(1, end) infinite; }
+    .usecases:not(:has(input:checked)) .p-res { animation:cyc2 18s steps(1, end) infinite; }
+    .usecases:not(:has(input:checked)) .p-des { animation:cyc3 18s steps(1, end) infinite; }
+    /* Clicking pins one and cancels the rotation. */
+    #uc-rep:checked ~ .uc-panels .p-rep,
+    #uc-res:checked ~ .uc-panels .p-res,
+    #uc-des:checked ~ .uc-panels .p-des { opacity:1; visibility:visible; animation:none; }
+    /* No :has() support, or motion turned down: show the first, do not rotate. */
+    @supports not selector(:has(*)) { .p-rep { opacity:1; visibility:visible; } }
+    @media (prefers-reduced-motion: reduce) {
+      .usecases .uc-panel { animation:none !important; }
+      .usecases:not(:has(input:checked)) .p-rep { opacity:1; visibility:visible; }
+    }
+    .uc-note { margin:14px 0 0; text-align:center; color:var(--muted); font-size:13.5px; }
+    /* The artifact frame is wide and short on a desk, tall and narrow on a
+       phone, or the chart inside gets 135px of height and clips. */
+    @media (max-width:900px) { iframe.life { aspect-ratio:16/8; } }
+    @media (max-width:700px) { iframe.life { aspect-ratio:4/3; } }
+    @media (max-width:520px) { iframe.life { aspect-ratio:17/11; } }
+
+    /* The promise is the demo: click the phrase (or the hand on it) and a
+       real thread opens under it. No author script runs on this page, so the
+       toggle is a checkbox and the reveal is a rule. */
+    /* The promise is the demo. A hand drags across the phrase, the selection
+       fills in behind it, and the run ends on a press so the invitation is
+       unmistakable. Clicking it selects the phrase for real and opens the
+       product's own composer — no second composer to drift from that one. */
+    .sub .hsel { display:inline; position:relative; cursor:pointer; color:var(--ink);
+      background-image:linear-gradient(#FFF2B8,#FFF2B8); background-repeat:no-repeat;
+      background-size:0% 100%; animation:hsel-fill 7s cubic-bezier(.42,0,.24,1) infinite; }
+    @keyframes hsel-fill { 0% { background-size:0% 100%; } 22%,88% { background-size:100% 100%; }
+      100% { background-size:0% 100%; } }
+    .tcur { position:absolute; left:0; top:.52em; width:23px; height:26px; pointer-events:none;
+      animation:hsel-drag 7s cubic-bezier(.42,0,.24,1) infinite; }
+    .tcur svg { width:100%; height:100%; display:block; filter:drop-shadow(0 1px 2px rgba(31,30,29,.3)); }
+    @keyframes hsel-drag { 0% { left:0; opacity:0; transform:none; } 7% { opacity:1; }
+      22% { left:100%; transform:none; } 26% { transform:translateY(3px) scale(.92); }
+      31% { transform:none; } 88% { left:100%; opacity:1; }
+      95%,100% { left:100%; opacity:0; } }
+    .tcur:after { content:""; position:absolute; left:-7px; top:-6px; width:24px; height:24px;
+      border:2px solid var(--ink); border-radius:50%; opacity:0;
+      animation:hsel-tap 7s cubic-bezier(.42,0,.24,1) infinite; }
+    @keyframes hsel-tap { 0%,23% { transform:scale(.3); opacity:0; }
+      28% { opacity:.5; } 42%,100% { transform:scale(1.6); opacity:0; } }
+    @media (prefers-reduced-motion: reduce) {
+      .sub .hsel { animation:none; background-size:100% 100%; }
+      .tcur { animation:none; left:100%; }
+      .tcur:after { animation:none; opacity:0; }
+    }
+    .tldr { display:flex; gap:11px; align-items:flex-start; margin:15px 0;
+      padding:12px 14px; background:var(--wash); border-left:3px solid var(--ink); }
+    .tldr-k { flex:none; font-size:10.5px; font-weight:800; letter-spacing:.09em;
+      color:var(--muted); padding-top:2px; }
+    .tldr span { font-size:14px; line-height:1.55; color:var(--body); }
+    .tldr b { color:var(--ink); font-weight:650; }
+
+    /* comment cards */
+    .note { border:1px solid var(--rule); border-radius:9px; padding:10px 12px; background:#fff; box-shadow:0 1px 3px rgba(16,18,26,.05); }
+    .note + .note { margin-top:8px; }
+    .nhead { display:flex; align-items:center; gap:7px; margin:0 0 4px; }
+    .av { width:19px; height:19px; border-radius:50%; flex:none; display:grid; place-items:center; font-size:9.5px; font-weight:700; color:#fff; }
+    .av svg { width:12px; height:12px; }
+    .who { font-size:12.5px; font-weight:650; color:var(--ink); }
+    .ntext { font-size:12.5px; line-height:1.5; margin:0; color:var(--body); }
+    .agent { border-color:#cfe0d6; background:#f4faf6; }
+    .done { margin-left:auto; font-size:10.5px; font-weight:700; color:var(--good); }
+    .margin-notes { padding:0 30px 24px; }
+
+    /* Replicates the real .tdoc-margin-comment: 13px system-ui on #111,
+       white, 1px #e5e5e5, 10px radius, 12px padding, and the same row order
+       (move anchor, author, text, reactions, meta, replies). */
+    .mc { width:100%; background:#fff; border:1px solid #e5e5e5; border-radius:10px; padding:12px; box-shadow:0 2px 8px rgba(0,0,0,.05); font:13px system-ui,sans-serif; color:#111; }
+    .mc-anchor { font-size:10.5px; letter-spacing:.06em; text-transform:uppercase; color:#9aa0aa; margin:0 0 8px; }
+    .mc-author { display:flex; align-items:center; gap:7px; margin:0 0 6px; min-height:22px; }
+    .mc-av { width:22px; height:22px; border-radius:50%; display:grid; place-items:center; color:#fff; font-size:10px; font-weight:700; flex:none; }
+    /* the reader builds agent avatars from agentLogoUrl(): the full colour
+       mark filling the slot, not a glyph inset on a white disc */
+    
+    .mc-av.mc-logo { background:#D97757; border:0; }
+    .mc-logo svg { width:14px; height:14px; fill:#fff; display:block; }
+    /* Dark mode repaints the page with one invert filter. Reaction emoji are
+       OS colour bitmaps and the agent mark is a brand colour, so both come
+       back wrong. Flip them a second time, the way the overlay restores its
+       own reaction chips. */
+    .emo { display:inline-block; line-height:1; }
+    html[data-tdoc-theme="dark"] .emo,
+    html[data-tdoc-theme="dark"] .mc-av.mc-logo { filter:invert(1) hue-rotate(180deg); }
+    .mc-text { color:#111; line-height:1.5; }
+    .mc-state { display:inline-block; font-size:11px; font-weight:700; color:#1a7340; background:#e8f5ed; border:1px solid #cfe0d6; border-radius:999px; padding:1px 8px; margin:0 0 7px; }
+    .mc-login { font-weight:650; color:#111; font-size:13px; }
+    .mc-reply .mc-login { font-weight:700; }
+    .mc-reply { margin:10px 0 0; padding:10px 12px; border-left:2px solid #e5e5e5; background:#fafbfa; border-radius:0 8px 8px 0; }
+    .mc-r.on { background:#e8f5ed; border-color:#cfe0d6; }
+    .mc-r.on.red { background:#fdeaea; border-color:#f2cccc; }
+    .mc-r.add { color:#9aa0aa; }
+    .mc-actions { display:inline-flex; gap:10px; }
+    .mc-actions .a { color:#1652f0; font-weight:600; }
+    .mc-actions .del { color:#c3452f; font-weight:600; }
+    .mc-reacts { display:flex; flex-wrap:wrap; gap:5px; margin:9px 0 0; }
+
+    .mc-r { font-size:11.5px; background:#f5f6f8; border:1px solid #e5e5e5; border-radius:999px; padding:2px 8px; }
+    .mc-meta { display:flex; justify-content:space-between; align-items:center; margin:9px 0 0; font-size:11px; color:#9aa0aa; }
+    .mc-replies { margin:9px 0 0; font-size:12px; color:var(--accent); font-weight:600; }
+    .mc-row { display:flex; align-items:flex-start; gap:9px; }
+    .mc-row.collapsed { margin-top:16px; align-items:center; }
+    .pin { width:26px; height:26px; border-radius:50%; overflow:hidden; flex:none; display:grid; place-items:center; background:#fff; border:2px solid var(--accent); box-shadow:0 1px 4px rgba(16,18,26,.12); }
+    /* The source art has its own margin around the character, so at pin size
+       you saw its backdrop rather than the face. Zoom past it and clip to the
+       ring. */
+    img.pin-av { object-fit:cover; transform:scale(1.34); display:block !important; margin:0 !important; }
+    .pin-av { width:100%; height:100%; border-radius:50%; display:grid; place-items:center; color:#fff; font-size:11px; font-weight:700; }
+    .pin-cluster { background:var(--accent); border-color:var(--accent); color:#fff; font-size:12px; font-weight:700; }
+    .pin-hint { font-size:11.5px; color:var(--muted); line-height:1.4; }
+    /* proof band */
+    .band { display:flex; flex-wrap:wrap; justify-content:center; align-items:center; gap:13px; font-size:14px; color:var(--muted); }
+    .band b { color:var(--ink); font-weight:650; }
+    .band span { display:inline-flex; align-items:center; gap:6px; }
+    .bsep { width:3px; height:3px; border-radius:50%; background:#ccd1db; }
+
+    /* artifact tiles */
+                
+    /* loop */
+    .loop { display:grid; grid-template-columns:repeat(3,1fr); gap:16px; }
+    .step { border:1px solid var(--rule); border-radius:12px; overflow:hidden; background:#fff; }
+    .step-viz { background:var(--wash); border-bottom:1px solid var(--rule); }
+    .step-viz svg { display:block; width:100%; height:auto; }
+
+    .step-txt { padding:14px 16px 16px; }
+    .step-n { display:inline-grid; place-items:center; width:20px; height:20px; border-radius:50%; background:var(--accent); color:#fff; font-size:11px; font-weight:700; margin:0 0 8px; }
+    .step h3 { font-size:15px; }
+    .step p { font-size:13px; margin:0; color:var(--muted); }
+
+    .pain-viz { border:1px solid var(--rule); border-radius:13px; overflow:hidden; background:var(--wash); max-width:640px; margin:0 auto; }
+    .pain-viz svg { display:block; width:100%; height:auto; }
+
+    /* runtime logos */
+    .runtimes { display:flex; flex-wrap:wrap; gap:11px; justify-content:center; }
+    .rt { display:inline-flex; align-items:center; gap:9px; border:1px solid var(--rule); border-radius:11px; padding:12px 19px; background:#fff; font-weight:600; font-size:15px; color:var(--ink); }
+    .rt svg { width:19px; height:19px; }
+
+    .logorow { justify-content:center; }
+
+    /* No setup: the agents are what you already have, not a menu you pick
+       from, and the hosts are the "or" in a sentence rather than a second
+       decision standing between you and a first doc. */
+    .nosetup { display:flex; flex-direction:column; align-items:center; gap:16px; }
+    .ns-cap { font-size:14px; color:var(--muted); margin:0; text-align:center; }
+    .ns-host { font-size:14px; color:var(--muted); margin:8px 0 0; text-align:center;
+      max-width:620px; display:flex; flex-wrap:wrap; align-items:center; justify-content:center; gap:9px; }
+    .ns-host b { color:var(--ink); font-weight:650; }
+    .ns-marks { display:inline-flex; gap:8px; align-items:center; }
+    .apptile.ns-small { width:42px; height:42px; border-radius:11px; }
+    .apptile.ns-small svg { width:21px; height:21px; }
+    .apptile.ns-small img.apptile-img { width:25px; height:25px; }
+
+    /* feature cards, opentag layout */
+        /* rows stretch so the four bottoms line up. align-items:start hugs the
+       content and leaves a ragged edge in a 2x2, which reads worse than the
+       even padding stretching produces. */
+    .sm-grid { display:grid; grid-template-columns:repeat(3,1fr); gap:16px; align-items:stretch; }
+    .sm-card { border:1px solid #E8E5DC; border-radius:0; overflow:hidden; background:#fff; display:flex; flex-direction:column; }
+    .sm-txt { flex:1; }
+    .sm-viz { background:#FAF9F5; border-bottom:1px solid #E8E5DC; }
+    .sm-viz svg { display:block; width:100%; height:auto; }
+    .sm-txt { padding:17px 19px 20px; }
+        /* One click, and the round is closed. No author script on this page, so
+       the button is a checkbox and a label — the swap is a rule, not an
+       animation, and it holds where the reader left it. */
+    .sm-label { font-size:11px; font-weight:700; letter-spacing:.11em; color:var(--accent); margin:0 0 6px; }
+    .sm-body { font-size:13.5px; margin:0; color:var(--muted); }
+
+    /* deploy */
+    .hosts { display:grid; grid-template-columns:1fr 1fr; gap:16px; }
+    .host { border:1px solid var(--rule); border-radius:13px; padding:28px; background:#fff; text-align:center; }
+    .host svg { width:52px; height:52px; display:block; margin:0 auto 14px; }
+    .host h3 { font-size:18px; }
+    .host p { font-size:13.5px; margin:0; color:var(--muted); }
+
+    /* compare, opentag marks */
+    .tablewrap { overflow-x:auto; border:1px solid var(--rule); border-radius:13px; scrollbar-width:thin; }
+    /* Below the table's own floor the last column is cut with nothing to show
+       for it — under overlay scrollbars the table looks complete and is not.
+       Fade the right edge so the cut is visible, and let the columns shrink
+       before resorting to scrolling at all. */
+    @media (max-width:890px) {
+      .tablewrap { -webkit-mask-image:linear-gradient(90deg,#000 92%,transparent); mask-image:linear-gradient(90deg,#000 92%,transparent); }
+      .tablewrap table { min-width:660px; }
+      .tablewrap th, .tablewrap td { padding-left:9px; padding-right:9px; }
+    }
+    /* The overlay styles author tables with `margin: 0 0 18px -14px`, which
+       pulls the table out of its own scroll wrapper and leaves a gap on the
+       right and bottom. Neutralised here with a more specific selector so the
+       homepage renders correctly today; the real fix is PR #128. */
+    .tablewrap table { margin:0; border-radius:13px; overflow:hidden; }
+    /* The overlay normalises author tables (border-collapse:separate,
+       border-spacing:3px). That put a gap and a rounded corner around every
+       cell in the middle of the grid. Only the outer corners round. */
+    .tablewrap table, body .tablewrap table { border-collapse:collapse !important; border-spacing:0 !important; }
+    .tablewrap th, .tablewrap td { border-radius:0 !important; }
+    .tablewrap tr:first-child th:first-child { border-top-left-radius:13px; }
+    .tablewrap tr:first-child th:last-child { border-top-right-radius:13px; }
+    .tablewrap tr:last-child td:first-child { border-bottom-left-radius:13px; }
+    .tablewrap tr:last-child td:last-child { border-bottom-right-radius:13px; }
+    table { border-collapse:collapse; border-spacing:0; width:100%; min-width:840px; font-size:14px; background:#fff; table-layout:fixed; }
+    th, td { padding:12px 14px; text-align:left; border-bottom:1px solid var(--rule); vertical-align:middle; }
+    tbody tr:hover td { background:#fbfcfe; }
+    tbody tr:hover td.us { background:#eaf0fe; }
+    thead th { font-size:11.5px; letter-spacing:.05em; text-transform:uppercase; color:var(--muted); font-weight:700; background:var(--wash); }
+    thead th:first-child { background:#eef0f5; }
+    thead th.us { background:var(--soft); color:var(--accent); }
+    td.us { background:#fafbff; }
+    .lbl { font-weight:700; color:var(--ink); width:27%; background:#f2f4f8; font-size:14px; }
+    tbody tr:last-child td { border-bottom:0; }
+    .yes,.no,.part { display:inline-flex; align-items:center; gap:7px; font-weight:500; }
+    .yes { color:var(--ink); }
+    .no { color:#5b6070; }
+    .part { color:var(--body); }
+    .yes svg,.no svg,.part svg { width:18px; height:18px; flex:none; border-radius:50%; padding:2.5px; }
+    .yes svg { background:var(--good); color:#fff; }
+    .no svg { background:#8a90a0; color:#fff; }
+    .part svg { background:#c9a227; color:#fff; }
+
+    /* hero split: doc left, comments in the right margin, as on desktop */
+    .stage { display:grid; grid-template-columns:1fr 300px; }
+    /* A real report does not stop where the frame does. Cap the stage and fade
+       the cut, so it reads as a screenshot of something longer rather than a
+       short page with dead space under it. Lives here, beside the other
+       .stage rules, because it was once written next to the switcher CSS and
+       a later rewrite of that block took it out with no test to notice. */
+    /* 585 is thirty lines of 19.5px, so the fade starts on a whole line
+       instead of slicing one, and it clears the artifact's bottom edge (569)
+       rather than cropping the chart. */
+    .doc-tail { max-height:104px; overflow:hidden; position:relative; }
+    .doc-tail:after { content:""; position:absolute; left:0; right:0; bottom:0; height:64px;
+      background:linear-gradient(transparent,#fff); pointer-events:none; }
+    .stage-notes { padding:22px 16px 22px 0; }
+    /* A comment sits beside the thing it points at. The two artifact-anchored
+       threads line up with the island; the two that select a phrase ride up
+       to that line instead. Measured, not guessed: the aside adds its own
+       22px, so the offset is anchorTop - 22. */
+    .mc-row { padding-top:238px; }
+    .p-res .mc-row, .p-des .mc-row { padding-top:68px; }
+    .stage-notes .lbl-n { font-size:10.5px; font-weight:700; letter-spacing:.1em; text-transform:uppercase; color:var(--muted); margin:0 0 10px; }
+
+    /* the second way in, under the buttons: a small terminal with the two
+       routes that actually exist. No Copy button — this page runs no script,
+       so a button that cannot copy would be a lie. user-select:all makes one
+       click select the whole line, which is real. */
+    /* trusted by marquee */
+    .trust-label { margin:0 0 22px; text-align:center; font:700 11.5px ui-monospace,SFMono-Regular,Menlo,monospace; letter-spacing:.14em; text-transform:uppercase; color:var(--muted); }
+    .marquee { overflow:hidden; -webkit-mask-image:linear-gradient(90deg,transparent,#000 14%,#000 86%,transparent); mask-image:linear-gradient(90deg,transparent,#000 14%,#000 86%,transparent); }
+    .track { display:flex; width:max-content; animation:scroll 30s linear infinite; }
+    .marquee:hover .track { animation-play-state:paused; }
+    @keyframes scroll { from { transform:translateX(0); } to { transform:translateX(-50%); } }
+    .tlogo { flex:0 0 auto; display:inline-flex; align-items:center; gap:11px; margin-right:70px; font-size:17px; font-weight:700; white-space:nowrap; color:var(--ink); opacity:.5; }
+    .tlogo svg { width:21px; height:21px; fill:currentColor; flex:none; }
+    .tlogo-img { gap:0; }
+    .tlogo-img img { height:24px; width:auto; display:block !important; margin:0 !important; }
+    @media (prefers-reduced-motion: reduce) { .track { animation:none; } }
+
+    /* big runtime tiles, opentag apptile treatment */
+    .logorow { display:flex; flex-wrap:wrap; gap:14px; justify-content:center; }
+    .apptile { width:84px; height:84px; border-radius:20px; display:grid; place-items:center; border:1px solid rgba(0,0,0,.1); }
+    .apptile svg { width:42px; height:42px; }
+    img.apptile-img { width:52px; height:52px; display:block !important; margin:0 !important; }
+    .apptile.more { font-size:30px; font-weight:700; color:var(--muted); background:var(--wash); }
+
+    /* social proof wall */
+    .proof-wall { display:grid; grid-template-columns:repeat(3,1fr); gap:15px; align-items:stretch; }
+    .proof-card { margin:0; border:1px solid var(--rule); border-radius:12px; padding:16px; background:#fff; }
+    .proof-card blockquote { margin:0 0 13px; font-size:14.5px; line-height:1.55; color:var(--ink); }
+    .proof-card figcaption { display:flex; align-items:center; gap:10px; }
+    .proof-card img { width:32px; height:32px; border-radius:50%; flex:none; background:var(--wash); }
+    .pname { font-size:13.5px; font-weight:650; color:var(--ink); display:flex; align-items:center; gap:5px; }
+    .prole { font-size:12.5px; color:var(--muted); }
+    .badge { width:13px; height:13px; color:var(--accent); }
+
+    /* ── overlay overrides ─────────────────────────────────────────────
+       The reader's overlay restyles author content, and three of its rules
+       fight this page. Scoped overrides rather than blanket !important, so
+       the overlay keeps winning everywhere it should.
+       1. `table { border-collapse:separate; border-spacing:3px }` opened
+          visible seams between every cell and made the compare table read
+          as loose tiles.
+       2. `table { margin:0 0 18px -14px }` pulled the table out of its own
+          scroll wrapper (PR #128 is the real fix).
+       3. author `img { display:block; margin:16px auto }` centred every
+          avatar and added 16px of vertical air, which is what pushed the
+          names and roles away from their faces. */
+    .tablewrap table { border-collapse:collapse; border-spacing:0; margin:0; border-radius:13px; overflow:hidden; }
+    /* The overlay's author-image rule is a long :not() chain, so it outranks
+       a plain selector. Narrowly scoped !important is the honest tool here:
+       margin:16px auto was resolving to 34px of side air and shoving every
+       name away from its face. */
+    .proof-card img, .mc img, .mc svg, .mc-av svg { display:inline-block !important; margin:0 !important; }
+    .proof-card img, .mc img { border-radius:50% !important; }
+
+    /* social proof caption: face, then name, then role, all left aligned */
+    .proof-card figcaption { display:flex; align-items:center; gap:11px; }
+    .proof-card figcaption > span { display:flex; flex-direction:column; align-items:flex-start; gap:2px; min-width:0; }
+    .pname { display:inline-flex; align-items:center; gap:5px; font-size:13.5px; font-weight:650; color:var(--ink); }
+    .prole { font-size:12.5px; color:var(--muted); text-align:left; }
+    .proof-card img { width:32px; height:32px; object-fit:cover; flex:none; }
+
+    /* runtimes and hosts sit on one baseline instead of leaving a well
+       under the shorter column */
+    .rt-split { align-items:center; }
+    .rt-hosts { align-self:center; }
+
+    /* final */
+    footer { padding:28px 0 64px; font-size:13px; color:var(--muted); text-align:center; }
+    footer a { display:inline-flex; align-items:center; gap:6px; }
+
+    /* the split is the product's real desktop layout, so hold it as long as
+       the margin column stays usable rather than collapsing at tablet width */
+    @media (max-width:900px) {
+      .stage { grid-template-columns:1fr; }
+      .stage-doc { border-right:0; border-bottom:1px solid var(--rule); }
+      .mc-row { padding-top:0; }
+    }
+    @media (max-width:840px) {
+      h1.tagline { font-size:38px; }
+      h2 { font-size:25px; }
+      section { padding:56px 0; }
+      .doc { padding:20px; }
+    }
+    /* Below ~360 the two CTAs cannot share a row without touching the screen
+       edge, so they stack instead of spilling. */
+    @media (max-width:640px) {
+      h1.tagline { font-size:34px; }
+      /* On a phone the demo has to be one screen or it stops reading as a
+         screenshot and starts reading as a scroll. The stage keeps the three
+         things that carry the story — the doc, the artifact, the thread —
+         and drops the supporting prose. */
+      .tldr { display:none; }
+      .doc-tail { display:none; }
+      .doc h4:not(:first-child) { display:none; }
+      /* The thread keeps what tells the story — who said it, what the agent
+         did — and drops the reader furniture that costs 116px of the one
+         screen: the anchor hint, the reaction rows, the timestamps. */
+      .mc-anchor, .mc-reacts, .mc-meta { display:none; }
+      /* The lead paragraph stays: on two tabs it carries the phrase the
+         comment is anchored to. Everything around it gives up a few pixels
+         each until the window fits the screen. */
+      .stage-notes { padding:12px 14px 14px 0; }
+      .doc { padding:14px 14px 4px; }
+      .doc h4 { margin-bottom:6px; }
+      .doc p { font-size:13px; line-height:1.5; margin-bottom:8px; }
+      .tbar { padding:7px 12px; }
+      .mc-text { font-size:12px; line-height:1.45; }
+      .mc-reply { margin-top:8px; padding-top:8px; }
+      iframe.life { aspect-ratio:17/12; }
+      .sfnm { font-size:11px; } .sft { padding:4px 7px; }
+      .sfx, .sfside, .sfnav { display:none; }
+      /* 342px of usable width at 375, so two 232px tracks cannot sit side by
+         side. Share the row instead of stacking, and drop the two words that
+         do not fit rather than the second button. */
+      .cta { grid-template-columns:1fr; max-width:none; gap:10px; }
+      .btn { font-size:14px; padding:0 12px; }
+      .btn-long { display:none; }
+      .doc-tail { max-height:78px; }
+      /* v28 left these on desktop tracks. At 375 the loop is 98px
+         (one word per line), the quote wall is three 164px columns
+         (scrollWidth 545), and the feature cards are 156px. */
+      .loop, .sm-grid, .proof-wall { grid-template-columns:1fr; }
+    }
+  
+    /* After the 640 block on purpose: same specificity, so the later rule is
+       the one that applies. Written before it, this never fired and the two
+       buttons stayed side by side with the second one flush to the edge. */
+    @media (max-width:360px) { .cta { grid-template-columns:1fr; } }
+
+    /* Below ~430 the six-column table hid 59% of itself behind a fade. A fade
+       says "there is more"; it does not say "drag me sideways", and on a phone
+       there is no scrollbar to notice. Stack it into one card per row instead,
+       each cell labelled by its column. */
+    @media (max-width:430px) {
+      .tablewrap { overflow:visible; border:0; border-radius:0; -webkit-mask-image:none; mask-image:none; }
+      .tablewrap table { min-width:0; display:block; background:none; }
+      .tablewrap thead { display:none; }
+      .tablewrap tbody, .tablewrap tr { display:block; }
+      .tablewrap tr { border:1px solid var(--rule); border-radius:11px; padding:12px 13px 9px; margin:0 0 10px; background:#fff; }
+      /* The row label becomes the card's heading. */
+      /* width:auto matters: the desktop rule pins the label column narrow,
+         which made every heading wrap one word per line. */
+      .tablewrap td.lbl { display:block; width:auto; min-width:0; background:none; font-weight:700;
+        color:var(--ink); font-size:14px; line-height:1.3;
+        padding:0 0 9px; margin:0 0 9px; border-bottom:1px solid var(--rule); }
+      /* Five products in two columns rather than five full-width rows, or a
+         seven-feature table becomes thirty-five rows of scrolling. */
+      .tablewrap tr { display:grid; grid-template-columns:1fr 1fr; gap:7px 10px; }
+      .tablewrap td.lbl { grid-column:1 / -1; }
+      .tablewrap td { display:block; background:none !important; border:0; padding:0; text-align:left; font-size:12.5px; }
+      .tablewrap td:not(.lbl):before { content:attr(data-col); display:block; font-size:10px; font-weight:700;
+        letter-spacing:.06em; text-transform:uppercase; color:var(--muted); margin:0 0 2px; }
+      .tablewrap td.us { grid-column:1 / -1; background:var(--soft) !important; border-radius:8px; padding:7px 9px; min-height:0; }
+      .tablewrap td span.yes, .tablewrap td span.no, .tablewrap td span.part { vertical-align:-2px; }
+    }
+</style>
+</head>
+<body>
+
+<!-- brand marks, real vendor paths -->
+<svg style="display:none" aria-hidden="true">
+  <symbol id="i-github" viewBox="0 0 24 24"><path d="M12 .297c-6.63 0-12 5.373-12 12 0 5.303 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61C4.422 18.07 3.633 17.7 3.633 17.7c-1.087-.744.084-.729.084-.729 1.205.084 1.838 1.236 1.838 1.236 1.07 1.835 2.809 1.305 3.495.998.108-.776.417-1.305.76-1.605-2.665-.3-5.466-1.332-5.466-5.93 0-1.31.465-2.38 1.235-3.22-.135-.303-.54-1.523.105-3.176 0 0 1.005-.322 3.3 1.23.96-.267 1.98-.399 3-.405 1.02.006 2.04.138 3 .405 2.28-1.552 3.285-1.23 3.285-1.23.645 1.653.24 2.873.12 3.176.765.84 1.23 1.91 1.23 3.22 0 4.61-2.805 5.625-5.475 5.92.42.36.81 1.096.81 2.22 0 1.606-.015 2.896-.015 3.286 0 .315.21.69.825.57C20.565 22.092 24 17.592 24 12.297c0-6.627-5.373-12-12-12"/></symbol>
+  <symbol id="i-claude" viewBox="0 0 24 24"><path d="m4.7144 15.9555 4.7174-2.6471.079-.2307-.079-.1275h-.2307l-.7893-.0486-2.6956-.0729-2.3375-.0971-2.2646-.1214-.5707-.1215-.5343-.7042.0546-.3522.4797-.3218.686.0608 1.5179.1032 2.2767.1578 1.6514.0972 2.4468.255h.3886l.0546-.1579-.1336-.0971-.1032-.0972L6.973 9.8356l-2.55-1.6879-1.3356-.9714-.7225-.4918-.3643-.4614-.1578-1.0078.6557-.7225.8803.0607.2246.0607.8925.686 1.9064 1.4754 2.4893 1.8336.3643.3035.1457-.1032.0182-.0728-.164-.2733-1.3539-2.4467-1.445-2.4893-.6435-1.032-.17-.6194c-.0607-.255-.1032-.4674-.1032-.7285L6.287.1335 6.6997 0l.9957.1336.419.3642.6192 1.4147 1.0018 2.2282 1.5543 3.0296.4553.8985.2429.8318.091.255h.1579v-.1457l.1275-1.706.2368-2.0947.2307-2.6957.0789-.7589.3764-.9107.7468-.4918.5828.2793.4797.686-.0668.4433-.2853 1.8517-.5586 2.9021-.3643 1.9429h.2125l.2429-.2429.9835-1.3053 1.6514-2.0643.7286-.8196.85-.9046.5464-.4311h1.0321l.759 1.1293-.34 1.1657-1.0625 1.3478-.8804 1.1414-1.2628 1.7-.7893 1.36.0729.1093.1882-.0183 2.8535-.607 1.5421-.2794 1.8396-.3157.8318.3886.091.3946-.3278.8075-1.967.4857-2.3072.4614-3.4364.8136-.0425.0304.0486.0607 1.5482.1457.6618.0364h1.621l3.0175.2247.7892.522.4736.6376-.079.4857-1.2142.6193-1.6393-.3886-3.825-.9107-1.3113-.3279h-.1822v.1093l1.0929 1.0686 2.0035 1.8092 2.5075 2.3314.1275.5768-.3218.4554-.34-.0486-2.2039-1.6575-.85-.7468-1.9246-1.621h-.1275v.17l.4432.6496 2.3436 3.5214.1214 1.0807-.17.3521-.6071.2125-.6679-.1214-1.3721-1.9246L14.38 17.959l-1.1414-1.9428-.1397.079-.674 7.2552-.3156.3703-.7286.2793-.6071-.4614-.3218-.7468.3218-1.4753.3886-1.9246.3157-1.53.2853-1.9004.17-.6314-.0121-.0425-.1397.0182-1.4328 1.9672-2.1796 2.9446-1.7243 1.8456-.4128.164-.7164-.3704.0667-.6618.4008-.5889 2.386-3.0357 1.4389-1.882.929-1.0868-.0062-.1579h-.0546l-6.3385 4.1164-1.1293.1457-.4857-.4554.0608-.7467.2307-.2429 1.9064-1.3114Z"/></symbol>
+  <symbol id="i-openai" viewBox="0 0 24 24"><path d="M22.2819 9.8211a5.9847 5.9847 0 0 0-.5157-4.9108 6.0462 6.0462 0 0 0-6.5098-2.9A6.0651 6.0651 0 0 0 4.9807 4.1818a5.9847 5.9847 0 0 0-3.9977 2.9 6.0462 6.0462 0 0 0 .7427 7.0966 5.98 5.98 0 0 0 .511 4.9107 6.051 6.051 0 0 0 6.5146 2.9001A5.9847 5.9847 0 0 0 13.2599 24a6.0557 6.0557 0 0 0 5.7718-4.2058 5.9894 5.9894 0 0 0 3.9977-2.9001 6.0557 6.0557 0 0 0-.7475-7.0729zm-9.022 12.6081a4.4755 4.4755 0 0 1-2.8764-1.0408l.1419-.0804 4.7783-2.7582a.7948.7948 0 0 0 .3927-.6813v-6.7369l2.02 1.1686a.071.071 0 0 1 .038.052v5.5826a4.504 4.504 0 0 1-4.4945 4.4944zm-9.6607-4.1254a4.4708 4.4708 0 0 1-.5346-3.0137l.142.0852 4.783 2.7582a.7712.7712 0 0 0 .7806 0l5.8428-3.3685v2.3324a.0804.0804 0 0 1-.0332.0615L9.74 19.9502a4.4992 4.4992 0 0 1-6.1408-1.6464zM2.3408 7.8956a4.485 4.485 0 0 1 2.3655-1.9728V11.6a.7664.7664 0 0 0 .3879.6765l5.8144 3.3543-2.0201 1.1685a.0757.0757 0 0 1-.071 0l-4.8303-2.7865A4.504 4.504 0 0 1 2.3408 7.872zm16.5963 3.8558L13.1038 8.364 15.1192 7.2a.0757.0757 0 0 1 .071 0l4.8303 2.7913a4.4944 4.4944 0 0 1-.6765 8.1042v-5.6772a.79.79 0 0 0-.407-.667zm2.0107-3.0231l-.142-.0852-4.7735-2.7818a.7759.7759 0 0 0-.7854 0L9.409 9.2297V6.8974a.0662.0662 0 0 1 .0284-.0615l4.8303-2.7866a4.4992 4.4992 0 0 1 6.6802 4.66zM8.3065 12.863l-2.02-1.1638a.0804.0804 0 0 1-.038-.0567V6.0742a4.4992 4.4992 0 0 1 7.3757-3.4537l-.142.0805L8.704 5.459a.7948.7948 0 0 0-.3927.6813zm1.0976-2.3654l2.602-1.4998 2.6069 1.4998v2.9994l-2.5974 1.4997-2.6067-1.4997Z"/></symbol>
+  <symbol id="i-cursor" viewBox="0 0 24 24"><path d="M11.503.131 1.891 5.678a.84.84 0 0 0-.42.726v11.188c0 .3.162.575.42.724l9.609 5.55a1 1 0 0 0 .998 0l9.61-5.55a.84.84 0 0 0 .42-.724V6.404a.84.84 0 0 0-.42-.726L12.497.131a1.01 1.01 0 0 0-.996 0M2.657 6.338h18.55c.263 0 .43.287.297.515L12.23 22.918c-.062.107-.229.064-.229-.06V12.335a.59.59 0 0 0-.295-.51l-9.11-5.257c-.109-.063-.064-.23.061-.23"/></symbol>
+  <symbol id="i-gemini" viewBox="0 0 24 24"><path d="M11.04 19.32Q12 21.51 12 24q0-2.49.93-4.68.96-2.19 2.58-3.81t3.81-2.55Q21.51 12 24 12q-2.49 0-4.68-.93a12.3 12.3 0 0 1-3.81-2.58 12.3 12.3 0 0 1-2.58-3.81Q12 2.49 12 0q0 2.49-.96 4.68-.93 2.19-2.55 3.81a12.3 12.3 0 0 1-3.81 2.58Q2.49 12 0 12q2.49 0 4.68.96 2.19.93 3.81 2.55t2.55 3.81"/></symbol>
+  <symbol id="i-x" viewBox="0 0 24 24"><path d="M14.234 10.162 22.977 0h-2.072l-7.591 8.824L7.251 0H.258l9.168 13.343L.258 24H2.33l8.016-9.318L16.749 24h6.993zm-2.837 3.299-.929-1.329L3.076 1.56h3.182l5.965 8.532.929 1.329 7.754 11.09h-3.182z"/></symbol><symbol id="i-grok" viewBox="0 0 24 24"><path fill="currentColor" d="m3.005 8.858 8.783 12.544h3.904L6.908 8.858zM6.905 15.825 3 21.402h3.907l1.951-2.788zM16.585 2l-6.75 9.64 1.953 2.79L20.492 2zM17.292 7.965v13.437h3.2V3.395z"/></symbol>
+  <symbol id="i-cloudflare" viewBox="0 0 24 24"><path d="M16.5088 16.8447c.1475-.5068.0908-.9707-.1553-1.3154-.2246-.3164-.6045-.499-1.0615-.5205l-8.6592-.1123a.1559.1559 0 0 1-.1333-.0713c-.0283-.042-.0351-.0986-.021-.1553.0278-.084.1123-.1484.2036-.1562l8.7359-.1123c1.0351-.0489 2.1601-.8868 2.5537-1.9136l.499-1.3013c.0215-.0561.0293-.1128.0147-.168-.5625-2.5463-2.835-4.4453-5.5499-4.4453-2.5039 0-4.6284 1.6177-5.3876 3.8614-.4927-.3658-1.1187-.5625-1.794-.499-1.2026.119-2.1665 1.083-2.2861 2.2856-.0283.31-.0069.6128.0635.894C1.5683 13.171 0 14.7754 0 16.752c0 .1748.0142.3515.0352.5273.0141.083.0844.1475.1689.1475h15.9814c.0909 0 .1758-.0645.2032-.1553l.12-.4268zm2.7568-5.5634c-.0771 0-.1611 0-.2383.0112-.0566 0-.1054.0415-.127.0976l-.3378 1.1744c-.1475.5068-.0918.9707.1543 1.3164.2256.3164.6055.498 1.0625.5195l1.8437.1133c.0557 0 .1055.0263.1329.0703.0283.043.0351.1074.0214.1562-.0283.084-.1132.1485-.204.1553l-1.921.1123c-1.041.0488-2.1582.8867-2.5527 1.914l-.1406.3585c-.0283.0713.0215.1416.0986.1416h6.5977c.0771 0 .1474-.0489.169-.126.1122-.4082.1757-.837.1757-1.2803 0-2.6025-2.125-4.727-4.7344-4.727"/></symbol>
+  <symbol id="i-vercel" viewBox="0 0 24 24"><path d="m12 1.608 12 20.784H0Z"/></symbol>
+  <symbol id="i-google" viewBox="0 0 24 24"><path d="M12.48 10.92v3.28h7.84c-.24 1.84-.853 3.187-1.787 4.133-1.147 1.147-2.933 2.4-6.053 2.4-4.827 0-8.6-3.893-8.6-8.72s3.773-8.72 8.6-8.72c2.6 0 4.507 1.027 5.907 2.347l2.307-2.307C18.747 1.44 16.133 0 12.48 0 5.867 0 .307 5.387.307 12s5.56 12 12.173 12c3.573 0 6.267-1.173 8.373-3.36 2.16-2.16 2.84-5.213 2.84-7.667 0-.76-.053-1.467-.173-2.053H12.48z"/></symbol>
+  <symbol id="i-coinbase" viewBox="0 0 24 24"><path d="M22.35 9.7A10.6 10.6 0 1 0 22.35 14.3L15.63 14.3A4.3 4.3 0 1 1 15.63 9.7Z"/></symbol>
+  <symbol id="i-bytedance" viewBox="0 0 24 24"><path d="M19.8772 1.4685L24 2.5326v18.9426l-4.1228 1.0563V1.4685zm-13.3481 9.428l4.115 1.0641v8.9786l-4.115 1.0642v-11.107zM0 2.572l4.115 1.0642v16.7354L0 21.428V2.572zm17.4553 5.6205v11.107l-4.1228-1.0642V9.2568l4.1228-1.0642z"/></symbol>
+  <symbol id="i-code" viewBox="0 0 24 24"><path fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round" d="m8 6-6 6 6 6M16 6l6 6-6 6"/></symbol>
+  <symbol id="i-card" viewBox="0 0 24 24"><rect x="2" y="5" width="20" height="14" rx="3" fill="none" stroke="currentColor" stroke-width="2.2"/><path d="M2 10h20" stroke="currentColor" stroke-width="2.2"/></symbol>
+  <symbol id="i-check" viewBox="0 0 24 24"><path fill="none" stroke="currentColor" stroke-width="3.4" stroke-linecap="round" stroke-linejoin="round" d="M20 6 9 17l-5-5"/></symbol>
+  <symbol id="i-cross" viewBox="0 0 24 24"><path fill="none" stroke="currentColor" stroke-width="3.4" stroke-linecap="round" d="M18 6 6 18M6 6l12 12"/></symbol>
+  <symbol id="i-dash" viewBox="0 0 24 24"><path fill="none" stroke="currentColor" stroke-width="3.4" stroke-linecap="round" d="M6 12h12"/></symbol>
+</svg>
+
+<div class="wrap">
+
+  <!-- ══ HERO ══ -->
+  <section class="hero">
+    <div class="brand"><img class="brand-mark" src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAGAAAABgCAYAAADimHc4AAAABGdBTUEAALGPC/xhBQAAACBjSFJNAAB6JgAAgIQAAPoAAACA6AAAdTAAAOpgAAA6mAAAF3CculE8AAAAeGVYSWZNTQAqAAAACAAEARoABQAAAAEAAAA+ARsABQAAAAEAAABGASgAAwAAAAEAAgAAh2kABAAAAAEAAABOAAAAAAAAAEgAAAABAAAASAAAAAEAA6ABAAMAAAABAAEAAKACAAQAAAABAAAAYKADAAQAAAABAAAAYAAAAACavGt5AAAACXBIWXMAAAsTAAALEwEAmpwYAAABWWlUWHRYTUw6Y29tLmFkb2JlLnhtcAAAAAAAPHg6eG1wbWV0YSB4bWxuczp4PSJhZG9iZTpuczptZXRhLyIgeDp4bXB0az0iWE1QIENvcmUgNi4wLjAiPgogICA8cmRmOlJERiB4bWxuczpyZGY9Imh0dHA6Ly93d3cudzMub3JnLzE5OTkvMDIvMjItcmRmLXN5bnRheC1ucyMiPgogICAgICA8cmRmOkRlc2NyaXB0aW9uIHJkZjphYm91dD0iIgogICAgICAgICAgICB4bWxuczp4bXA9Imh0dHA6Ly9ucy5hZG9iZS5jb20veGFwLzEuMC8iPgogICAgICAgICA8eG1wOkNyZWF0b3JUb29sPkZpZ21hPC94bXA6Q3JlYXRvclRvb2w+CiAgICAgIDwvcmRmOkRlc2NyaXB0aW9uPgogICA8L3JkZjpSREY+CjwveDp4bXBtZXRhPgoE/1zIAAAKl0lEQVR4Ae1cBahVTRCeZ3c3dnd3Ync3KCYqYoAJJqJgIYqJgS2Y2C02iIXdndjdNf98A+fy3vW+++593vf26L8D951z9uzZ2Z3Z6dUwFiALxigQxxhmi1gpYBlgeCNYBlgGGKaAYfRWAiwDDFPAMHorAZYBhilgGL2VAMsAwxQwjN5KgGWAYQoYRm8lwDLAMAUMo7cSYBlgmAKG0VsJsAwwTAHD6K0EWAYYpoBh9FYCLAMMU8AweisBlgGGKWAYvZUAywDDFDCM3kqAZYBhChhGHy+m8d++fZu2b99OFy5coHjx4lHlypWpefPmlDx58phG/VeMHxbq09EfP36kEydO0KtXr+jw4cO0evVqypkzJ5UuXVoJcurUKfr06RPNmjWLatWq9VcQKUYnCQaECo4dO8aFCxfm/Pnzc5kyZVgIzIcOHYow/I8fP3jRokWcMWNG3rFjR4R3/8cHCsWiZbfz6dOnOWvWrDx69Gj+/v17lMNu3ryZs2fPznfu3Imy77/cIdoq6OrVq7RixQo6ePAgPXnyhH79+kVFixalrVu30owZM+jdu3c0ZswYv9I7bNgwevr0KS1btsxvv3/5ZbSM8IIFC5S4lSpVoh49epCoG8qSJQulTZtWaSW7WhkQFeGGDh1KNWvWpHv37lGOHDmi6v5vvg9WvC9dusTp0qXj3bt3B/upz/5dunRhkRif7/4PjUGroP79++vuDpXaEEbShAkT6MiRIwHvcDHk9OHDB/Wm4HWJzaGwsDBKmjSpurdwceHy/g0QFAOwUKibKVOmUIMGDSJd38OHDylx4sQelRRpR3mBMevUqUNVqlShIUOGUIoUKbQNrurz588JY0GlIZ64e/eu2pvXr1/Tly9f4EBQnDhx9AcczjNwp0qVSn9Qi2AInpMkSUIJEyakBAkSUPz48Slu3Lj6c+aHscA4tDvj4hn9EyVKRMmSJdMxMEf80PanEBQDQAQQC758mjRpfsMNYt2/f5/atm1LqVOnpkGDBlH37t1/6+fdgHHRD9+DSGDKt2/flKBYdObMmdVG5M6dW6/ibVH69OmVsCA2iAnif/36VSXj5cuXatyfPXtGL168IDAMDIXUfP78WceH04AfvsMP95AigNP28+dPwg/zwRWSBxx4DyZhjfny5aPq1atT7dq1A9pw3mvHYAHDo0ePWIwtb9y4keHPy2L025UrV7IEXyxRLsukWCbEN2/eZAm+AnYzZYF89uxZ3rdvHx89epQvX77MQsCAXNqAF/CHHbFmUXk6rytXrvDOnTtZtAG3adOGq1atyjNnzgx6vkFJALgnxKZJkyZRgQIFdEdh50AiMmTIoNHvpk2b6Nq1ayQMIAm0SPz9f9rDgVRdvHiRFi9erC44Ui7ipPy20SNrCJoBGOjt27dUr149ggHs3bu3jt2+fXtasmSJijGIXqpUKWrWrJn2iwz539IOFQS1JhqAbt26RdevX9cNBpUJWwQ7U7x4cc1xlS1bNqhlRYsBwPDgwQOdVMmSJT2MgC6HrmzUqBGNHTtWJwId7BiwoGZmoLNDZKwDEgyj//jxY3rz5o2uC/YJ9gi2SNItqgWQ50qZMmW0ZxttBoTHCBeydevWJD49TZ06VY3V/v37VV1Jfkg9kE6dOlHXrl0jTNbxZGBIYxtAVIlpVH1ChWBDYT6Yi+SpVG3mypWL8MuWLZuqWDgEoYaQMKBv377qDTRp0kTV0LZt29SraNiwIYHw8Bzg68NOSCJO1wDJaNGiBY0aNcqvSxvKBUOF7Nq1i8TQqzqBFyPJQ4IU4wpCw12NVfhDx0A/F8PLRYoUYRFNFlvAkg9SbyH82CLWXL9+fU8TImCxH0F7DZ4BvG5kR3O3bt1Y1IjXG+aTJ0+ypExYYg3FiUSg5K9+62eiISg31N8ExTgx3FRfsGfPHhaDzHny5GHxmhh9CxUqxMiiRgVw/QKB9+/fc968edWVdfpLoo979eqlhJ83bx6L1DmvXHMNWU0YhgkJufAAI9a4cWPq168fVatWTQMW2Ijjx4+ryEMF+AO4eC1btiRkXqMCRKww9nACABJLEFQg5oR0R58+faIXKEWF+E/fx9RWgDRgx8vCWbKdvHTpUpYomoVIWgeQTKiiRhC3ZcsWn9OAtIwbN053sNgRn32cRuxuFIPEa9GCT4kSJXjv3r3Oa9deQ6aCvFcoSTtu1aoVS2qCJW3Nkp7gDRs2sAQqXLduXR4wYIB+gqh57ty53p97nqGCJObgESNGeNp83SCKluBQdT36i/T56ua6thhhAHauBCY8bdo0Ll++PEP/hgfJm/C6detYivVcrFixKG2BuIhcsGBBFtc2/DAR7qXGzOJCsiT0WNzJCO/c/BAjDMCCBw4cyJKo4tmzZ3vWLwk2FreUO3bsyKLXWbKU+uzklDwdfdxAYlBHFp/dx1tmSBzyVJJ48/nerY0xxgCoDm9ijBw5kps2bareSMWKFVnSFfj/6rhcuXK8cOFChivpDRLksaS+VW1NnDhRJQbS4w2SHlHGYqxAvCvv7009hyQQC8QRQNJOiKP1YlFJmkKePn26ekYIfjJlyqThP46voOaAFDO8F0Spw4cPp86dO2ubFP8JgR/KoePHj49wvkiYTu3atdPUCIJBjOF2CJkbGtVCUeCQQIk6dOhAN27cIFFNWlNAYR9pALEVJJ6SFvaR2kBxH0UPhP8gqkNMMEfiCs3RizHXQ18ObriiyNYizYDK3V8BsS16Bw4cYBjV8HDmzBmWLKKqGRxvCQ/Q7bL7wzd57hHgwYuCh4V6hAOO0Ubwh9pCIDbG+Ta2rzFmA4JdiFSs1GuS5BdL4MbQ6QDYBTBHsqv67P0H8cH8+fM1VhDp0oIO+sD+9OzZU2MOeFDwjuSojPfnxp9dwwCHEnfkoJacHWUEUpAMAII6EBEGOTJApUoOCmi+CUYb+SiA1JU10KtQoYIn9ohsDBPtrmOAQ4TJkyez5N49hJwzZ06kqsj5xrkiXoDUrF271mnSewSAbgPXnt3AqTkc1oL3c+7cOYLBFYJqmhsG3R/gsBe8KRz4cmD9+vWaG3Ke3XL1vxLDs0QiDZ6Qk6OHlxMIICEHd9UpD54/f17dWRSM3AauZsCaNWv0vBCYAIKi/BfV7geBcV4V9Wq4tgBRZypJvo7SaAeTf9ymE535IIOK09ZI4AGQ11+1apXzOtIrjsjjeLwEedoHKQ85NOza6NiVRhhJPOR1JJ+v7iiKLVJPiLTg43ADGVMpe7IcCPNU2nBcHrGEW8FVDED+aPDgwZrEQ8DmAP5BB3x6fyBqR31+VNvCQ40aNVjqwOGbXHUfmFWLJR2JA12y+/WEBdIRKJ4LtUhOoNHy5cv9zkKKOnqsEakNnOMB4HgjjpXgzI5bIdaScYEQAOc2JdOp5zqd0iIYgCQezqT6A+STkICD8XXOeKI/DDHKoW4FVzHArUSKyXm52g2NyYW7ZWzLAMOcsAywDDBMAcPorQRYBhimgGH0VgIsAwxTwDB6KwGWAYYpYBi9lQDLAMMUMIzeSoBlgGEKGEZvJcAywDAFDKO3EmAZYJgChtFbCbAMMEwBw+itBFgGGKaAYfRWAiwDDFPAMHorAZYBhilgGL2VAMsAwxQwjP4/Mg5Dwj3bST4AAAAASUVORK5CYII=" alt="" width="26" height="26"><span class="brand-name">tdoc</span></div>
+
+
+    <p class="eyebrow" style="text-align:left;margin-bottom:14px;">AI-native docs for research, reports &amp; analysis</p>
+    <h1 class="tagline">Your agent writes the doc.<br>You just comment.</h1>
+    <p class="sub"><span>No more endless AI chat threads or copy&#8209;pasting between apps. Your agent drafts it; you <span class="hsel" data-tdoc-select>leave every piece of feedback as a comment<i class="tcur"><svg viewBox="0 0 40 46" aria-hidden="true"><path d="M17 27V9a4 4 0 0 1 8 0v13h2.5a3.2 3.2 0 0 1 3.2 3.2V27h1.6a3 3 0 0 1 3 3v1.4a3 3 0 0 1 .7 2v4.1A7.5 7.5 0 0 1 28.5 45h-7.9a7.4 7.4 0 0 1-5.5-2.4l-6.8-7.6a3.4 3.4 0 0 1 5-4.6L17 33z" fill="#fff" stroke="#1F1E1D" stroke-width="2.6" stroke-linejoin="round" stroke-linecap="round"/></svg></i></span>, and it rewrites all of them into the next version.</span></p>
+
+    <p class="trustline">
+      <span><svg aria-hidden="true"><use href="#i-code"/></svg>Open source</span>
+      <span><svg aria-hidden="true"><use href="#i-card"/></svg>Free &middot; No card</span>
+    </p>
+    <div class="cta">
+      <a class="btn btn-primary" href="/start"><span class="btn-in">Create your first doc</span></a>
+    </div>
+
+    <!-- tdoc demo: refined static mock (self-contained, hd- namespaced).
+         Auto-rotates the three docs until a tab is clicked, then pins. -->
+<svg style="display:none">
+  <symbol id="hd-ck" viewBox="0 0 24 24"><path d="M20 6 9 17l-5-5" fill="none" stroke="currentColor" stroke-width="3.5" stroke-linecap="round" stroke-linejoin="round"/></symbol>
+  <symbol id="hd-lock" viewBox="0 0 24 24"><rect x="4" y="10" width="16" height="11" rx="2" fill="none" stroke="currentColor" stroke-width="2"/><path d="M8 10V7a4 4 0 0 1 8 0v3" fill="none" stroke="currentColor" stroke-width="2"/></symbol>
+  <symbol id="hd-fbars" viewBox="0 0 24 24"><rect x="3" y="12" width="4" height="9" rx="1"/><rect x="10" y="6" width="4" height="15" rx="1"/><rect x="17" y="9" width="4" height="12" rx="1"/></symbol>
+  <symbol id="hd-fscan" viewBox="0 0 24 24"><circle cx="10" cy="10" r="7" fill="none" stroke="currentColor" stroke-width="2.6"/><path d="m20 20-5-5" stroke="currentColor" stroke-width="2.6" stroke-linecap="round"/></symbol>
+  <symbol id="hd-fcode" viewBox="0 0 24 24"><path d="m8 6-6 6 6 6M16 6l6 6-6 6" fill="none" stroke="currentColor" stroke-width="2.6" stroke-linecap="round" stroke-linejoin="round"/></symbol>
+  <symbol id="hd-claude" viewBox="0 0 24 24"><path d="m4.7144 15.9555 4.7174-2.6471.079-.2307-.079-.1275h-.2307l-.7893-.0486-2.6956-.0729-2.3375-.0971-2.2646-.1214-.5707-.1215-.5343-.7042.0546-.3522.4797-.3218.686.0608 1.5179.1032 2.2767.1578 1.6514.0972 2.4468.255h.3886l.0546-.1579-.1336-.0971-.1032-.0972L6.973 9.8356l-2.55-1.6879-1.3356-.9714-.7225-.4918-.3643-.4614-.1578-1.0078.6557-.7225.8803.0607.2246.0607.8925.686 1.9064 1.4754 2.4893 1.8336.3643.3035.1457-.1032.0182-.0728-.164-.2733-1.3539-2.4467-1.445-2.4893-.6435-1.032-.17-.6194c-.0607-.255-.1032-.4674-.1032-.7285L6.287.1335 6.6997 0l.9957.1336.419.3642.6192 1.4147 1.0018 2.2282 1.5543 3.0296.4553.8985.2429.8318.091.255h.1579v-.1457l.1275-1.706.2368-2.0947.2307-2.6957.0789-.7589.3764-.9107.7468-.4918.5828.2793.4797.686-.0668.4433-.2853 1.8517-.5586 2.9021-.3643 1.9429h.2125l.2429-.2429.9835-1.3053 1.6514-2.0643.7286-.8196.85-.9046.5464-.4311h1.0321l.759 1.1293-.34 1.1657-1.0625 1.3478-.8804 1.1414-1.2628 1.7-.7893 1.36.0729.1093.1882-.0183 2.8535-.607 1.5421-.2794 1.8396-.3157.8318.3886.091.3946-.3278.8075-1.967.4857-2.3072.4614-3.4364.8136-.0425.0304.0486.0607 1.5482.1457.6618.0364h1.621l3.0175.2247.7892.522.4736.6376-.079.4857-1.2142.6193-1.6393-.3886-3.825-.9107-1.3113-.3279h-.1822v.1093l1.0929 1.0686 2.0035 1.8092 2.5075 2.3314.1275.5768-.3218.4554-.34-.0486-2.2039-1.6575-.85-.7468-1.9246-1.621h-.1275v.17l.4432.6496 2.3436 3.5214.1214 1.0807-.17.3521-.6071.2125-.6679-.1214-1.3721-1.9246L14.38 17.959l-1.1414-1.9428-.1397.079-.674 7.2552-.3156.3703-.7286.2793-.6071-.4614-.3218-.7468.3218-1.4753.3886-1.9246.3157-1.53.2853-1.9004.17-.6314-.0121-.0425-.1397.0182-1.4328 1.9672-2.1796 2.9446-1.7243 1.8456-.4128.164-.7164-.3704.0667-.6618.4008-.5889 2.386-3.0357 1.4389-1.882.929-1.0868-.0062-.1579h-.0546l-6.3385 4.1164-1.1293.1457-.4857-.4554.0608-.7467.2307-.2429 1.9064-1.3114Z" fill="#fff"/></symbol>
+  <symbol id="hd-openai" viewBox="0 0 24 24"><path d="M22.2819 9.8211a5.9847 5.9847 0 0 0-.5157-4.9108 6.0462 6.0462 0 0 0-6.5098-2.9A6.0651 6.0651 0 0 0 4.9807 4.1818a5.9847 5.9847 0 0 0-3.9977 2.9 6.0462 6.0462 0 0 0 .7427 7.0966 5.98 5.98 0 0 0 .511 4.9107 6.051 6.051 0 0 0 6.5146 2.9001A5.9847 5.9847 0 0 0 13.2599 24a6.0557 6.0557 0 0 0 5.7718-4.2058 5.9894 5.9894 0 0 0 3.9977-2.9001 6.0557 6.0557 0 0 0-.7475-7.0729zm-9.022 12.6081a4.4755 4.4755 0 0 1-2.8764-1.0408l.1419-.0804 4.7783-2.7582a.7948.7948 0 0 0 .3927-.6813v-6.7369l2.02 1.1686a.071.071 0 0 1 .038.052v5.5826a4.504 4.504 0 0 1-4.4945 4.4944zm-9.6607-4.1254a4.4708 4.4708 0 0 1-.5346-3.0137l.142.0852 4.783 2.7582a.7712.7712 0 0 0 .7806 0l5.8428-3.3685v2.3324a.0804.0804 0 0 1-.0332.0615L9.74 19.9502a4.4992 4.4992 0 0 1-6.1408-1.6464zM2.3408 7.8956a4.485 4.485 0 0 1 2.3655-1.9728V11.6a.7664.7664 0 0 0 .3879.6765l5.8144 3.3543-2.0201 1.1685a.0757.0757 0 0 1-.071 0l-4.8303-2.7865A4.504 4.504 0 0 1 2.3408 7.872zm16.5963 3.8558L13.1038 8.364 15.1192 7.2a.0757.0757 0 0 1 .071 0l4.8303 2.7913a4.4944 4.4944 0 0 1-.6765 8.1042v-5.6772a.79.79 0 0 0-.407-.667zm2.0107-3.0231l-.142-.0852-4.7735-2.7818a.7759.7759 0 0 0-.7854 0L9.409 9.2297V6.8974a.0662.0662 0 0 1 .0284-.0615l4.8303-2.7866a4.4992 4.4992 0 0 1 6.6802 4.66zM8.3065 12.863l-2.02-1.1638a.0804.0804 0 0 1-.038-.0567V6.0742a4.4992 4.4992 0 0 1 7.3757-3.4537l-.142.0805L8.704 5.459a.7948.7948 0 0 0-.3927.6813zm1.0976-2.3654l2.602-1.4998 2.6069 1.4998v2.9994l-2.5974 1.4997-2.6067-1.4997Z" fill="#fff"/></symbol>
+  <symbol id="hd-x" viewBox="0 0 24 24"><path d="M14.234 10.162 22.977 0h-2.072l-7.591 8.824L7.251 0H.258l9.168 13.343L.258 24H2.33l8.016-9.318L16.749 24h6.993zm-2.837 3.299-.929-1.329L3.076 1.56h3.182l5.965 8.532.929 1.329 7.754 11.09h-3.182z" fill="#fff"/></symbol>
+</svg>
+<style>
+/* ============================ tdoc demo (hd-) ============================ */
+  .hd{--serif:"Iowan Old Style","Palatino Linotype",Palatino,Georgia,serif;--mono:ui-monospace,SFMono-Regular,Menlo,monospace;
+    display:grid;position:relative}
+  .hd input{position:absolute;opacity:0;pointer-events:none}
+  /* the published overlay forces margin:16px auto + border-radius on every doc
+     svg (to space out figures). That pushes our inline icons out of their
+     discs, so opt every demo svg back out. */
+  .hd svg{margin:0 !important;border-radius:0 !important}
+  .hd-win{grid-area:1/1;min-width:0;border-radius:14px;background:#fff;overflow:hidden;border:1px solid var(--rule);
+    box-shadow:0 1px 2px rgba(16,18,26,.04);
+    opacity:0;visibility:hidden}
+  /* auto-rotate until a tab is clicked (mirrors the original) */
+  .hd:not(:has(input:checked)) .hd-w1{animation:hcyc1 18s steps(1,end) infinite}
+  .hd:not(:has(input:checked)) .hd-w2{animation:hcyc2 18s steps(1,end) infinite}
+  .hd:not(:has(input:checked)) .hd-w3{animation:hcyc3 18s steps(1,end) infinite}
+  @keyframes hcyc1{0%{opacity:1;visibility:visible}33.33%{opacity:0;visibility:hidden}}
+  @keyframes hcyc2{0%{opacity:0;visibility:hidden}33.33%{opacity:1;visibility:visible}66.66%{opacity:0;visibility:hidden}}
+  @keyframes hcyc3{0%{opacity:0;visibility:hidden}66.66%{opacity:1;visibility:visible}}
+  /* click pins one and cancels rotation */
+  #hd1:checked~.hd-w1,#hd2:checked~.hd-w2,#hd3:checked~.hd-w3{opacity:1;visibility:visible;animation:none}
+  @supports not selector(:has(*)){.hd-w1{opacity:1;visibility:visible}}
+
+  .hd-bar{display:flex;align-items:center;gap:10px;height:46px;padding:0 14px;background:var(--wash);border-bottom:1px solid var(--rule)}
+  .hd-lights{display:flex;gap:8px;flex:none}
+  .hd-lights i{width:11px;height:11px;border-radius:50%;display:block}
+  .hd-lights i:nth-child(1){background:#ff5f57}.hd-lights i:nth-child(2){background:#febc2e}.hd-lights i:nth-child(3){background:#28c840}
+  .hd-tabs{display:flex;align-items:flex-end;gap:2px;margin-left:4px;min-width:0}
+  .hd-tab{display:flex;align-items:center;gap:7px;height:30px;padding:0 12px;border-radius:9px 9px 0 0;font-size:12.5px;color:var(--muted);
+    white-space:nowrap;position:relative;top:1px;cursor:pointer;transition:background .12s,color .12s}
+  .hd-tab:hover{background:rgba(16,18,26,.045);color:var(--body)}
+  .hd-tab .hd-fav{width:15px;height:15px;border-radius:4px;display:grid;place-items:center;flex:none}
+  .hd-tab .hd-fav svg{width:9px;height:9px;display:block}
+  .hd-tab .hd-x{opacity:0;font-size:14px;margin-left:2px}
+  .hd-tab.on{background:#fff;color:var(--ink);font-weight:600;border:1px solid var(--rule);border-bottom-color:#fff}
+  .hd-tab.on .hd-x{opacity:.4}
+  .hd-addr{flex:1;display:flex;justify-content:center}
+  .hd-omni{display:inline-flex;align-items:center;gap:7px;height:28px;padding:0 16px;max-width:340px;background:#fff;border:1px solid var(--rule);border-radius:8px;font-size:12.5px;color:var(--muted)}
+  .hd-omni svg{width:11px;height:11px;flex:none;opacity:.5;display:block}
+  .hd-omni b{color:var(--ink);font-weight:600}
+
+  .hd-canvas{display:grid;grid-template-columns:1fr 300px;min-height:434px}
+  .hd-doc{padding:32px 36px 26px;border-right:1px solid var(--rule);position:relative;overflow:hidden}
+  .hd-ey{font:700 10.5px/1 system-ui;letter-spacing:.16em;text-transform:uppercase;color:var(--accent);margin:0 0 12px}
+  .hd-doc h3{font:600 29px/1.15 var(--serif);color:var(--ink);letter-spacing:-.01em;margin:0 0 6px}
+  .hd-by{font-size:12.5px;color:var(--muted);margin:0 0 18px}
+  .hd-doc p{font-size:14.5px;line-height:1.62;color:var(--body);margin:0 0 14px}
+  .hd-lead{font-size:15.5px;color:#2b3040}
+  .hd-anchor{background:linear-gradient(transparent 62%,#fff2b8 0);box-shadow:0 0 0 1px #f2d675 inset;border-radius:2px;padding:0 1px}
+  .hd-pin{display:inline-grid;place-items:center;vertical-align:-3px;margin-left:3px;width:22px;height:22px;border-radius:50% 50% 50% 3px;
+    background:var(--accent);border:2px solid #fff;color:#fff;font:700 9px/1 system-ui}
+  .hd-tldr{display:flex;gap:11px;padding:12px 15px;background:var(--wash);border:1px solid var(--rule);border-left:3px solid var(--ink);border-radius:0 8px 8px 0;margin:4px 0 18px;font-size:13.5px}
+  .hd-tldr b.k{color:var(--ink);font-weight:700;letter-spacing:.03em;font-size:11px;flex:none;padding-top:1px}
+  .hd-tldr b{color:var(--ink)}
+  .hd-viz{border:1px solid var(--rule);border-radius:10px;padding:15px 17px 12px;background:#fff;margin:0 0 8px}
+  .hd-vt{display:flex;justify-content:space-between;align-items:baseline;margin:0 0 13px}
+  .hd-vt b{font-size:13px;color:var(--ink)}.hd-vt span{font-size:11px;color:var(--muted)}
+  .hd-bars{display:flex;align-items:flex-end;gap:16px;height:112px;padding-left:4px}
+  .hd-bars .c{flex:1;display:flex;flex-direction:column;justify-content:flex-end;align-items:center;gap:7px;height:100%}
+  .hd-bars .b{width:100%;max-width:44px;border-radius:5px 5px 0 0;background:#e3e7ef;transform-origin:bottom;animation:hgrow 1s cubic-bezier(.2,.85,.25,1) both}
+  .hd-bars .c.hot .b{background:var(--accent)}
+  .hd-bars .c:nth-child(1) .b{animation-delay:.05s}.hd-bars .c:nth-child(2) .b{animation-delay:.13s}
+  .hd-bars .c:nth-child(3) .b{animation-delay:.21s}.hd-bars .c:nth-child(4) .b{animation-delay:.29s}
+  .hd-bars .v{font:700 11px/1 var(--mono);color:var(--ink);animation:hrise .6s .35s both}
+  .hd-bars .l{font-size:10.5px;color:var(--muted)}
+  @keyframes hgrow{from{transform:scaleY(0)}}
+  @keyframes hrise{from{opacity:0;transform:translateY(6px)}}
+  .hd-scatter{width:100%;height:auto;animation:hfade .7s ease both}
+  @keyframes hfade{from{opacity:0;transform:translateY(10px)}}
+  .hd-stack{display:flex;height:34px;border-radius:7px;overflow:hidden;border:1px solid var(--rule);animation:hwipe .9s cubic-bezier(.2,.8,.2,1) both}
+  @keyframes hwipe{from{clip-path:inset(0 100% 0 0)}}
+  .hd-stack i{display:grid;place-items:center;font:600 10px/1 var(--mono);color:#fff}
+  .hd-sleg{display:flex;flex-wrap:wrap;gap:9px 15px;margin:11px 0 0;font-size:11px;color:var(--muted)}
+  .hd-sleg span{display:inline-flex;align-items:center;gap:5px}.hd-sleg em{width:9px;height:9px;border-radius:2px}
+  .hd-fade{position:absolute;left:0;right:301px;bottom:0;height:44px;background:linear-gradient(transparent,#fff);pointer-events:none}
+
+  .hd-notes{background:#fafbfc;padding:20px 18px}
+  .hd-thread{border:1px solid var(--rule);border-radius:12px;background:#fff;padding:13px 14px}
+  .hd-chip{display:inline-flex;align-items:center;gap:5px;font:700 10px/1 system-ui;letter-spacing:.04em;text-transform:uppercase;color:var(--good);background:#e8f6ee;border-radius:5px;padding:4px 7px;margin:0 0 10px}
+  .hd-chip.b{color:var(--accent);background:var(--soft)}
+  .hd-chip svg{width:11px;height:11px;display:block}
+  .hd-who{display:flex;align-items:center;gap:8px;margin:0 0 7px}
+  .hd-av{width:24px;height:24px;border-radius:50%;flex:none;display:grid;place-items:center;overflow:hidden}
+  .hd-av.ph{background:#c9d2e8;color:#4f5f88;font:700 9.5px/1 system-ui}
+  .hd-av svg{width:15px;height:15px;display:block}
+  .hd-who b{font-size:12.5px;color:var(--ink);font-weight:650}.hd-who .t{margin-left:auto;font-size:10.5px;color:var(--muted)}
+  .hd-msg{font-size:12.5px;line-height:1.5;color:var(--body);margin:0 0 9px}.hd-msg b{color:var(--ink)}
+  .hd-reply{margin-top:11px;padding-top:12px;border-top:1px solid var(--rule)}
+  .hd-r{display:inline-flex;align-items:center;gap:4px;font-size:11px;color:var(--muted);background:var(--wash);border:1px solid var(--rule);border-radius:20px;padding:2px 8px}
+  .hd-vbump{display:flex;align-items:center;gap:7px;margin:13px 2px 0;font:600 11px/1 var(--mono);color:var(--accent)}
+  .hd-vbump .dot{width:5px;height:5px;border-radius:50%;background:var(--good)}
+  .hd-vbump .f{color:var(--muted)}.hd-vbump em{color:var(--muted);font:500 11px/1 system-ui;font-style:normal}
+  .hd-cap{text-align:center;color:var(--muted);font-size:13px;margin:20px 0 0}.hd-cap b{color:var(--ink);font-weight:600}
+
+  @media (prefers-reduced-motion:reduce){
+    .hd:not(:has(input:checked)) .hd-w1{opacity:1;visibility:visible;animation:none}
+    .hd:not(:has(input:checked)) .hd-w2,.hd:not(:has(input:checked)) .hd-w3{animation:none}
+    .hd-bars .b,.hd-bars .v,.hd-scatter,.hd-stack{animation:none}
+  }
+  @media (max-width:560px){
+    .wrap{margin:20px auto;padding:0 12px}
+    .hd-win{border-radius:13px}
+    .hd-bar{height:42px;padding:0 10px;gap:6px}
+    .hd-addr{display:none}
+    .hd-tabs{gap:1px;margin-left:2px;overflow-x:auto;-ms-overflow-style:none;scrollbar-width:none}
+    .hd-tabs::-webkit-scrollbar{display:none}
+    .hd-tab{padding:0 9px;font-size:11.5px;gap:5px}.hd-tab .hd-x{display:none}
+    .hd-canvas{grid-template-columns:1fr}
+    .hd-doc{padding:22px 18px 18px;border-right:0}
+    .hd-doc h3{font-size:23px}.hd-doc p{font-size:13.5px}.hd-lead{font-size:14px}
+    .hd-fade{display:none}
+    .hd-notes{border-top:1px solid var(--rule);padding:16px 16px 18px}
+    .hd-cap{font-size:12px;margin-top:14px}
+  }
+</style>
+    <div class="hd" style="margin-top:34px">
+    <input type="radio" name="hd" id="hd1"><input type="radio" name="hd" id="hd2"><input type="radio" name="hd" id="hd3">
+
+    <!-- window 1 : GTM report -->
+    <div class="hd-win hd-w1">
+      <div class="hd-bar">
+        <div class="hd-lights"><i></i><i></i><i></i></div>
+        <div class="hd-tabs">
+          <label class="hd-tab on" for="hd1"><span class="hd-fav" style="background:#eef3ff;color:#1652f0"><svg viewBox="0 0 24 24"><use href="#hd-fbars"/></svg></span>GTM report<span class="hd-x">×</span></label>
+          <label class="hd-tab" for="hd2"><span class="hd-fav" style="background:#f3eefe;color:#7c3aed"><svg viewBox="0 0 24 24"><use href="#hd-fscan"/></svg></span>Competitor analysis</label>
+          <label class="hd-tab" for="hd3"><span class="hd-fav" style="background:#eefaf1;color:#1a7340"><svg viewBox="0 0 24 24"><use href="#hd-fcode"/></svg></span>Tech design doc</label>
+        </div>
+        <div class="hd-addr"><span class="hd-omni"><svg viewBox="0 0 24 24"><use href="#hd-lock"/></svg>tdoc.dev/d/<b>gtm-weekly</b></span></div>
+      </div>
+      <div class="hd-canvas">
+        <div class="hd-doc">
+          <p class="hd-ey">Growth · weekly</p>
+          <h3>Weekly GTM report</h3>
+          <p class="hd-by">Prepared by your agent · Aug 18 · 947 signups, up 23%</p>
+          <p class="hd-lead">Fund referral next week and cut paid social back. <span class="hd-anchor">Paid social is down but we spent more there.<span class="hd-pin">JP</span></span> Referral costs a fraction of it.</p>
+          <div class="hd-tldr"><b class="k">TL;DR</b><span>Paid social is <b>19% of signups and 62% of the spend</b>. Referral is 34% of signups on 19% of it.</span></div>
+          <div class="hd-viz"><div class="hd-vt"><b>Signups by channel</b><span>this week</span></div>
+            <div class="hd-bars">
+              <div class="c hot"><span class="v">322</span><div class="b" style="height:96%"></div><span class="l">Referral</span></div>
+              <div class="c"><span class="v">180</span><div class="b" style="height:54%"></div><span class="l">Paid social</span></div>
+              <div class="c"><span class="v">151</span><div class="b" style="height:45%"></div><span class="l">Organic</span></div>
+              <div class="c"><span class="v">94</span><div class="b" style="height:28%"></div><span class="l">Direct</span></div>
+            </div>
+          </div>
+          <p>Referral is the cheapest channel we have and it is still supply-limited: only 6% of accounts have ever sent an invite.</p>
+          <div class="hd-fade"></div>
+        </div>
+        <aside class="hd-notes"><div class="hd-thread">
+          <span class="hd-chip"><svg viewBox="0 0 24 24"><use href="#hd-ck"/></svg>fixed · v2</span>
+          <div class="hd-who"><span class="hd-av ph">JP</span><b>Jesse Pollak</b><span class="t">9:12 AM</span></div>
+          <p class="hd-msg">Paid social is down but we spent more there. Can you split it by cost per signup?</p>
+          <span class="hd-r">✅ 1</span>
+          <div class="hd-reply"><div class="hd-who"><span class="hd-av" style="background:#d97757"><svg viewBox="0 0 24 24"><use href="#hd-claude"/></svg></span><b>Claude</b><span class="t">9:14 AM</span></div>
+            <span class="hd-chip b"><svg viewBox="0 0 24 24"><use href="#hd-ck"/></svg>applied</span>
+            <p class="hd-msg">Split by cost per signup. Paid social costs <b>$63</b> against referral’s <b>$11</b>, so it is the most expensive channel now, not the second.</p>
+            <span class="hd-r">❤️ 1</span></div>
+        </div><div class="hd-vbump"><span class="dot"></span><span class="f">v1</span>→<span>v2</span><em>1 comment applied</em></div></aside>
+      </div>
+    </div>
+
+    <!-- window 2 : Competitor analysis -->
+    <div class="hd-win hd-w2">
+      <div class="hd-bar">
+        <div class="hd-lights"><i></i><i></i><i></i></div>
+        <div class="hd-tabs">
+          <label class="hd-tab" for="hd1"><span class="hd-fav" style="background:#eef3ff;color:#1652f0"><svg viewBox="0 0 24 24"><use href="#hd-fbars"/></svg></span>GTM report</label>
+          <label class="hd-tab on" for="hd2"><span class="hd-fav" style="background:#f3eefe;color:#7c3aed"><svg viewBox="0 0 24 24"><use href="#hd-fscan"/></svg></span>Competitor analysis<span class="hd-x">×</span></label>
+          <label class="hd-tab" for="hd3"><span class="hd-fav" style="background:#eefaf1;color:#1a7340"><svg viewBox="0 0 24 24"><use href="#hd-fcode"/></svg></span>Tech design doc</label>
+        </div>
+        <div class="hd-addr"><span class="hd-omni"><svg viewBox="0 0 24 24"><use href="#hd-lock"/></svg>tdoc.dev/d/<b>competitor-analysis</b></span></div>
+      </div>
+      <div class="hd-canvas">
+        <div class="hd-doc">
+          <p class="hd-ey">Market · teardown</p>
+          <h3>Competitor analysis</h3>
+          <p class="hd-by">Prepared by your agent · 42 products screened, 5 plotted</p>
+          <p class="hd-lead"><span class="hd-anchor">Everything with your context is built for one person; everything built for a team makes you paste it in.<span class="hd-pin">JP</span></span></p>
+          <div class="hd-tldr"><b class="k">TL;DR</b><span>Of 42 products, <b>none</b> sit in team-shaped and already-has-your-context. Five come close on one axis and fail the other.</span></div>
+          <div class="hd-viz"><div class="hd-vt"><b>Where they land</b><span>context × team</span></div>
+            <svg class="hd-scatter" viewBox="0 0 300 150">
+              <line x1="34" y1="8" x2="34" y2="128" stroke="#c9cedb" stroke-width="1"/><line x1="34" y1="128" x2="292" y2="128" stroke="#c9cedb" stroke-width="1"/>
+              <line x1="163" y1="8" x2="163" y2="128" stroke="#eceef4" stroke-width="1" stroke-dasharray="3 3"/><line x1="34" y1="68" x2="292" y2="68" stroke="#eceef4" stroke-width="1" stroke-dasharray="3 3"/>
+              <text x="6" y="16" font-family="system-ui" font-size="7.5" fill="#767c8b">has your</text><text x="6" y="25" font-family="system-ui" font-size="7.5" fill="#767c8b">context</text>
+              <text x="6" y="124" font-family="system-ui" font-size="7.5" fill="#767c8b">paste</text><text x="44" y="140" font-family="system-ui" font-size="7.5" fill="#767c8b">solo</text><text x="270" y="140" font-family="system-ui" font-size="7.5" fill="#767c8b">team</text>
+              <circle cx="66" cy="34" r="4.5" fill="#c3cbdb"/><circle cx="88" cy="50" r="4.5" fill="#c3cbdb"/><circle cx="54" cy="52" r="4.5" fill="#c3cbdb"/><circle cx="214" cy="104" r="4.5" fill="#c3cbdb"/><circle cx="238" cy="92" r="4.5" fill="#c3cbdb"/>
+              <g transform="translate(252 38)"><path d="M0-8 2.4-2.5 8.3-2.2 3.6 1.5 5.1 7.4 0 3.9-5.1 7.4-3.6 1.5-8.3-2.2-2.4-2.5Z" fill="#1652f0"/></g>
+              <text x="236" y="28" font-family="system-ui" font-size="8.5" font-weight="700" fill="#1652f0">tdoc</text>
+            </svg>
+          </div>
+          <p>The solo tools sit inside your editor, which is why they have your context and why nobody else can comment. The team tools own the thread and never see the repo.</p>
+          <div class="hd-fade"></div>
+        </div>
+        <aside class="hd-notes"><div class="hd-thread">
+          <span class="hd-chip"><svg viewBox="0 0 24 24"><use href="#hd-ck"/></svg>fixed · v3</span>
+          <div class="hd-who"><span class="hd-av ph">JP</span><b>Jesse Pollak</b><span class="t">10:02 AM</span></div>
+          <p class="hd-msg">Notion has an AI panel now. Does that still count as pasting?</p>
+          <span class="hd-r">✅ 1</span>
+          <div class="hd-reply"><div class="hd-who"><span class="hd-av" style="background:#0a0a0a"><svg viewBox="0 0 24 24"><use href="#hd-openai"/></svg></span><b>Codex</b><span class="t">10:05 AM</span></div>
+            <span class="hd-chip b"><svg viewBox="0 0 24 24"><use href="#hd-ck"/></svg>applied</span>
+            <p class="hd-msg">It reads the page you are on, not your repo and not your session. Outside Notion it is still paste, so it stays on the left.</p>
+            <span class="hd-r">❤️ 1</span></div>
+        </div><div class="hd-vbump"><span class="dot"></span><span class="f">v2</span>→<span>v3</span><em>1 comment applied</em></div></aside>
+      </div>
+    </div>
+
+    <!-- window 3 : Tech design doc -->
+    <div class="hd-win hd-w3">
+      <div class="hd-bar">
+        <div class="hd-lights"><i></i><i></i><i></i></div>
+        <div class="hd-tabs">
+          <label class="hd-tab" for="hd1"><span class="hd-fav" style="background:#eef3ff;color:#1652f0"><svg viewBox="0 0 24 24"><use href="#hd-fbars"/></svg></span>GTM report</label>
+          <label class="hd-tab" for="hd2"><span class="hd-fav" style="background:#f3eefe;color:#7c3aed"><svg viewBox="0 0 24 24"><use href="#hd-fscan"/></svg></span>Competitor analysis</label>
+          <label class="hd-tab on" for="hd3"><span class="hd-fav" style="background:#eefaf1;color:#1a7340"><svg viewBox="0 0 24 24"><use href="#hd-fcode"/></svg></span>Tech design doc<span class="hd-x">×</span></label>
+        </div>
+        <div class="hd-addr"><span class="hd-omni"><svg viewBox="0 0 24 24"><use href="#hd-lock"/></svg>tdoc.dev/d/<b>agent-context</b></span></div>
+      </div>
+      <div class="hd-canvas">
+        <div class="hd-doc">
+          <p class="hd-ey">Engineering · design</p>
+          <h3>How the agent gets your context</h3>
+          <p class="hd-by">Prepared by your agent · measured over 40 sessions</p>
+          <p class="hd-lead">The window is full before tdoc asks for anything. <span class="hd-anchor">Once it fills, the oldest thread silently falls out and nobody is told.<span class="hd-pin">JP</span></span></p>
+          <div class="hd-tldr"><b class="k">TL;DR</b><span>The repo is a third of the window. The doc being edited is <b>14%</b>, and free space is <b>12%</b>.</span></div>
+          <div class="hd-viz"><div class="hd-vt"><b>200k context window</b><span>this session</span></div>
+            <div class="hd-stack"><i style="flex:68;background:#1652f0">repo 68k</i><i style="flex:44;background:#4f7bf7">conn 44k</i><i style="flex:36;background:#7a9bf9">threads</i><i style="flex:28;background:#a9c0fb;color:#1a2c66">doc</i><i style="flex:24;background:#eef1f8;color:#767c8b">free</i></div>
+            <div class="hd-sleg"><span><em style="background:#1652f0"></em>repo 68k</span><span><em style="background:#4f7bf7"></em>connectors 44k</span><span><em style="background:#7a9bf9"></em>threads 36k</span><span><em style="background:#a9c0fb"></em>this doc 28k</span><span><em style="background:#eef1f8;box-shadow:0 0 0 1px var(--rule) inset"></em>free 24k</span></div>
+          </div>
+          <p>Nothing here is a new integration. Every source is already open in the session before tdoc is asked for anything.</p>
+          <div class="hd-fade"></div>
+        </div>
+        <aside class="hd-notes"><div class="hd-thread">
+          <span class="hd-chip"><svg viewBox="0 0 24 24"><use href="#hd-ck"/></svg>fixed · v5</span>
+          <div class="hd-who"><span class="hd-av ph">JP</span><b>Jesse Pollak</b><span class="t">11:20 AM</span></div>
+          <p class="hd-msg">24k free is nothing. What happens the moment it runs out?</p>
+          <span class="hd-r">✅ 1</span>
+          <div class="hd-reply"><div class="hd-who"><span class="hd-av" style="background:#0a0a0a"><svg viewBox="0 0 24 24"><use href="#hd-x"/></svg></span><b>Grok</b><span class="t">11:23 AM</span></div>
+            <span class="hd-chip b"><svg viewBox="0 0 24 24"><use href="#hd-ck"/></svg>applied</span>
+            <p class="hd-msg">The oldest thread drops silently and nobody is told. That is in the last section now, with the repo trim that buys <b>44k</b> back.</p>
+            <span class="hd-r">❤️ 1</span></div>
+        </div><div class="hd-vbump"><span class="dot"></span><span class="f">v4</span>→<span>v5</span><em>1 comment applied</em></div></aside>
+      </div>
+    </div>
+  </div>
+  <p class="hd-cap">You comment on the line. <b>Your agent rewrites the doc and replies:</b> a new version, every note answered.</p>
+
+  </section>
+
+  <!-- ══ WORKS WITH ══
+       Agents and hosts tdoc actually runs on, plus the Berkeley wordmark
+       already on the page. Not a borrowed user list from another product. -->
+  <section style="padding:40px 0">
+    <p class="trust-label">Works with</p>
+    <div class="marquee"><div class="track"><span class="tlogo"><svg aria-hidden="true"><use href="#i-openai"/></svg>OpenAI</span><span class="tlogo"><svg aria-hidden="true"><use href="#i-google"/></svg>Google</span><span class="tlogo"><svg aria-hidden="true"><use href="#i-claude"/></svg>Claude</span><span class="tlogo"><svg aria-hidden="true"><use href="#i-cloudflare"/></svg>Cloudflare</span><span class="tlogo"><svg aria-hidden="true"><use href="#i-cursor"/></svg>Cursor</span><span class="tlogo tlogo-img"><img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAPAAAABMCAYAAABTXTqcAAAmfklEQVR42u1dd5hU1dn/3Tuzhd2lihQBlaZSVFQUYzQSIwgq1hgTY9cv5lPzWaJ8xsT4WaIpSozGRGPXoElsGGzEihGNgg1RqQIqvS99d2bu98f5nWdeXs+9c2d2tsDOfZ77zM7OLae87bzldzw0/5HgZwZAgNIhD0982jPDs7X1OwCQLpGEe6CSALoAKOf3tGCmQDGXD6ASQBueFfyeBFDGT4/X2dM+JwVgM4B1AJYBWMzvUATamufDF9+DkPHoAqAvgKUA5gsC354PX/QjCOlPDYABpLFpAOpLDGyOQwHcK5goTcKp55kWBJUEUMXBrBbM7Ofx3g0AvgTwKYB3ALwOYKpqU0kbm6OSDNsLQD8AQwAcwM8/AbiKVkx6B+x3RwA9AOwGYDD7/U0A6wF8B8A80l2rFfpJfq4F8DmA7tTCHrVpX2rYOMcSaoMVADYBqOMzugDoQwIsI2NaSToAwMm89y0A9wD4F6/xWhETWyLcB8BpJN5qAB0AdOK8dCZBJx3Ljx3hOAbAGNJbe/Z7J54dqCTssZljVDoUEVVz8Oy5L4BnKd1T6pT/u43aoR0FQJkwqasB9AZwOoAXyNgBP1PCPA+omf9CqYs8tfqOIEjPBrCRY5tW5mQg1oF2/K/fQRjZA3BLjn5nSDNpWm67tjIaKfgYTA3pIqQAwAJq6jhHOYDzAHwhnpERn/bZbwHYW5nUrWEpUwNgGIDRAI4D8D0AjwrCzag5+MUOpIk7AxgJ4Hie5wF4SdFHiv1+m5ZdiYEdhOQ5vIBPKmeWZODPAOzO6xIxngkAhwD4xPFM+dz3AexRmiR0AjA9ZKzG7oCmtDz2h3HUScsjADCJFmJrEfCRZjOU11N6AO3fMyIcS766FhHP9GguvkUJu8Cx1vU5UfsB+BW1UtCKJkp675MAVgP4KOTa+h3I4ScjF2UUSovoqNL0taHkgY6n2SzTLC6StLOSNAngPzQBt4S0KwXgRJpTrckjnRGnFVxLQ8Z/R/I8B6Lfdo2/lT4BLaTqSjHh/EzTtUWeqBSJ8TEAfw/Rwj6l8FkwYavWGlYKANQ2cP6218OazWGKpcTAMa/b0oja5g6aiZqJ7SQdDGBQK504Ox6pHL/vyNZIqsSmDWfg+kZYh1ri+xDARDFhkoEDAG2R9Ui31qM+gsBLR4mBYzNbY7w/jWys2Xe8KwDQs5XPU9BKNTBK/S4OAzf28SFMJpgr+8pDNmRQOkpHiYFbEAPbiVgGYE6EWViHUnw+H9O6dJQYuEmPjTAxv7BjWYmBS2vg0tEyGdiWEG52EKsH44WcWWLg0Jh6azWhS2Y0tq1saW4zOqm+28/PAXxcmirnkSqtgUsauCUc5TA5v9o89AA8h2wmWGniShq4RActkIHbIVtCaJk3AVMF9XAry4XOZ55KSQ4lE7rZ13YBmbe/Wu9lANwKk8hfDNQFbzuW5GFtr2/BbQwaOUMraKW00KIYOBDpkl2pUWyb7oGBjClGeWSU08PP06PrxbQGghyE4Sn4oKAAgks1krUV10nk52CoOOPfVCa0xFyLooU4bfWL7HyLS1Nfe1aymc3CgGvfMzmwtj0PALgCxjNdKNBdQoHzeTBwLeUC72ureHZcRm4oMSbwdaBArwBcq3w1cKYRTPqMUgaVIrtuixr/RBGRR/OZA0+0SbalAqZsMQ2TZ1An+pOIABRsjPBdwTSVLDKioBfTlJKa52IA3+D/NgAYB+A3MLhahZjOEpgvCYMo8i0Y4L7+MBA/G2FqkWfCoDtM5Xo7itCsJukKA2CQEZBC9fxMwGSNdYPBcpoM40XXhASB+7QVxkmXzrO/mRgMbNts8c3awyCCbuD7yjlGSRK0JerPkS1hDBOM4FgMAzAcpvi+K7Jx+7kAPoCp/f4E2WScpgSh80RVUw1MjflwWny7weBsrRSRjrfZ5rWOvsqjKwyCSEaUPabFPUmOrT0h0GtWOuanA+fHltHWKXihCvqJ2rPN9QCmAFgTdwBGRyBnzBQOKC8HU/nK/PgRiSngAJ7cwJIxec8wGKTNlXz+LJiiiWdhwPcCocWmArgaBrsLIfFo2+5xvG8LhcxKAAthMskWAFglkCOucDxrL75rEgy20zQAfwAw1PFui7RxjQPSaBOAw3OMlW3zbnxPwPYt4njMADCb47GYfamFAZdzPdcXwucimJpui2U2GcDTJKyUaOcSAH8FcLToT9w69GoA/xTzZItq7hPKx4uBLX0CgGfE/e8BmAAD2bNKYbK9BOC/RFTEU23uQ0Zfz77N5Th+AJMS/DFpYSF/ryWDp2BKZ9s6aOpixVcbBZjBXBgE17VqXL+dD0O4GNh+X80BqqGUaMuzitLHNVltYIr5N1IjjBO4Wn4DmbcCwJUcAMu4P6BWtJKxD6/5SvVpBoALhNT0HM8/B8BTAJ6gQJgVATx3kbi/LRl6Tgho21cAfqwIzxL8Lx3Xb4CBJopDxNUw4AiXAricAuGVkHZM4DyGPesgAC+K6++EqRarYns7wEC+Pqueuw7AI7SIkEe7XQx8j6ArL0JwdWf71vO+l9m2jrymDQwS6G2kRUnbr1HoaATQnvTNTKDwC3KcCyjYnoSBAK5y9PNAWp238nxYCRZ7LoMBfbzAEXbNm4HluZqEPJPnpzA4TlM5EE9Tav4WwE8B/I3PmwvgSPG+sgIdBJ7Aj7pPWAdvAxgYcd+hlMaBII56AOMRjnroCXOzEsDOMMAEEi3Svv9U3jMUJp4t37GVppIkzK0Avutg4GsdY15LK6NQa2V/GHDBNH0N1gray9Fv+/zjSZC2rZdH4HG1A3CTQB+17f4cwA9zMHEuBr47goFtewYoIfVwBNEnAJxBK0SC59UCuFEwnXxnOZXOZLGckUuqNDXoUEEv+SxJr1bIrxsBfD9f/ojLwJthwj2v8nyLTLxMwMi6zhU0c8dwTdEQvONqSnj77C+oLSTChzTlbd8GAnhXMbFFxhycoz32GWeKeyUczo0A/ltYA2EwsRkxTveKSbLvvc5h+awlE8ZlYF9gkvmU+svE85bBoELq/tq2jAGwXLTh98q8DFsm/UwwcUqY//8r2uLlycB/VpaKbms/Yd4HAN6gBQb1Tr0TxjECgVXSwnj6NFxjPYLMJefd9vO5mIzrsvROUUvVewrxWucyoTOUxJfQhPaEJu0IYE+aIddyzbfOsYa2z3odBhe5fZ6NtJrqZvGsNLVDLuK2v+1HayAQWtQiY+4ZMsie2EbmeGGCyXGSwusDAI+T+G6n1pbmd0pBxUpGut7BwKto/uWjgaVWv0w8q1ZoRd+x7hsi/AYZrvVyYXfLdfytYl5SgkHGOhg+DgPf6WBg+9lBmO8Zms8jYghi24ZTOR4a7vhxB21aa+wxNYf281VaIl4emtM+90wx50s5ByimBpa40LuLAQojprY0lx+iBA6EuZkR31/k++I4s+yEnEgGSgnG6x5DCEiCPpXryoyYvAAGjH6nHObaGOGM0+M0BwbXa1fl9fcpHG6hQyxDAXeY+N0+/0YHA69A/lBDvjAvZ4m19AUhZrOtxX5OEGaGVkWc90qmmuSY8/VimeHlwcB/DHFWyeVGSmjPRMy22vG+KYTWx4UIuONJ05rpl3Cs8xWy0lka0MmZKGSpFIeBZ3Et4ImXSPMkoSRfBQl+mgOJMCMcHr8TjJOIMAm70tyVZs/VMaWep9z+41XfLBHclEOAHKsY2PZjOZ0mLthYSQSXCJOrxkFQv3Iw8LIQ6yAX83YRDLkewIUhgs6++8citGFxwPvkMb5WaI0UjhnpJ5jn6EcuBv5DiDm5P8dcWoej8xA2lla7cUkYKIG+metQOz62/x3p65E0Y/v3kwL4ra2g6WUMsxa0tIzDwLM5obnUu68a0ItudUmUGeXweEGkWPohBHaRum+pcO4kHGaSZdiE45kjaT6l1cZu0gzzHG0Yzfs0A98fsgb3FIN6AM4XzK7XwDc5GHiJI/00l6XSEWanh4Aho7MjwkUezeSpwmklzVfXBgB6fPUxQaz364VQ+BuXXXE18LiQjQPuU7T5HpWAFxIWlG3VY3CFivXbtn6qaNL28yeKju3f/xaho7h+isPoGLbOt0SYNek3McJgWgzel4wDPyayrTyRBRMAGEXHVD8H4F2aBHmy+A56wecIBk2qPYiltzhDi2AXel8HiHFJCodHmuvkfD2+7+LrW7RqIegJ59UrIZk+fgjkajqPjLQuAO5iSG0hw2EPRvQnoEDZj+0pJwO9w/aUC43lKf9DSrStA+PrBwk/idw7q54WXNc8xjftyOgbTHqR4/cWrTnNrK62BhQYPbg06SnGLyEETDtkdwyRbX1GhJV02O3ImPxm+zKctL0RwD/YvoQrKSrZjMXYHgf3UjLQ4RxUX2VqDWOc7ocCH9kSzBAOUCCY9H1KLxfweQeaRz1pNexJadqba1Qb/1zOtf1njA1/yOfmm0ZXm0derxcjcw0x9g52gQb2ZuxyFLXSxfTSut7pCYY9iuNax+/LKJRcwqOcIbUe9In059kXJpGkF7I7C35Jp+EnDDe+JzLh4lSeZRzm8wjOrbx/Ski+eELs+tiL7dyDimJ30kIF+7iYoa9PGWZ7n22W9OUz6vEsw6SBGpfT+Vsqh7WbphA5nM/4D527XpiwTjZzIYNPZvk5THLEzmoCLDEdDbMVyziFXHkIO5wSDNwXwEmM3bWjCdWDTNuTmmgnkaxRywl6ngQ1m+uyRWI91RRJ90GeyfOZiLZJjTiEcdODaI7+lMyTK/e6J0zKoTTBK7hcGERh2J5M0JNj3J1z2F4Q+CKO6VMUiPMoHJfSb1CoNSeJvhxm32BfpKSCobI6kWTUTdDCLmxrZ0FvK9i+Nym459D7voTr96i587gkPJfaUwrm4Rz/KRHjniAdD4HZFdSj53tDVPppS6hGStDUeYTElQmJC55PIliA7AbQ+4vBs/ccR5MlI0I5m2HipsupTedyYhbAZECtphcxHbF+zKDpS86CAhhYTvZIat6+DF1dy3GIUzixBzVnIN6/M0wyzhZk4Y62kMhWkeg/F0z6BRl1PdfQYftAxQUn8BSYn80d7iESUCQtXCo87LZoYRPneyFMfNi2dyG1ba2IkricXIGDFuzf78GkYn5PKaBOXLpMidj72s7ZYVQws6m1I/fJbinlhNaR8QNKxozKeglo5oyESSUDpXx/VbJm1yJ/J6Gu4bmWRLQ5z7K75ka98CJMaBcDJ8S6+iwyW1uYtNHfC+2UjjEne4rCDvv+RVzOzBRMu1YUSGTyKMUMCiiJ1GtgTzhEu+LrSKZ30ztcy3au5t/rYyCdaqdREMMEzjCScZKDt46m5fKJQ4Dae9tTW3swqbqLsJ1gYnlcX7xHBnatDZJ0p9tUyU5q0jxOzm0w6W2FFnVnWiB0TCJGCZovqm6u5NmGVs04RShxjl0da9I3YOLWhY5tseqCtQDqJvwX9vlz6L1f2sD25nu8Qc/9wcJ6CeiHOFZsq+ta8gygz2cDrU3k0sB+C9n/xqeJNVV54/TRX8SG23P9C4WTnBJe5LASR4SkNWI7g5UNFILJ7jApd7/kEiOj4sr51NC6kle2tJCxTTn2UC5T79osIhGJJmivnYu1tCY9h3l8In0wGYelZ83nDvTHzIjjR2lpu9vNClkr2WMndtA6VJIOE7IyJGSDHRAXWhLfUVwzfV/034dJKT2W3/OxuCod/6tQpntzja2ugy5zCLRy4Q9oKlqw736e62pf1XkfIDLtAiVYa0Qu+pPkg5z82dIYeHnIToieKEOsjHAqVQhTakcCwUtErLk6Avg1PZZVXPP7al11Cz2bqTyyedIODdE+LB7ZxIIsFQMho60q3WvKJc9c+mK0iZyEKVIoc4TuBpC536cZju0JlTIQOzSkY2qirQ5HRKVYu2EHR6XsAFP48CZMXPd2mLDadQoeJkOH1B9gwjzpGMLNVgzpozvN1aCF4WFvcTieuvBsjqgKYEpoVwqB54vIwGAHXtgIKqAJXLf7ccbZb2EmYjKkTbYjm4QnuVbs3i4zuQZFBb53ABPaE1hiP4GJXR5LZl4K43l9SKVpBjDJAbfSVIuTLLHa8f4eArXEbyZnJ8QyyxMb0Ncpf0A1sqGlpnRM2vXtNJg0St32jjBeap3scSytp+fy8Vm0NBNaJli4jhWCsFYLD6Nc2xxATREUWFfckjWwXDfVA7gBJu79unDWbKET600hxa1A+z6yhR65hMUXDgbaGdnkjuZcomjLa6nKerPjNFwJsqYUNFu4rKlTaJcB52wncc++MIX/r8BkecWOFrQ0Dbx7iPMEIs/ZMvA6ZHc0lCbKPoiJF7SdroEDEZP9Ewk3KXJ7fRL0WF7jK2F2JUyFUS4BN0sQn9QsY2i+p5uJfmQ81o7Fl9g2FdO260hEI7I0phb2YEoopztiywNh4sKBqCf3YfIXUnHN52IxsIfibG7mwaSR+crkCESa2VvCGSDDThqJ0oKSZXYQZ5YXsQ7UywXLaG/DYF/VO2L/19NkS4uQkD5mK/A/Oy+HCa+218zjYdvwFUyussai7iJwxvxmMPdXw3iUdZuTMJVgZXS0ncD2v5QvjHIxOlWhSsEKMQ8zMNk0BztiX/bvTwH8S907hYPki+1Y7Hrvwh1oSxY/BxGHaYCHANyhhGQGJv/3NphKo1TIGC2B8YbqeytgYHL6NJMWlmWYgcgWey2kPWdQw6WbeEll5+UpZPf2kr8dDgOMcBb9Nn+nVVnUXSLioFKuQhabyS/g+faeC6gtMupd9u/LVP4saG4/oYr5JUzM6Q1Ev891X6564B800Eqx/XzY8ey5yOI8RQHDtYdBz5R1svZzMv0FYdhSYwTeU1qN77PYtgTQa+DuGbkgderEu891FNX3EuV8GfU5D9kacb/IbY1zz10OGCkLXGFz9PdsTFMlioG3ADiiQAZOiMF/z9FJ+/dEbIu5Je89RmEYyTaugfHU+iGIGF4eGNbNycCPFMDAGuRtqkKMkBjL5SEYyNUw4ZBAAS2kBODCXg6B7EcwpudAJYmLSmnn90LVTvt5VQQNzSatIE9a8GPSQlQ/jnAA38nzgcayZDyRiO1iYDs4pxUgnRIii+Zuh4awRDItAljODuydDiJLi4l/BMY7nYyAUUmEIDN4MHG73hF9ODqEgX/YQO1kJ/WxEAbuHkNAJEVp3dwQDfVzh3ayffuGQGpMh0AqnR8C2eqrsfVDIg9DVfTBtqFGWA/1Yn7Hhqxrd6LZH0YLa2Hyo3vHbKvnyDPYH8Ybnw8mWA2FnWyX3NXh2GJ5yiVGVFIgJ4wKkRy2MdfEALVzQetUwWQRhUHqTIYBDc9lJnZHFgM45bASLAjcPTD5qH1gsrrCjhpqrRNhqkvmY1ssJHvarUnCGPhcgQuVFIgQyYj1mEQRsagXLgaeJ8Dq9fPDdlQYQyLW47NRAdsl1DydT0vLhSZq/54Ck7Z5oKqxdQm9bjRpx8IUsTxDz7amu2qYxAYNqXOrQvaQ+QNDhfOtPqStttDhSJjYdlTosiMF+FkwwPAfURnExajyxRimHHhrr4n0YK+heyOFlc/VhKAl2L9HMaSxKo9qn4E0ec5QKB0JmGqMB2GgYhdHBLXtPUtIgPfB7IMEhye7MwfxXJpTs2BinSuRRRSs5rpuN5qG/Rii+LnwJsrxSQuPsGtnu2+yH6k8QxAZ9fyko0+d2M6leYQ1JsIgXP5WjWEVzM4ASc6jhi+6DyY10YKcS+QUCa5wCAXlZ2K7lnVcv9o0114w9cn78lmPwGSPrYUb67uj4//DSPRrHAJ9Ggz4wz0U1BlHGWM/OuIuQRaCyW5fYosgaqgY+tDJ1A0GTugSLveQZw3zy3zXIJUN9yTfW9CeUZ7K+hjIMEG1wD1qTwbdJweBTOKgTeGiPMxjvTe9gqciCw4GkWn1Agw+1Et5bPhlr+lBYjhbeSrlGReecz1N+zthitPtGPWi5K4SZtUotcMERMLBC5Ta6wRqv8UEe5l9lrmyR8CE08rE3smnqsC/PT7iOK0TY7SKDqZFDsFndxS4lw6+jBg7WxH2GM8v+dwl4v5TYZJH+jmKKTJ5lqhOgUEenShQV/YVgqGMXvJRjiiHdaJ9LOBpJ8PA/Vhv+f4UVN+JqDqK29aFMPXUDwpPcSFLod/RSrHb6M6m+TyngN0pnZ7gByJ2ENgqNvTaLDZs0tctpDn7EE2dm2DqUR+FSdTeqDYWW82B/w01VkWBYS5frKlPJYFsdbQvI8yxlOM3O1lD1LMtEZ1FC2Erx8IWts+DqfX8CCZ4P5PPWiPSPjfznjpev4+qprGbkKVEGzO8bx2ftZrnGrGLXZ3Y/WCzwG1OhAjsngIGNWyu11CbXqJopD9M3vXSkHtTAnVSL7s2kjZOF2YjaPW8q/qdEht9rRV9XyccQtK0/qtIApIonFfQ2goDFaxXDjIJyj+dmnq3Bu4akhDOrNXiHb9z7BRSkAa2UngkTFlaPQlhA4mvVsCipMXGUG1pyu0ksJG6c3KqlOlnJ2M1tcNcEvl0DvCGAjZaDsOCAts2gp7HoWxXOyUgLFEth4kzvwqTizrbod3tZzdK90q22SJ+bBTj46ktO6toklXRumnDe6YozCOrdXYRSfp1onBD7ylcJrawLBNbT74fooFlf/rQUukohPFW3tOW7fboBX5BbZANrgvHkCj7kw6qldCtI8MtIIM+D5P2uclBf/uz34GAnK0XQiojtGYl+1olBO8sni5a2IUa/igKzZ3Zx6RKjNlAi+MDWpSTYID80MCtUX2xVPknx2wpTErl1IZq32If1STWag60J7TEBp6bYmTYNNQZFygJ3xemUqkbBzJF4lpMhp3jWPtt73XEjRWZ0In4fenZ7UGBUMY5luieqxthnvPJ2IKwcvqQFjqTRutoRX1BIfBlkdsqBdXTFHx/pQAtKgqM7wirJFQsTJ9Rbvc4KPheI2cw+Xm2yYu55AgDaw87XWMX5/lR7/Ejrs1nDqJOP0ZGVDHmIld/cvXbK8Lchu2e0dAjKXaOWErL6qiWWFCUi7D8BsZFGyqYdCgnGbFDXunIz4eSDDkTLWhsPQct6LYWmxZcm8O/mCN0VTpKR+lAy8pjtwkxKWwLO1s6SkfpaMHWiQfjcPuHSE5q3xIY2CvSdV4ev7nWgVG/F5KYHuedXpEdhLmeW8j74z67MeYwTnvz7XNjlbI2BY+cw3VvCiaZqKR9GzBJ3naANum18Gc3V7u87ZDu+iO7F/M0mJBW0fxAcTJR2nFxL7N9EjQDtiKLS1XF/69HNtSQgIkJb4UJH3nCfFhL06Kav21xQIW2F7/Z8IRGS6ylZKuACV/JAP9Gx1YWdhe6brx2EbIQLbZf9exHOa8NHLA2daJddQrSxRMIjqsjQhAB39Gd7V+F7B66ts1lYsxkDHhLxN5Csr+dYOKem2FCZqmQ66sFsGCg5qGdSEKBI8G/hv2vIx20Ve/xRB6BRLjswuuWql0zyvgMmRyi57Kc716v0kzbi1I9T6CH1Dr6XCNyAYJGYN4yGHijPUhrj3AO/MbG6ZIplvfAZM9IhL9+MMkCNyKbNPEoTCLEIHFdX5jMpOsEk0/keqASwKEwCRTXOKphzoFJ9BhGQfM4TH7t5yLPdipM+h1gUA1m8J75MFlRdyBbeSLztqfAJGCshEGuOAnZ/YDehCl2B0wxwzy+cwZM6t5sEpwFiHuEz+st3nEoTDLAzTnGdzhMksQqEtw8TngHcc1+bKPdb2g+THLBXTme3Ynj/rno6ySYGKQW3EfBJFpMQHYXwTIBNv4BshtV6+1ezuaYW7zjc2GSdObAZKItgEHMOFsIiks47+so4P7NsbZC8lukr5ls/0yYvZYHizZfz/k/RuUgPAcDrF5F4foK700op9Kx7PPTeVQXIc/MqwsotDLsT88GZHPlrYE9sUfOAOX2riRhfYJsjvMBZIDLYDbd3soB3YcEYAdvEKVmJUyAvyNMpc/dyOZQVwI4k/fPZzvtjnjjKa3bkPDXCIIdRGZ6i225GCZgfxql7ACYdNEMTBqbD5Ot1V8QwD4i6WCxKAM7hsT9BH+fTg34Bkxq4OkwecLlMPWqg0moWiNa6XsI+9KGQnIZTLbQdTCJJ5dRo1XD5I8v4rtt1tW0HHW042DSPicKx8kpMGmWLwkkDo9MdyDvfRQmkUGiKO7r2PIGohJsT4HH3YWC+1kKvTbssy1lvALA/5H5fsW2ngcDWnAGhUhH0teHfE5P9mUvmOyllTCprkNhUh3/wzmxdLJWhIr2FglFcuvUs9nnA2DSficU0euchon5Xs13ZTiuXzUk6woFOj5eIfH0EL8PIoPaHeg7U9MGZK6TRLpdPUzyPKixZnLybHL+XSTU47AtSt8WGCxjq+E/oyYKA707kwP1IyHlJnIyLRrDeWzj1eK+KmQLE/YhcTzueP54at7+apyqaHksIpMM4xj8OWJcy0WR/nexLdbzZI7tYUKbr4OpEoor+Y8jg45X49VLFCJYBh1ATfkU+zBeJXAcy7m4IUQDX8lxH83vY9V3qK1xlpOxpUAYzjF7le21ABK/FNfcSzo5GlmoGl3P3I6a/13SWmcyzesK+8sKxCf5+UgRmdduSzNJLAE+pqArOjaX3wAYEf1/u4bbBINR3EGgGnoh93mUfGXYtmpkFIn8X4owk4LZPMenHKC02J4iISp1QCbr5sCa1u2T2WZl/Ltafd8EU/zQiSbTefzf7Y4xtpq4KzXwe9TwPgl3LQw2Urkoi/REbnXUjoUyT3k423gvma+M3+3G2rJdR5PYb6HlMprCOhMTSiYsGlDuyII6hEz1OK2bCv42mUy2Hy2mzQ5i36rGwQIbfgGzjegQjnsigt4gEFTawFQrTSO99SiSGW2tjJFC0z4AEwP2ir329YsI4FVBk/oWTsSPY+ypG1Abf8YOd2ebTqbUmopt0ff3hMkhnUAJ9z+O5x9Bk/lmao8plPgeJfwTAkt5LM29KCeT3g82EMn1ttb0ebbpGhgUjj+yT2HwoB3Y19kUcoEoM5zH5++qEu1HU+v8k2blsJD2lvHeraKgISWKUOS2K0muiefB1LpOpvl6RBHA3K6mhnuRVla5wNCay3bUCyKfRQtmJ/G/g7k0seP6oVg6JLh8upkW2tXUwPU5NoMr53r7UwG+3plLqYbCH2VgkjQuEY7PGTSfGyW33i8yjKaV+q+ROQ4TkhMROwA8w/XNYH4O4TptuWIk6yXuKCqe9HEMTN3mVRQAFwsPZC215M840b/huw/NY5vJwNHvNM39CjLN/SHXuxLk5fMzgngTDm9vB56dhJPJi7GvLdR+UlawDOVyZTzf+yy19ClF2Hq2hvPUiXOWVFZI4NiLyVNAAYfTP3A9Ne0FAuHRKo0X6Kw8BaaMtD6HpXAgTN37o3zn0/Q/nNCAfZ8s8+4LgzDTRtDGPar0sqhHMo8NuF0QrYFDC6/gemkCpWJZDrMhoKk8lmbjJg7sJDW51ul1Mk3hpHDEyHbcxuc9yGtWqXav5iA/zPXytTB76L5ZoASWG1qt5HpyUY4KlnUcp92pEeTG27349xI1TxNgkgDKhcZ2vaOeBFlBbebaVNseIygQRsBU6dTwPIRr448jhIOXQzhdS4uhUvhGVvLvXYVAtm3andesoSPM49r0IVo0bSjQPVWQn+YSZgw1dTW1qxcSWhtNTX00/QG2zwfR8flZnmEe65TqSiHeW0DYfsiIC5paAwdq35l2lKZ24LqRMdcoCZTiYEymV7mfGOSojZM/plf3JErR6fQswkGctaJeuV4JmQwl9WSGeQ6m1A5E3K9ceJjvICP1UhoqKGDD50SMKp1AYC6/Q22wv2DIBAxaSaD21bFjm6FFs9VBYJIhLOTLSWoJUEErJ805HUmNu4FLiY50RrblulDWstY7APEQssTIiIL+LcjuZTSVwmsMGc0CKgxiWz5k1MFuY7qYS6Bfc/l0uXpPPa2wxTSldxZmtJ63lOjzQtHnDjSluwo/TNyKNE8w7x20GCRN3p/PRmWNlcgxkWuGWykJa2iCblJA6+UCBiZDafRtmmkJdV25IvyVNN9+IWJ864V0s4KmN03iDSKp4yWun2xVkQUS+BvX4RfRTJpNp8VAEVA/hZN+vxiPshCgels87zUA5N4yWR0MztQoWgI3kKlPIwM/RiGkn+upPW/DBMQL9Nhfwfe9TDP2bI7h4VyqHMpw1e1iXbwbnVnf45zbvh9Gi6VcOMSeEuOeUBvUJUV7rXk8gw6dy6hZ76eVMJYM/RcK5koBGpEkbbxOC+QxCoIKEaLxON9HwUD5litnmt0zejgF5uWkZU9sjP4Bzej7hBMtl28EMEUKN9BvkBIe/I9oNTV79lgl43VLGEvdABOcv0SBh1vEBYn2eAIZ5RYRn3yL5nFHlTDwLZqhC2jOSAuhHZ0hy6kxV9EUXiLCT6dR2p0j3n8u77Hx2EvJyBtEwfmddGKAzP2ZCHvJwb+bTrqBDo1rQ2nT6WEtz4Gk6Yk2f0JhtZF9e1CFWCwc7K0x/Ra+SAB5nlbSRr7jM45BkqGX+Q5cMtvXBbSgvsXrVohMsbXCNLyQJrvVXhfx++iQcerAZc5StmsjnWgXi2tHcG6vEm06nvfcJMzrmWQ+iPDQfJhkjhoKh4/EXr03MMzkgpX9CxXB3jmSLWzo0K53VzigeOZS6TV6vW8+0mEQO17HQZivtKiN+c5UKZdDyGzz+X2ggECRa9gKagUrqVOKKAeoFD0r2efQrN4ZBmlhvkoI2Zdm2yyxX87eFCYLOcEQG4gP4PPmKilsza1PVdhJWjOD+dtsRwpn2NGV97VhzPIjdW8Nx2WVGvM4RxuY2HYXCqzpJDjQJC1nf/Sewd2oie0c7aVCIEk+x0Lb9haZVd3JVDMdqJHyGMj76ilYvlRe+v5k4q+EoB9Ck3wG56Md/5a7FQ4gbcxkm/fmnMxin8t4T+BISLF9XhMCCGgtqF/AJKPYYwaXLXNJU+8oWKYWUVEUhq2E7aw2M9NIMD4trT1hwiPRzHsnh/WvGPTUFDBIPpeF/bi2r6UgW6jGtUkgmfLdScFzYBfL34MY/w+7TidhhGW5wAFpG4SsDz3hQMg4oF2CGNfr90fFthMFYBxFtSdXm5CHs0XPmx+xEbqvNK4fgfGtxz3XOj1Xu8L6rP8X1v4oeovb56ABOdBeCH80yvH/Uqedlhyl4BoAAAAASUVORK5CYII=" alt="UC Berkeley"></span><span class="tlogo"><svg aria-hidden="true"><use href="#i-openai"/></svg>OpenAI</span><span class="tlogo"><svg aria-hidden="true"><use href="#i-google"/></svg>Google</span><span class="tlogo"><svg aria-hidden="true"><use href="#i-claude"/></svg>Claude</span><span class="tlogo"><svg aria-hidden="true"><use href="#i-cloudflare"/></svg>Cloudflare</span><span class="tlogo"><svg aria-hidden="true"><use href="#i-cursor"/></svg>Cursor</span><span class="tlogo tlogo-img"><img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAPAAAABMCAYAAABTXTqcAAAmfklEQVR42u1dd5hU1dn/3Tuzhd2lihQBlaZSVFQUYzQSIwgq1hgTY9cv5lPzWaJ8xsT4WaIpSozGRGPXoElsGGzEihGNgg1RqQIqvS99d2bu98f5nWdeXs+9c2d2tsDOfZ77zM7OLae87bzldzw0/5HgZwZAgNIhD0982jPDs7X1OwCQLpGEe6CSALoAKOf3tGCmQDGXD6ASQBueFfyeBFDGT4/X2dM+JwVgM4B1AJYBWMzvUATamufDF9+DkPHoAqAvgKUA5gsC354PX/QjCOlPDYABpLFpAOpLDGyOQwHcK5goTcKp55kWBJUEUMXBrBbM7Ofx3g0AvgTwKYB3ALwOYKpqU0kbm6OSDNsLQD8AQwAcwM8/AbiKVkx6B+x3RwA9AOwGYDD7/U0A6wF8B8A80l2rFfpJfq4F8DmA7tTCHrVpX2rYOMcSaoMVADYBqOMzugDoQwIsI2NaSToAwMm89y0A9wD4F6/xWhETWyLcB8BpJN5qAB0AdOK8dCZBJx3Ljx3hOAbAGNJbe/Z7J54dqCTssZljVDoUEVVz8Oy5L4BnKd1T6pT/u43aoR0FQJkwqasB9AZwOoAXyNgBP1PCPA+omf9CqYs8tfqOIEjPBrCRY5tW5mQg1oF2/K/fQRjZA3BLjn5nSDNpWm67tjIaKfgYTA3pIqQAwAJq6jhHOYDzAHwhnpERn/bZbwHYW5nUrWEpUwNgGIDRAI4D8D0AjwrCzag5+MUOpIk7AxgJ4Hie5wF4SdFHiv1+m5ZdiYEdhOQ5vIBPKmeWZODPAOzO6xIxngkAhwD4xPFM+dz3AexRmiR0AjA9ZKzG7oCmtDz2h3HUScsjADCJFmJrEfCRZjOU11N6AO3fMyIcS766FhHP9GguvkUJu8Cx1vU5UfsB+BW1UtCKJkp675MAVgP4KOTa+h3I4ScjF2UUSovoqNL0taHkgY6n2SzTLC6StLOSNAngPzQBt4S0KwXgRJpTrckjnRGnFVxLQ8Z/R/I8B6Lfdo2/lT4BLaTqSjHh/EzTtUWeqBSJ8TEAfw/Rwj6l8FkwYavWGlYKANQ2cP6218OazWGKpcTAMa/b0oja5g6aiZqJ7SQdDGBQK504Ox6pHL/vyNZIqsSmDWfg+kZYh1ri+xDARDFhkoEDAG2R9Ui31qM+gsBLR4mBYzNbY7w/jWys2Xe8KwDQs5XPU9BKNTBK/S4OAzf28SFMJpgr+8pDNmRQOkpHiYFbEAPbiVgGYE6EWViHUnw+H9O6dJQYuEmPjTAxv7BjWYmBS2vg0tEyGdiWEG52EKsH44WcWWLg0Jh6azWhS2Y0tq1saW4zOqm+28/PAXxcmirnkSqtgUsauCUc5TA5v9o89AA8h2wmWGniShq4RActkIHbIVtCaJk3AVMF9XAry4XOZ55KSQ4lE7rZ13YBmbe/Wu9lANwKk8hfDNQFbzuW5GFtr2/BbQwaOUMraKW00KIYOBDpkl2pUWyb7oGBjClGeWSU08PP06PrxbQGghyE4Sn4oKAAgks1krUV10nk52CoOOPfVCa0xFyLooU4bfWL7HyLS1Nfe1aymc3CgGvfMzmwtj0PALgCxjNdKNBdQoHzeTBwLeUC72ureHZcRm4oMSbwdaBArwBcq3w1cKYRTPqMUgaVIrtuixr/RBGRR/OZA0+0SbalAqZsMQ2TZ1An+pOIABRsjPBdwTSVLDKioBfTlJKa52IA3+D/NgAYB+A3MLhahZjOEpgvCYMo8i0Y4L7+MBA/G2FqkWfCoDtM5Xo7itCsJukKA2CQEZBC9fxMwGSNdYPBcpoM40XXhASB+7QVxkmXzrO/mRgMbNts8c3awyCCbuD7yjlGSRK0JerPkS1hDBOM4FgMAzAcpvi+K7Jx+7kAPoCp/f4E2WScpgSh80RVUw1MjflwWny7weBsrRSRjrfZ5rWOvsqjKwyCSEaUPabFPUmOrT0h0GtWOuanA+fHltHWKXihCvqJ2rPN9QCmAFgTdwBGRyBnzBQOKC8HU/nK/PgRiSngAJ7cwJIxec8wGKTNlXz+LJiiiWdhwPcCocWmArgaBrsLIfFo2+5xvG8LhcxKAAthMskWAFglkCOucDxrL75rEgy20zQAfwAw1PFui7RxjQPSaBOAw3OMlW3zbnxPwPYt4njMADCb47GYfamFAZdzPdcXwucimJpui2U2GcDTJKyUaOcSAH8FcLToT9w69GoA/xTzZItq7hPKx4uBLX0CgGfE/e8BmAAD2bNKYbK9BOC/RFTEU23uQ0Zfz77N5Th+AJMS/DFpYSF/ryWDp2BKZ9s6aOpixVcbBZjBXBgE17VqXL+dD0O4GNh+X80BqqGUaMuzitLHNVltYIr5N1IjjBO4Wn4DmbcCwJUcAMu4P6BWtJKxD6/5SvVpBoALhNT0HM8/B8BTAJ6gQJgVATx3kbi/LRl6Tgho21cAfqwIzxL8Lx3Xb4CBJopDxNUw4AiXAricAuGVkHZM4DyGPesgAC+K6++EqRarYns7wEC+Pqueuw7AI7SIkEe7XQx8j6ArL0JwdWf71vO+l9m2jrymDQwS6G2kRUnbr1HoaATQnvTNTKDwC3KcCyjYnoSBAK5y9PNAWp238nxYCRZ7LoMBfbzAEXbNm4HluZqEPJPnpzA4TlM5EE9Tav4WwE8B/I3PmwvgSPG+sgIdBJ7Aj7pPWAdvAxgYcd+hlMaBII56AOMRjnroCXOzEsDOMMAEEi3Svv9U3jMUJp4t37GVppIkzK0Avutg4GsdY15LK6NQa2V/GHDBNH0N1gray9Fv+/zjSZC2rZdH4HG1A3CTQB+17f4cwA9zMHEuBr47goFtewYoIfVwBNEnAJxBK0SC59UCuFEwnXxnOZXOZLGckUuqNDXoUEEv+SxJr1bIrxsBfD9f/ojLwJthwj2v8nyLTLxMwMi6zhU0c8dwTdEQvONqSnj77C+oLSTChzTlbd8GAnhXMbFFxhycoz32GWeKeyUczo0A/ltYA2EwsRkxTveKSbLvvc5h+awlE8ZlYF9gkvmU+svE85bBoELq/tq2jAGwXLTh98q8DFsm/UwwcUqY//8r2uLlycB/VpaKbms/Yd4HAN6gBQb1Tr0TxjECgVXSwnj6NFxjPYLMJefd9vO5mIzrsvROUUvVewrxWucyoTOUxJfQhPaEJu0IYE+aIddyzbfOsYa2z3odBhe5fZ6NtJrqZvGsNLVDLuK2v+1HayAQWtQiY+4ZMsie2EbmeGGCyXGSwusDAI+T+G6n1pbmd0pBxUpGut7BwKto/uWjgaVWv0w8q1ZoRd+x7hsi/AYZrvVyYXfLdfytYl5SgkHGOhg+DgPf6WBg+9lBmO8Zms8jYghi24ZTOR4a7vhxB21aa+wxNYf281VaIl4emtM+90wx50s5ByimBpa40LuLAQojprY0lx+iBA6EuZkR31/k++I4s+yEnEgGSgnG6x5DCEiCPpXryoyYvAAGjH6nHObaGOGM0+M0BwbXa1fl9fcpHG6hQyxDAXeY+N0+/0YHA69A/lBDvjAvZ4m19AUhZrOtxX5OEGaGVkWc90qmmuSY8/VimeHlwcB/DHFWyeVGSmjPRMy22vG+KYTWx4UIuONJ05rpl3Cs8xWy0lka0MmZKGSpFIeBZ3Et4ImXSPMkoSRfBQl+mgOJMCMcHr8TjJOIMAm70tyVZs/VMaWep9z+41XfLBHclEOAHKsY2PZjOZ0mLthYSQSXCJOrxkFQv3Iw8LIQ6yAX83YRDLkewIUhgs6++8citGFxwPvkMb5WaI0UjhnpJ5jn6EcuBv5DiDm5P8dcWoej8xA2lla7cUkYKIG+metQOz62/x3p65E0Y/v3kwL4ra2g6WUMsxa0tIzDwLM5obnUu68a0ItudUmUGeXweEGkWPohBHaRum+pcO4kHGaSZdiE45kjaT6l1cZu0gzzHG0Yzfs0A98fsgb3FIN6AM4XzK7XwDc5GHiJI/00l6XSEWanh4Aho7MjwkUezeSpwmklzVfXBgB6fPUxQaz364VQ+BuXXXE18LiQjQPuU7T5HpWAFxIWlG3VY3CFivXbtn6qaNL28yeKju3f/xaho7h+isPoGLbOt0SYNek3McJgWgzel4wDPyayrTyRBRMAGEXHVD8H4F2aBHmy+A56wecIBk2qPYiltzhDi2AXel8HiHFJCodHmuvkfD2+7+LrW7RqIegJ59UrIZk+fgjkajqPjLQuAO5iSG0hw2EPRvQnoEDZj+0pJwO9w/aUC43lKf9DSrStA+PrBwk/idw7q54WXNc8xjftyOgbTHqR4/cWrTnNrK62BhQYPbg06SnGLyEETDtkdwyRbX1GhJV02O3ImPxm+zKctL0RwD/YvoQrKSrZjMXYHgf3UjLQ4RxUX2VqDWOc7ocCH9kSzBAOUCCY9H1KLxfweQeaRz1pNexJadqba1Qb/1zOtf1njA1/yOfmm0ZXm0derxcjcw0x9g52gQb2ZuxyFLXSxfTSut7pCYY9iuNax+/LKJRcwqOcIbUe9In059kXJpGkF7I7C35Jp+EnDDe+JzLh4lSeZRzm8wjOrbx/Ski+eELs+tiL7dyDimJ30kIF+7iYoa9PGWZ7n22W9OUz6vEsw6SBGpfT+Vsqh7WbphA5nM/4D527XpiwTjZzIYNPZvk5THLEzmoCLDEdDbMVyziFXHkIO5wSDNwXwEmM3bWjCdWDTNuTmmgnkaxRywl6ngQ1m+uyRWI91RRJ90GeyfOZiLZJjTiEcdODaI7+lMyTK/e6J0zKoTTBK7hcGERh2J5M0JNj3J1z2F4Q+CKO6VMUiPMoHJfSb1CoNSeJvhxm32BfpKSCobI6kWTUTdDCLmxrZ0FvK9i+Nym459D7voTr96i587gkPJfaUwrm4Rz/KRHjniAdD4HZFdSj53tDVPppS6hGStDUeYTElQmJC55PIliA7AbQ+4vBs/ccR5MlI0I5m2HipsupTedyYhbAZECtphcxHbF+zKDpS86CAhhYTvZIat6+DF1dy3GIUzixBzVnIN6/M0wyzhZk4Y62kMhWkeg/F0z6BRl1PdfQYftAxQUn8BSYn80d7iESUCQtXCo87LZoYRPneyFMfNi2dyG1ba2IkricXIGDFuzf78GkYn5PKaBOXLpMidj72s7ZYVQws6m1I/fJbinlhNaR8QNKxozKeglo5oyESSUDpXx/VbJm1yJ/J6Gu4bmWRLQ5z7K75ka98CJMaBcDJ8S6+iwyW1uYtNHfC+2UjjEne4rCDvv+RVzOzBRMu1YUSGTyKMUMCiiJ1GtgTzhEu+LrSKZ30ztcy3au5t/rYyCdaqdREMMEzjCScZKDt46m5fKJQ4Dae9tTW3swqbqLsJ1gYnlcX7xHBnatDZJ0p9tUyU5q0jxOzm0w6W2FFnVnWiB0TCJGCZovqm6u5NmGVs04RShxjl0da9I3YOLWhY5tseqCtQDqJvwX9vlz6L1f2sD25nu8Qc/9wcJ6CeiHOFZsq+ta8gygz2cDrU3k0sB+C9n/xqeJNVV54/TRX8SG23P9C4WTnBJe5LASR4SkNWI7g5UNFILJ7jApd7/kEiOj4sr51NC6kle2tJCxTTn2UC5T79osIhGJJmivnYu1tCY9h3l8In0wGYelZ83nDvTHzIjjR2lpu9vNClkr2WMndtA6VJIOE7IyJGSDHRAXWhLfUVwzfV/034dJKT2W3/OxuCod/6tQpntzja2ugy5zCLRy4Q9oKlqw736e62pf1XkfIDLtAiVYa0Qu+pPkg5z82dIYeHnIToieKEOsjHAqVQhTakcCwUtErLk6Avg1PZZVXPP7al11Cz2bqTyyedIODdE+LB7ZxIIsFQMho60q3WvKJc9c+mK0iZyEKVIoc4TuBpC536cZju0JlTIQOzSkY2qirQ5HRKVYu2EHR6XsAFP48CZMXPd2mLDadQoeJkOH1B9gwjzpGMLNVgzpozvN1aCF4WFvcTieuvBsjqgKYEpoVwqB54vIwGAHXtgIKqAJXLf7ccbZb2EmYjKkTbYjm4QnuVbs3i4zuQZFBb53ABPaE1hiP4GJXR5LZl4K43l9SKVpBjDJAbfSVIuTLLHa8f4eArXEbyZnJ8QyyxMb0Ncpf0A1sqGlpnRM2vXtNJg0St32jjBeap3scSytp+fy8Vm0NBNaJli4jhWCsFYLD6Nc2xxATREUWFfckjWwXDfVA7gBJu79unDWbKET600hxa1A+z6yhR65hMUXDgbaGdnkjuZcomjLa6nKerPjNFwJsqYUNFu4rKlTaJcB52wncc++MIX/r8BkecWOFrQ0Dbx7iPMEIs/ZMvA6ZHc0lCbKPoiJF7SdroEDEZP9Ewk3KXJ7fRL0WF7jK2F2JUyFUS4BN0sQn9QsY2i+p5uJfmQ81o7Fl9g2FdO260hEI7I0phb2YEoopztiywNh4sKBqCf3YfIXUnHN52IxsIfibG7mwaSR+crkCESa2VvCGSDDThqJ0oKSZXYQZ5YXsQ7UywXLaG/DYF/VO2L/19NkS4uQkD5mK/A/Oy+HCa+218zjYdvwFUyussai7iJwxvxmMPdXw3iUdZuTMJVgZXS0ncD2v5QvjHIxOlWhSsEKMQ8zMNk0BztiX/bvTwH8S907hYPki+1Y7Hrvwh1oSxY/BxGHaYCHANyhhGQGJv/3NphKo1TIGC2B8YbqeytgYHL6NJMWlmWYgcgWey2kPWdQw6WbeEll5+UpZPf2kr8dDgOMcBb9Nn+nVVnUXSLioFKuQhabyS/g+faeC6gtMupd9u/LVP4saG4/oYr5JUzM6Q1Ev891X6564B800Eqx/XzY8ey5yOI8RQHDtYdBz5R1svZzMv0FYdhSYwTeU1qN77PYtgTQa+DuGbkgderEu891FNX3EuV8GfU5D9kacb/IbY1zz10OGCkLXGFz9PdsTFMlioG3ADiiQAZOiMF/z9FJ+/dEbIu5Je89RmEYyTaugfHU+iGIGF4eGNbNycCPFMDAGuRtqkKMkBjL5SEYyNUw4ZBAAS2kBODCXg6B7EcwpudAJYmLSmnn90LVTvt5VQQNzSatIE9a8GPSQlQ/jnAA38nzgcayZDyRiO1iYDs4pxUgnRIii+Zuh4awRDItAljODuydDiJLi4l/BMY7nYyAUUmEIDN4MHG73hF9ODqEgX/YQO1kJ/WxEAbuHkNAJEVp3dwQDfVzh3ayffuGQGpMh0AqnR8C2eqrsfVDIg9DVfTBtqFGWA/1Yn7Hhqxrd6LZH0YLa2Hyo3vHbKvnyDPYH8Ybnw8mWA2FnWyX3NXh2GJ5yiVGVFIgJ4wKkRy2MdfEALVzQetUwWQRhUHqTIYBDc9lJnZHFgM45bASLAjcPTD5qH1gsrrCjhpqrRNhqkvmY1ssJHvarUnCGPhcgQuVFIgQyYj1mEQRsagXLgaeJ8Dq9fPDdlQYQyLW47NRAdsl1DydT0vLhSZq/54Ck7Z5oKqxdQm9bjRpx8IUsTxDz7amu2qYxAYNqXOrQvaQ+QNDhfOtPqStttDhSJjYdlTosiMF+FkwwPAfURnExajyxRimHHhrr4n0YK+heyOFlc/VhKAl2L9HMaSxKo9qn4E0ec5QKB0JmGqMB2GgYhdHBLXtPUtIgPfB7IMEhye7MwfxXJpTs2BinSuRRRSs5rpuN5qG/Rii+LnwJsrxSQuPsGtnu2+yH6k8QxAZ9fyko0+d2M6leYQ1JsIgXP5WjWEVzM4ASc6jhi+6DyY10YKcS+QUCa5wCAXlZ2K7lnVcv9o0114w9cn78lmPwGSPrYUb67uj4//DSPRrHAJ9Ggz4wz0U1BlHGWM/OuIuQRaCyW5fYosgaqgY+tDJ1A0GTugSLveQZw3zy3zXIJUN9yTfW9CeUZ7K+hjIMEG1wD1qTwbdJweBTOKgTeGiPMxjvTe9gqciCw4GkWn1Agw+1Et5bPhlr+lBYjhbeSrlGReecz1N+zthitPtGPWi5K4SZtUotcMERMLBC5Ta6wRqv8UEe5l9lrmyR8CE08rE3smnqsC/PT7iOK0TY7SKDqZFDsFndxS4lw6+jBg7WxH2GM8v+dwl4v5TYZJH+jmKKTJ5lqhOgUEenShQV/YVgqGMXvJRjiiHdaJ9LOBpJ8PA/Vhv+f4UVN+JqDqK29aFMPXUDwpPcSFLod/RSrHb6M6m+TyngN0pnZ7gByJ2ENgqNvTaLDZs0tctpDn7EE2dm2DqUR+FSdTeqDYWW82B/w01VkWBYS5frKlPJYFsdbQvI8yxlOM3O1lD1LMtEZ1FC2Erx8IWts+DqfX8CCZ4P5PPWiPSPjfznjpev4+qprGbkKVEGzO8bx2ftZrnGrGLXZ3Y/WCzwG1OhAjsngIGNWyu11CbXqJopD9M3vXSkHtTAnVSL7s2kjZOF2YjaPW8q/qdEht9rRV9XyccQtK0/qtIApIonFfQ2goDFaxXDjIJyj+dmnq3Bu4akhDOrNXiHb9z7BRSkAa2UngkTFlaPQlhA4mvVsCipMXGUG1pyu0ksJG6c3KqlOlnJ2M1tcNcEvl0DvCGAjZaDsOCAts2gp7HoWxXOyUgLFEth4kzvwqTizrbod3tZzdK90q22SJ+bBTj46ktO6toklXRumnDe6YozCOrdXYRSfp1onBD7ylcJrawLBNbT74fooFlf/rQUukohPFW3tOW7fboBX5BbZANrgvHkCj7kw6qldCtI8MtIIM+D5P2uclBf/uz34GAnK0XQiojtGYl+1olBO8sni5a2IUa/igKzZ3Zx6RKjNlAi+MDWpSTYID80MCtUX2xVPknx2wpTErl1IZq32If1STWag60J7TEBp6bYmTYNNQZFygJ3xemUqkbBzJF4lpMhp3jWPtt73XEjRWZ0In4fenZ7UGBUMY5luieqxthnvPJ2IKwcvqQFjqTRutoRX1BIfBlkdsqBdXTFHx/pQAtKgqM7wirJFQsTJ9Rbvc4KPheI2cw+Xm2yYu55AgDaw87XWMX5/lR7/Ejrs1nDqJOP0ZGVDHmIld/cvXbK8Lchu2e0dAjKXaOWErL6qiWWFCUi7D8BsZFGyqYdCgnGbFDXunIz4eSDDkTLWhsPQct6LYWmxZcm8O/mCN0VTpKR+lAy8pjtwkxKWwLO1s6SkfpaMHWiQfjcPuHSE5q3xIY2CvSdV4ev7nWgVG/F5KYHuedXpEdhLmeW8j74z67MeYwTnvz7XNjlbI2BY+cw3VvCiaZqKR9GzBJ3naANum18Gc3V7u87ZDu+iO7F/M0mJBW0fxAcTJR2nFxL7N9EjQDtiKLS1XF/69HNtSQgIkJb4UJH3nCfFhL06Kav21xQIW2F7/Z8IRGS6ylZKuACV/JAP9Gx1YWdhe6brx2EbIQLbZf9exHOa8NHLA2daJddQrSxRMIjqsjQhAB39Gd7V+F7B66ts1lYsxkDHhLxN5Csr+dYOKem2FCZqmQ66sFsGCg5qGdSEKBI8G/hv2vIx20Ve/xRB6BRLjswuuWql0zyvgMmRyi57Kc716v0kzbi1I9T6CH1Dr6XCNyAYJGYN4yGHijPUhrj3AO/MbG6ZIplvfAZM9IhL9+MMkCNyKbNPEoTCLEIHFdX5jMpOsEk0/keqASwKEwCRTXOKphzoFJ9BhGQfM4TH7t5yLPdipM+h1gUA1m8J75MFlRdyBbeSLztqfAJGCshEGuOAnZ/YDehCl2B0wxwzy+cwZM6t5sEpwFiHuEz+st3nEoTDLAzTnGdzhMksQqEtw8TngHcc1+bKPdb2g+THLBXTme3Ynj/rno6ySYGKQW3EfBJFpMQHYXwTIBNv4BshtV6+1ezuaYW7zjc2GSdObAZKItgEHMOFsIiks47+so4P7NsbZC8lukr5ls/0yYvZYHizZfz/k/RuUgPAcDrF5F4foK700op9Kx7PPTeVQXIc/MqwsotDLsT88GZHPlrYE9sUfOAOX2riRhfYJsjvMBZIDLYDbd3soB3YcEYAdvEKVmJUyAvyNMpc/dyOZQVwI4k/fPZzvtjnjjKa3bkPDXCIIdRGZ6i225GCZgfxql7ACYdNEMTBqbD5Ot1V8QwD4i6WCxKAM7hsT9BH+fTg34Bkxq4OkwecLlMPWqg0moWiNa6XsI+9KGQnIZTLbQdTCJJ5dRo1XD5I8v4rtt1tW0HHW042DSPicKx8kpMGmWLwkkDo9MdyDvfRQmkUGiKO7r2PIGohJsT4HH3YWC+1kKvTbssy1lvALA/5H5fsW2ngcDWnAGhUhH0teHfE5P9mUvmOyllTCprkNhUh3/wzmxdLJWhIr2FglFcuvUs9nnA2DSficU0euchon5Xs13ZTiuXzUk6woFOj5eIfH0EL8PIoPaHeg7U9MGZK6TRLpdPUzyPKixZnLybHL+XSTU47AtSt8WGCxjq+E/oyYKA707kwP1IyHlJnIyLRrDeWzj1eK+KmQLE/YhcTzueP54at7+apyqaHksIpMM4xj8OWJcy0WR/nexLdbzZI7tYUKbr4OpEoor+Y8jg45X49VLFCJYBh1ATfkU+zBeJXAcy7m4IUQDX8lxH83vY9V3qK1xlpOxpUAYzjF7le21ABK/FNfcSzo5GlmoGl3P3I6a/13SWmcyzesK+8sKxCf5+UgRmdduSzNJLAE+pqArOjaX3wAYEf1/u4bbBINR3EGgGnoh93mUfGXYtmpkFIn8X4owk4LZPMenHKC02J4iISp1QCbr5sCa1u2T2WZl/Ltafd8EU/zQiSbTefzf7Y4xtpq4KzXwe9TwPgl3LQw2Urkoi/REbnXUjoUyT3k423gvma+M3+3G2rJdR5PYb6HlMprCOhMTSiYsGlDuyII6hEz1OK2bCv42mUy2Hy2mzQ5i36rGwQIbfgGzjegQjnsigt4gEFTawFQrTSO99SiSGW2tjJFC0z4AEwP2ir329YsI4FVBk/oWTsSPY+ypG1Abf8YOd2ebTqbUmopt0ff3hMkhnUAJ9z+O5x9Bk/lmao8plPgeJfwTAkt5LM29KCeT3g82EMn1ttb0ebbpGhgUjj+yT2HwoB3Y19kUcoEoM5zH5++qEu1HU+v8k2blsJD2lvHeraKgISWKUOS2K0muiefB1LpOpvl6RBHA3K6mhnuRVla5wNCay3bUCyKfRQtmJ/G/g7k0seP6oVg6JLh8upkW2tXUwPU5NoMr53r7UwG+3plLqYbCH2VgkjQuEY7PGTSfGyW33i8yjKaV+q+ROQ4TkhMROwA8w/XNYH4O4TptuWIk6yXuKCqe9HEMTN3mVRQAFwsPZC215M840b/huw/NY5vJwNHvNM39CjLN/SHXuxLk5fMzgngTDm9vB56dhJPJi7GvLdR+UlawDOVyZTzf+yy19ClF2Hq2hvPUiXOWVFZI4NiLyVNAAYfTP3A9Ne0FAuHRKo0X6Kw8BaaMtD6HpXAgTN37o3zn0/Q/nNCAfZ8s8+4LgzDTRtDGPar0sqhHMo8NuF0QrYFDC6/gemkCpWJZDrMhoKk8lmbjJg7sJDW51ul1Mk3hpHDEyHbcxuc9yGtWqXav5iA/zPXytTB76L5ZoASWG1qt5HpyUY4KlnUcp92pEeTG27349xI1TxNgkgDKhcZ2vaOeBFlBbebaVNseIygQRsBU6dTwPIRr448jhIOXQzhdS4uhUvhGVvLvXYVAtm3andesoSPM49r0IVo0bSjQPVWQn+YSZgw1dTW1qxcSWhtNTX00/QG2zwfR8flZnmEe65TqSiHeW0DYfsiIC5paAwdq35l2lKZ24LqRMdcoCZTiYEymV7mfGOSojZM/plf3JErR6fQswkGctaJeuV4JmQwl9WSGeQ6m1A5E3K9ceJjvICP1UhoqKGDD50SMKp1AYC6/Q22wv2DIBAxaSaD21bFjm6FFs9VBYJIhLOTLSWoJUEErJ805HUmNu4FLiY50RrblulDWstY7APEQssTIiIL+LcjuZTSVwmsMGc0CKgxiWz5k1MFuY7qYS6Bfc/l0uXpPPa2wxTSldxZmtJ63lOjzQtHnDjSluwo/TNyKNE8w7x20GCRN3p/PRmWNlcgxkWuGWykJa2iCblJA6+UCBiZDafRtmmkJdV25IvyVNN9+IWJ864V0s4KmN03iDSKp4yWun2xVkQUS+BvX4RfRTJpNp8VAEVA/hZN+vxiPshCgels87zUA5N4yWR0MztQoWgI3kKlPIwM/RiGkn+upPW/DBMQL9Nhfwfe9TDP2bI7h4VyqHMpw1e1iXbwbnVnf45zbvh9Gi6VcOMSeEuOeUBvUJUV7rXk8gw6dy6hZ76eVMJYM/RcK5koBGpEkbbxOC+QxCoIKEaLxON9HwUD5litnmt0zejgF5uWkZU9sjP4Bzej7hBMtl28EMEUKN9BvkBIe/I9oNTV79lgl43VLGEvdABOcv0SBh1vEBYn2eAIZ5RYRn3yL5nFHlTDwLZqhC2jOSAuhHZ0hy6kxV9EUXiLCT6dR2p0j3n8u77Hx2EvJyBtEwfmddGKAzP2ZCHvJwb+bTrqBDo1rQ2nT6WEtz4Gk6Yk2f0JhtZF9e1CFWCwc7K0x/Ra+SAB5nlbSRr7jM45BkqGX+Q5cMtvXBbSgvsXrVohMsbXCNLyQJrvVXhfx++iQcerAZc5StmsjnWgXi2tHcG6vEm06nvfcJMzrmWQ+iPDQfJhkjhoKh4/EXr03MMzkgpX9CxXB3jmSLWzo0K53VzigeOZS6TV6vW8+0mEQO17HQZivtKiN+c5UKZdDyGzz+X2ggECRa9gKagUrqVOKKAeoFD0r2efQrN4ZBmlhvkoI2Zdm2yyxX87eFCYLOcEQG4gP4PPmKilsza1PVdhJWjOD+dtsRwpn2NGV97VhzPIjdW8Nx2WVGvM4RxuY2HYXCqzpJDjQJC1nf/Sewd2oie0c7aVCIEk+x0Lb9haZVd3JVDMdqJHyGMj76ilYvlRe+v5k4q+EoB9Ck3wG56Md/5a7FQ4gbcxkm/fmnMxin8t4T+BISLF9XhMCCGgtqF/AJKPYYwaXLXNJU+8oWKYWUVEUhq2E7aw2M9NIMD4trT1hwiPRzHsnh/WvGPTUFDBIPpeF/bi2r6UgW6jGtUkgmfLdScFzYBfL34MY/w+7TidhhGW5wAFpG4SsDz3hQMg4oF2CGNfr90fFthMFYBxFtSdXm5CHs0XPmx+xEbqvNK4fgfGtxz3XOj1Xu8L6rP8X1v4oeovb56ABOdBeCH80yvH/Uqedlhyl4BoAAAAASUVORK5CYII=" alt="UC Berkeley"></span></div></div>
+  </section>
+
+  <!-- ══ THE LOOP ══ -->
+  <section>
+    <div class="sec-head ctr">
+      <p class="eyebrow">How it works</p>
+      <h2>Review, comment, done.</h2>
+    </div>
+
+    <div class="loop">
+      <div class="step">
+        <div class="step-viz">
+          <svg viewBox="0 0 520 240" role="img" aria-label="step"><g class="vgrid" fill="none" stroke="#10121a" stroke-opacity=".08" stroke-width="1"><path d="M0 0V240"/><path d="M26 0V240"/><path d="M52 0V240"/><path d="M78 0V240"/><path d="M104 0V240"/><path d="M130 0V240"/><path d="M156 0V240"/><path d="M182 0V240"/><path d="M208 0V240"/><path d="M234 0V240"/><path d="M260 0V240"/><path d="M286 0V240"/><path d="M312 0V240"/><path d="M338 0V240"/><path d="M364 0V240"/><path d="M390 0V240"/><path d="M416 0V240"/><path d="M442 0V240"/><path d="M468 0V240"/><path d="M494 0V240"/><path d="M520 0V240"/><path d="M0 0H520"/><path d="M0 26H520"/><path d="M0 52H520"/><path d="M0 78H520"/><path d="M0 104H520"/><path d="M0 130H520"/><path d="M0 156H520"/><path d="M0 182H520"/><path d="M0 208H520"/><path d="M0 234H520"/></g><rect x="60" y="52" width="400" height="136" rx="14" fill="#fff" stroke="#10121a" stroke-width="2.4"/><rect x="88" y="80" width="240" height="9" rx="4.5" fill="#10121a" opacity=".2"/><rect x="88" y="106" width="300" height="28" rx="7" fill="#ffd84d" stroke="#10121a" stroke-width="2"/><rect x="88" y="152" width="180" height="9" rx="4.5" fill="#10121a" opacity=".12"/><path d="M330 118 l30 22 l-11 3 l8 16 l-8 4 l-8 -16 l-9 7z" fill="#10121a"/></svg>
+        </div>
+        <div class="step-txt">
+          <span class="step-n">1</span>
+          <h3>They comment, on the page</h3>
+          <p>Any line or chart, right in the browser. No install, nothing to paste.</p>
+        </div>
+      </div>
+
+      <div class="step">
+        <div class="step-viz">
+          <svg viewBox="0 0 520 240" role="img" aria-label="step"><g class="vgrid" fill="none" stroke="#10121a" stroke-opacity=".08" stroke-width="1"><path d="M0 0V240"/><path d="M26 0V240"/><path d="M52 0V240"/><path d="M78 0V240"/><path d="M104 0V240"/><path d="M130 0V240"/><path d="M156 0V240"/><path d="M182 0V240"/><path d="M208 0V240"/><path d="M234 0V240"/><path d="M260 0V240"/><path d="M286 0V240"/><path d="M312 0V240"/><path d="M338 0V240"/><path d="M364 0V240"/><path d="M390 0V240"/><path d="M416 0V240"/><path d="M442 0V240"/><path d="M468 0V240"/><path d="M494 0V240"/><path d="M520 0V240"/><path d="M0 0H520"/><path d="M0 26H520"/><path d="M0 52H520"/><path d="M0 78H520"/><path d="M0 104H520"/><path d="M0 130H520"/><path d="M0 156H520"/><path d="M0 182H520"/><path d="M0 208H520"/><path d="M0 234H520"/></g><circle cx="260" cy="120" r="70" fill="#1652f0" opacity=".1"/><rect x="34" y="38" width="118" height="30" rx="9" fill="#fff" stroke="#10121a" stroke-width="2"/><circle cx="54" cy="53" r="7" fill="#b4732f"/><rect x="34" y="84" width="118" height="30" rx="9" fill="#fff" stroke="#10121a" stroke-width="2"/><circle cx="54" cy="99" r="7" fill="#3f6ab4"/><rect x="34" y="130" width="118" height="30" rx="9" fill="#fff" stroke="#10121a" stroke-width="2"/><circle cx="54" cy="145" r="7" fill="#4a8560"/><rect x="34" y="176" width="118" height="30" rx="9" fill="#fff" stroke="#10121a" stroke-width="2"/><circle cx="54" cy="191" r="7" fill="#8a5ba8"/><path d="M156 53 C210 53 214 120 250 120" stroke="#10121a" stroke-width="1.8" fill="none" opacity=".4"/><path d="M156 99 C210 99 214 120 250 120" stroke="#10121a" stroke-width="1.8" fill="none" opacity=".4"/><path d="M156 145 C210 145 214 120 250 120" stroke="#10121a" stroke-width="1.8" fill="none" opacity=".4"/><path d="M156 191 C210 191 214 120 250 120" stroke="#10121a" stroke-width="1.8" fill="none" opacity=".4"/><rect x="256" y="94" width="220" height="52" rx="14" fill="#fff" stroke="#1652f0" stroke-width="2.6"/><svg x="278" y="110" width="20" height="20" viewBox="0 0 24 24" fill="#d97757"><use href="#i-claude"/></svg><text x="384" y="126" text-anchor="middle" font-family="system-ui,sans-serif" font-size="14" font-weight="700" fill="#10121a">fix them all</text></svg>
+        </div>
+        <div class="step-txt">
+          <span class="step-n">2</span>
+          <h3>You say “apply them”</h3>
+          <p>Your agent pulls every note at once, and what each one points at.</p>
+        </div>
+      </div>
+
+      <div class="step">
+        <div class="step-viz">
+          <svg viewBox="0 0 520 240" role="img" aria-label="step"><g class="vgrid" fill="none" stroke="#10121a" stroke-opacity=".08" stroke-width="1"><path d="M0 0V240"/><path d="M26 0V240"/><path d="M52 0V240"/><path d="M78 0V240"/><path d="M104 0V240"/><path d="M130 0V240"/><path d="M156 0V240"/><path d="M182 0V240"/><path d="M208 0V240"/><path d="M234 0V240"/><path d="M260 0V240"/><path d="M286 0V240"/><path d="M312 0V240"/><path d="M338 0V240"/><path d="M364 0V240"/><path d="M390 0V240"/><path d="M416 0V240"/><path d="M442 0V240"/><path d="M468 0V240"/><path d="M494 0V240"/><path d="M520 0V240"/><path d="M0 0H520"/><path d="M0 26H520"/><path d="M0 52H520"/><path d="M0 78H520"/><path d="M0 104H520"/><path d="M0 130H520"/><path d="M0 156H520"/><path d="M0 182H520"/><path d="M0 208H520"/><path d="M0 234H520"/></g><rect x="200" y="24" width="120" height="34" rx="17" fill="#1652f0" stroke="#10121a" stroke-width="2"/><text x="260" y="47" text-anchor="middle" font-family="system-ui,sans-serif" font-size="14" font-weight="700" fill="#fff">new version</text><rect x="60" y="76" width="400" height="38" rx="11" fill="#f4faf6" stroke="#1a7340" stroke-width="2"/><circle cx="84" cy="95" r="9" fill="#d97757"/><rect x="104" y="91" width="210" height="8" rx="4" fill="#1a7340" opacity=".3"/><path d="M420 91 l5 5 l9 -10" fill="none" stroke="#1a7340" stroke-width="2.6" stroke-linecap="round" stroke-linejoin="round"/><rect x="60" y="126" width="400" height="38" rx="11" fill="#f4faf6" stroke="#1a7340" stroke-width="2"/><circle cx="84" cy="145" r="9" fill="#d97757"/><rect x="104" y="141" width="260" height="8" rx="4" fill="#1a7340" opacity=".3"/><path d="M420 141 l5 5 l9 -10" fill="none" stroke="#1a7340" stroke-width="2.6" stroke-linecap="round" stroke-linejoin="round"/><rect x="60" y="176" width="400" height="38" rx="11" fill="#f4faf6" stroke="#1a7340" stroke-width="2"/><circle cx="84" cy="195" r="9" fill="#d97757"/><rect x="104" y="191" width="170" height="8" rx="4" fill="#1a7340" opacity=".3"/><path d="M420 191 l5 5 l9 -10" fill="none" stroke="#1a7340" stroke-width="2.6" stroke-linecap="round" stroke-linejoin="round"/></svg>
+        </div>
+        <div class="step-txt">
+          <span class="step-n">3</span>
+          <h3>It rewrites, and replies</h3>
+          <p>A new version, plus a reply on every comment saying what changed.</p>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- ══ COLLABORATIVE ══ -->
+  <section>
+    <div class="sec-head ctr">
+      <p class="eyebrow">Collaborative</p>
+      <h2>Many people, many agents, one doc.</h2>
+      <p>Anyone with the link can comment: your team, your reviewers, and their own AIs. Every agent answers in its own name, so one page holds the whole review.</p>
+    </div>
+  </section>
+
+  <!-- ══ NO SETUP ══ -->
+  <section>
+    <div class="sec-head ctr">
+      <p class="eyebrow">No setup</p>
+      <h2>It already runs where you work.</h2>
+      <p>Runs in the agent session you already have open. Nothing to install, no account, no key.</p>
+    </div>
+
+    <div class="nosetup">
+      <div class="logorow">
+        <div class="apptile" role="img" aria-label="Claude" title="Claude" style="background:#D97757"><svg fill="#fff" aria-hidden="true"><use href="#i-claude"/></svg></div>
+        <div class="apptile" role="img" aria-label="OpenAI Codex" title="OpenAI Codex" style="background:#fff"><svg fill="#0A0A0A" aria-hidden="true"><use href="#i-openai"/></svg></div>
+        <div class="apptile" role="img" aria-label="Grok" title="Grok" style="background:#0A0A0A"><svg fill="#fff" aria-hidden="true"><use href="#i-grok"/></svg></div>
+        <div class="apptile" role="img" aria-label="Cursor" title="Cursor" style="background:#0A0A0A"><svg fill="#fff" aria-hidden="true"><use href="#i-cursor"/></svg></div>
+        <div class="apptile more" aria-hidden="true">&hellip;</div>
+      </div>
+      <p class="ns-cap">Whichever one is already open on your machine.</p>
+      <div class="ns-host">
+        <span>Open source, MIT. Published to <b>tdoc.dev</b> by default, or <a href="https://github.com/tornado-doc/tdoc" target="_blank" rel="noopener">self-host it on your own stack &#8594;</a></span>
+      </div>
+    </div>
+  </section>
+
+  <!-- ══ FEATURES, opentag card layout ══ -->
+  <section>
+    <div class="sec-head ctr">
+      <p class="eyebrow">Features</p>
+      <h2>Why the round actually closes.</h2>
+    </div>
+
+    <div class="sm-grid">
+      <article class="sm-card">
+        <div class="sm-viz"><svg viewBox="0 0 520 240" aria-hidden="true"><g class="vgrid" fill="none" stroke="#10121a" stroke-opacity=".08" stroke-width="1"><path d="M0 0V240"/><path d="M26 0V240"/><path d="M52 0V240"/><path d="M78 0V240"/><path d="M104 0V240"/><path d="M130 0V240"/><path d="M156 0V240"/><path d="M182 0V240"/><path d="M208 0V240"/><path d="M234 0V240"/><path d="M260 0V240"/><path d="M286 0V240"/><path d="M312 0V240"/><path d="M338 0V240"/><path d="M364 0V240"/><path d="M390 0V240"/><path d="M416 0V240"/><path d="M442 0V240"/><path d="M468 0V240"/><path d="M494 0V240"/><path d="M520 0V240"/><path d="M0 0H520"/><path d="M0 26H520"/><path d="M0 52H520"/><path d="M0 78H520"/><path d="M0 104H520"/><path d="M0 130H520"/><path d="M0 156H520"/><path d="M0 182H520"/><path d="M0 208H520"/><path d="M0 234H520"/></g><rect x="26" y="30" width="286" height="38" fill="#fff" stroke="#E0DCD1" stroke-width="1.6"/><text x="40" y="54" font-family="system-ui,sans-serif" font-size="12.5" fill="#3D3A34">Split it by cost per signup</text><text x="298" y="54" text-anchor="end" font-family="system-ui,sans-serif" font-size="10.5" font-weight="700" fill="#A5A099">open</text><rect x="26" y="77" width="286" height="38" fill="#fff" stroke="#E0DCD1" stroke-width="1.6"/><text x="40" y="101" font-family="system-ui,sans-serif" font-size="12.5" fill="#3D3A34">Add Junction to the set</text><text x="298" y="101" text-anchor="end" font-family="system-ui,sans-serif" font-size="10.5" font-weight="700" fill="#A5A099">open</text><rect x="26" y="124" width="286" height="38" fill="#fff" stroke="#E0DCD1" stroke-width="1.6"/><text x="40" y="148" font-family="system-ui,sans-serif" font-size="12.5" fill="#3D3A34">Lose the gradient, keep the type</text><text x="298" y="148" text-anchor="end" font-family="system-ui,sans-serif" font-size="10.5" font-weight="700" fill="#A5A099">open</text><rect x="26" y="171" width="286" height="38" fill="#fff" stroke="#E0DCD1" stroke-width="1.6"/><text x="40" y="195" font-family="system-ui,sans-serif" font-size="12.5" fill="#3D3A34">Alert on p99, not median</text><text x="298" y="195" text-anchor="end" font-family="system-ui,sans-serif" font-size="10.5" font-weight="700" fill="#A5A099">open</text><circle cx="408" cy="118" r="54" fill="#EDEBE4" stroke="#C9C4B8" stroke-width="1.6"/><text x="408" y="115" text-anchor="middle" font-family="system-ui,sans-serif" font-size="15" font-weight="800" fill="#1F1E1D">Apply all</text><text x="408" y="134" text-anchor="middle" font-family="system-ui,sans-serif" font-size="15" font-weight="800" fill="#1F1E1D">12 comments</text><g transform="translate(438 146) rotate(-14) scale(1.05)"><path d="M17 27V9a4 4 0 0 1 8 0v13h2.5a3.2 3.2 0 0 1 3.2 3.2V27h1.6a3 3 0 0 1 3 3v1.4a3 3 0 0 1 .7 2v4.1A7.5 7.5 0 0 1 28.5 45h-7.9a7.4 7.4 0 0 1-5.5-2.4l-6.8-7.6a3.4 3.4 0 0 1 5-4.6L17 33z" fill="#fff" stroke="#1F1E1D" stroke-width="2.6" stroke-linejoin="round" stroke-linecap="round"/></g></svg></div>
+        <div class="sm-txt">
+          <p class="sm-label">01 / Apply every comment</p>
+          <h3>Apply every comment, yours and your team&#8217;s, in one click.</h3>
+          <p class="sm-body">Twelve comments, one instruction. It reads them all at once, edits the page, and closes each one out, so a review round stops eating an afternoon.</p>
+        </div>
+      </article>
+      <article class="sm-card">
+        <div class="sm-viz"><svg viewBox="0 0 520 240" aria-hidden="true"><g class="vgrid" fill="none" stroke="#10121a" stroke-opacity=".08" stroke-width="1"><path d="M0 0V240"/><path d="M26 0V240"/><path d="M52 0V240"/><path d="M78 0V240"/><path d="M104 0V240"/><path d="M130 0V240"/><path d="M156 0V240"/><path d="M182 0V240"/><path d="M208 0V240"/><path d="M234 0V240"/><path d="M260 0V240"/><path d="M286 0V240"/><path d="M312 0V240"/><path d="M338 0V240"/><path d="M364 0V240"/><path d="M390 0V240"/><path d="M416 0V240"/><path d="M442 0V240"/><path d="M468 0V240"/><path d="M494 0V240"/><path d="M520 0V240"/><path d="M0 0H520"/><path d="M0 26H520"/><path d="M0 52H520"/><path d="M0 78H520"/><path d="M0 104H520"/><path d="M0 130H520"/><path d="M0 156H520"/><path d="M0 182H520"/><path d="M0 208H520"/><path d="M0 234H520"/></g><path d="M90 62H438" stroke="#1F1E1D" stroke-width="2.2" stroke-opacity=".25"/><circle cx="90" cy="62" r="12" fill="#fff" stroke="#1F1E1D" stroke-width="2.4"/><text x="90" y="67" text-anchor="middle" font-family="system-ui,sans-serif" font-size="13" font-weight="800" fill="#1F1E1D">v1</text><circle cx="208" cy="62" r="12" fill="#fff" stroke="#1F1E1D" stroke-width="2.4"/><text x="208" y="67" text-anchor="middle" font-family="system-ui,sans-serif" font-size="13" font-weight="800" fill="#1F1E1D">v2</text><circle cx="326" cy="62" r="12" fill="#fff" stroke="#1F1E1D" stroke-width="2.4"/><text x="326" y="67" text-anchor="middle" font-family="system-ui,sans-serif" font-size="13" font-weight="800" fill="#1F1E1D">v3</text><circle cx="438" cy="62" r="19" fill="#1652f0" fill-opacity=".16"/><circle cx="438" cy="62" r="12" fill="#1652f0" stroke="#1F1E1D" stroke-width="2.4"/><text x="438" y="67" text-anchor="middle" font-family="system-ui,sans-serif" font-size="13" font-weight="800" fill="#fff">v4</text><text x="438" y="34" text-anchor="middle" font-family="system-ui,sans-serif" font-size="10" font-weight="700" letter-spacing=".08em" fill="#8B8781">NOW</text><rect x="52" y="100" width="416" height="118" fill="#fff" stroke="#1F1E1D" stroke-width="2"/><rect x="52" y="100" width="416" height="30" fill="#F6F8FA"/><path d="M52 130H468" stroke="#1F1E1D" stroke-width="2"/><text x="66" y="120" font-family="ui-monospace,SFMono-Regular,Menlo,monospace" font-size="12" font-weight="700" fill="#1F1E1D">v3 &#8594; v4</text><text x="454" y="120" text-anchor="end" font-family="system-ui,sans-serif" font-size="11" fill="#656D76">+1 &#8722;1</text><rect x="54" y="130" width="412" height="28" fill="#E6FFEC"/><rect x="54" y="130" width="30" height="28" fill="#E6FFEC" fill-opacity=".55"/><path d="M84 130H466" stroke="#D0D7DE" stroke-width="1"/><text x="64" y="149" font-family="ui-monospace,SFMono-Regular,Menlo,monospace" font-size="13" font-weight="700" fill="#1A7F37">+</text><text x="94" y="149" font-family="ui-monospace,SFMono-Regular,Menlo,monospace" font-size="12.5" fill="#1F1E1D">cost per signup column</text><rect x="54" y="158" width="412" height="28" fill="#FFEBE9"/><rect x="54" y="158" width="30" height="28" fill="#FFEBE9" fill-opacity=".55"/><path d="M84 158H466" stroke="#D0D7DE" stroke-width="1"/><text x="64" y="177" font-family="ui-monospace,SFMono-Regular,Menlo,monospace" font-size="13" font-weight="700" fill="#CF222E">&#8722;</text><text x="94" y="177" font-family="ui-monospace,SFMono-Regular,Menlo,monospace" font-size="12.5" fill="#1F1E1D">share-of-spend column</text><text x="54" y="234" font-family="system-ui,sans-serif" font-size="11" font-style="italic" fill="#8B8781">asked for in Jesse&#8217;s comment on v3</text></svg></div>
+        <div class="sm-txt">
+          <p class="sm-label">02 / On the record</p>
+          <h3>Every change is on the record.</h3>
+          <p class="sm-body">Every version shows what changed, when, and which comment asked for it. When your manager asks whether you addressed the feedback, the doc is the answer.</p>
+        </div>
+      </article>
+      <article class="sm-card">
+        <div class="sm-viz"><svg viewBox="0 0 520 240" aria-hidden="true"><g class="vgrid" fill="none" stroke="#10121a" stroke-opacity=".08" stroke-width="1"><path d="M0 0V240"/><path d="M26 0V240"/><path d="M52 0V240"/><path d="M78 0V240"/><path d="M104 0V240"/><path d="M130 0V240"/><path d="M156 0V240"/><path d="M182 0V240"/><path d="M208 0V240"/><path d="M234 0V240"/><path d="M260 0V240"/><path d="M286 0V240"/><path d="M312 0V240"/><path d="M338 0V240"/><path d="M364 0V240"/><path d="M390 0V240"/><path d="M416 0V240"/><path d="M442 0V240"/><path d="M468 0V240"/><path d="M494 0V240"/><path d="M520 0V240"/><path d="M0 0H520"/><path d="M0 26H520"/><path d="M0 52H520"/><path d="M0 78H520"/><path d="M0 104H520"/><path d="M0 130H520"/><path d="M0 156H520"/><path d="M0 182H520"/><path d="M0 208H520"/><path d="M0 234H520"/></g><g><text x="26" y="30" font-family="system-ui,sans-serif" font-size="8" font-weight="700" letter-spacing="1.1" fill="#767c8b">BRAND KIT</text><rect x="26" y="40" width="22" height="22" fill="#1652f0"/><rect x="52" y="40" width="22" height="22" fill="#10121a"/><rect x="78" y="40" width="22" height="22" fill="#e4e7ee"/><rect x="26" y="72" width="74" height="26" fill="#fff" stroke="#10121a" stroke-width="2"/><text x="63" y="89" text-anchor="middle" font-family="Georgia,serif" font-size="11" fill="#10121a">Georgia</text><rect x="26" y="104" width="74" height="26" fill="#fff" stroke="#10121a" stroke-width="2"/><rect x="34" y="112" width="10" height="10" fill="#1652f0"/><text x="50" y="121" font-family="Georgia,serif" font-size="8" font-weight="700" letter-spacing=".8" fill="#10121a">LOGO</text><path d="M100 112H132" stroke="#10121a" stroke-width="1.8" fill="none" opacity=".45"/><path d="M126 107l7 5-7 5z" fill="#10121a" opacity=".45"/></g><g opacity=".28"><rect x="400" y="8" width="96" height="224" fill="#fff" stroke="#10121a" stroke-width="2.4"/><rect x="416" y="26" width="11" height="11" fill="#1652f0"/><rect x="432" y="29" width="38" height="6" fill="#10121a" opacity=".55"/><path d="M416 46H480" stroke="#10121a" stroke-width="1.6"/><rect x="416" y="60" width="46" height="9" fill="#10121a" opacity=".7"/><rect x="416" y="76" width="30" height="5" fill="#10121a" opacity=".3"/><rect x="416" y="96" width="64" height="4" fill="#10121a" opacity=".22"/><rect x="416" y="106" width="64" height="4" fill="#10121a" opacity=".22"/><rect x="416" y="116" width="64" height="4" fill="#10121a" opacity=".22"/><rect x="416" y="152" width="9" height="16" fill="#1652f0"/><rect x="429" y="142" width="9" height="26" fill="#1652f0"/><rect x="442" y="147" width="9" height="21" fill="#1652f0"/><rect x="455" y="136" width="9" height="32" fill="#1652f0"/><path d="M416 168H471" stroke="#10121a" stroke-width="1.4"/><rect x="416" y="184" width="64" height="4" fill="#10121a" opacity=".22"/><rect x="416" y="193" width="64" height="4" fill="#10121a" opacity=".22"/><path d="M416 210H480" stroke="#10121a" stroke-width="1.2"/><rect x="416" y="216" width="34" height="4" fill="#10121a" opacity=".26"/></g><g><rect x="146" y="8" width="200" height="224" fill="#fff" stroke="#10121a" stroke-width="2.4"/><rect x="162" y="26" width="13" height="13" fill="#1652f0"/><text x="181" y="37" font-family="Georgia,serif" font-size="10" font-weight="700" letter-spacing="1.6" fill="#10121a">NORTHWIND</text><text x="330" y="37" text-anchor="end" font-family="Georgia,serif" font-size="7" fill="#767c8b">Q3 2026</text><path d="M162 48H330" stroke="#10121a" stroke-width="1.6"/><text x="162" y="70" font-family="Georgia,serif" font-size="14" fill="#10121a">Quarterly Review</text><text x="162" y="83" font-family="Georgia,serif" font-size="7.5" font-style="italic" fill="#767c8b">Prepared for the board</text><path d="M162 97H330" stroke="#10121a" stroke-opacity=".26" stroke-width="2.4"/><path d="M162 106H330" stroke="#10121a" stroke-opacity=".26" stroke-width="2.4"/><path d="M162 115H296" stroke="#10121a" stroke-opacity=".26" stroke-width="2.4"/><rect x="162" y="148" width="11" height="20" fill="#1652f0"/><rect x="179" y="135" width="11" height="33" fill="#1652f0"/><rect x="196" y="141" width="11" height="27" fill="#1652f0"/><rect x="213" y="127" width="11" height="41" fill="#1652f0"/><path d="M162 168H232" stroke="#10121a" stroke-width="1.4"/><path d="M162 184H330" stroke="#10121a" stroke-opacity=".26" stroke-width="2.4"/><path d="M162 193H278" stroke="#10121a" stroke-opacity=".26" stroke-width="2.4"/><path d="M162 210H330" stroke="#10121a" stroke-width="1.2"/><text x="162" y="221" font-family="Georgia,serif" font-size="6.5" letter-spacing=".9" fill="#767c8b">CONFIDENTIAL</text><text x="330" y="221" text-anchor="end" font-family="Georgia,serif" font-size="6.5" fill="#767c8b">1</text></g></svg></div>
+        <div class="sm-txt">
+          <p class="sm-label">03 / Your brand, applied</p>
+          <h3>Your brand, applied for you.</h3>
+          <p class="sm-body">Point tdoc at your brand once, at the fonts, colours, logo and the way your charts look, and it builds a template out of them: letterhead, headings, footer, page furniture. Every doc after that comes out on that template, official enough to send outside the company without anyone reformatting it.</p>
+        </div>
+      </article>
+
+    </div>
+  </section>
+
+  <!-- ══ COMPARE ══ -->
+  <section>
+    <div class="sec-head ctr">
+      <p class="eyebrow">Compare</p>
+      <h2>Where tdoc wins, and where it doesn't.</h2>
+    </div>
+
+    <div class="tablewrap">
+      <table>
+        <thead>
+          <tr>
+            <th scope="col">&nbsp;</th>
+            <th scope="col" class="us">tdoc</th>
+            <th scope="col">Google Docs</th>
+            <th scope="col">Notion</th>
+            <th scope="col">ChatGPT</th>
+            <th scope="col">Claude artifacts</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td class="lbl">Has your working context</td>
+            <td class="us" data-col="tdoc"><span class="yes"><svg viewBox="0 0 24 24"><use href="#i-check"/></svg><b>Runs in your agent session</b></span></td>
+            <td data-col="Google Docs"><span class="no"><svg viewBox="0 0 24 24"><use href="#i-cross"/></svg></span></td>
+            <td data-col="Notion"><span class="no"><svg viewBox="0 0 24 24"><use href="#i-cross"/></svg></span></td>
+            <td data-col="ChatGPT"><span class="part"><svg viewBox="0 0 24 24"><use href="#i-dash"/></svg>What you paste</span></td>
+            <td data-col="Claude artifacts"><span class="part"><svg viewBox="0 0 24 24"><use href="#i-dash"/></svg>What you paste</span></td>
+          </tr>
+          <tr>
+            <td class="lbl">Anyone can comment</td>
+            <td class="us" data-col="tdoc"><span class="yes"><svg viewBox="0 0 24 24"><use href="#i-check"/></svg></span></td>
+            <td data-col="Google Docs"><span class="yes"><svg viewBox="0 0 24 24"><use href="#i-check"/></svg></span></td>
+            <td data-col="Notion"><span class="yes"><svg viewBox="0 0 24 24"><use href="#i-check"/></svg></span></td>
+            <td data-col="ChatGPT"><span class="no"><svg viewBox="0 0 24 24"><use href="#i-cross"/></svg></span></td>
+            <td data-col="Claude artifacts"><span class="no"><svg viewBox="0 0 24 24"><use href="#i-cross"/></svg></span></td>
+          </tr>
+          <tr>
+            <td class="lbl">Your AI reads the comments</td>
+            <td class="us" data-col="tdoc"><span class="yes"><svg viewBox="0 0 24 24"><use href="#i-check"/></svg>All at once</span></td>
+            <td data-col="Google Docs"><span class="no"><svg viewBox="0 0 24 24"><use href="#i-cross"/></svg>You copy them</span></td>
+            <td data-col="Notion"><span class="no"><svg viewBox="0 0 24 24"><use href="#i-cross"/></svg>You copy them</span></td>
+            <td data-col="ChatGPT"><span class="no"><svg viewBox="0 0 24 24"><use href="#i-cross"/></svg>None to read</span></td>
+            <td data-col="Claude artifacts"><span class="no"><svg viewBox="0 0 24 24"><use href="#i-cross"/></svg>None to read</span></td>
+          </tr>
+          <tr>
+            <td class="lbl">Your AI has its own identity</td>
+            <td class="us" data-col="tdoc"><span class="yes"><svg viewBox="0 0 24 24"><use href="#i-check"/></svg>Its own name and avatar</span></td>
+            <td data-col="Google Docs"><span class="no"><svg viewBox="0 0 24 24"><use href="#i-cross"/></svg></span></td>
+            <td data-col="Notion"><span class="no"><svg viewBox="0 0 24 24"><use href="#i-cross"/></svg></span></td>
+            <td data-col="ChatGPT"><span class="no"><svg viewBox="0 0 24 24"><use href="#i-cross"/></svg></span></td>
+            <td data-col="Claude artifacts"><span class="no"><svg viewBox="0 0 24 24"><use href="#i-cross"/></svg></span></td>
+          </tr>
+          <tr>
+            <td class="lbl">What you can make</td>
+            <td class="us" data-col="tdoc"><span class="yes"><svg viewBox="0 0 24 24"><use href="#i-check"/></svg>Any web page</span></td>
+            <td data-col="Google Docs"><span class="part"><svg viewBox="0 0 24 24"><use href="#i-dash"/></svg>Text docs</span></td>
+            <td data-col="Notion"><span class="part"><svg viewBox="0 0 24 24"><use href="#i-dash"/></svg>Docs, databases</span></td>
+            <td data-col="ChatGPT"><span class="part"><svg viewBox="0 0 24 24"><use href="#i-dash"/></svg>Chat</span></td>
+            <td data-col="Claude artifacts"><span class="yes"><svg viewBox="0 0 24 24"><use href="#i-check"/></svg>Any web page</span></td>
+          </tr>
+          <tr>
+            <td class="lbl">Live co-editing</td>
+            <td class="us" data-col="tdoc"><span class="part"><svg viewBox="0 0 24 24"><use href="#i-dash"/></svg>Coming soon</span></td>
+            <td data-col="Google Docs"><span class="yes"><svg viewBox="0 0 24 24"><use href="#i-check"/></svg></span></td>
+            <td data-col="Notion"><span class="yes"><svg viewBox="0 0 24 24"><use href="#i-check"/></svg></span></td>
+            <td data-col="ChatGPT"><span class="no"><svg viewBox="0 0 24 24"><use href="#i-cross"/></svg></span></td>
+            <td data-col="Claude artifacts"><span class="no"><svg viewBox="0 0 24 24"><use href="#i-cross"/></svg></span></td>
+          </tr>
+          <tr>
+            <td class="lbl">Open source</td>
+            <td class="us" data-col="tdoc"><span class="yes"><svg viewBox="0 0 24 24"><use href="#i-check"/></svg>MIT</span></td>
+            <td data-col="Google Docs"><span class="no"><svg viewBox="0 0 24 24"><use href="#i-cross"/></svg></span></td>
+            <td data-col="Notion"><span class="no"><svg viewBox="0 0 24 24"><use href="#i-cross"/></svg></span></td>
+            <td data-col="ChatGPT"><span class="no"><svg viewBox="0 0 24 24"><use href="#i-cross"/></svg></span></td>
+            <td data-col="Claude artifacts"><span class="no"><svg viewBox="0 0 24 24"><use href="#i-cross"/></svg></span></td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  </section>
+
+  <!-- ══ FINAL CTA ══ -->
+  <section style="text-align:center">
+    <div class="sec-head ctr" style="margin-bottom:26px;max-width:660px">
+      <h2>Send the next review as a tdoc.</h2>
+      <p><span>Paste one line into your AI. It sets everything up and hands you a link.</span><span>Whoever you send it to comments like it's a Google Doc, with nothing to install.</span></p>
+    </div>
+    <p class="trustline" style="justify-content:center">
+      <span><svg aria-hidden="true"><use href="#i-code"/></svg>Open source</span>
+      <span><svg aria-hidden="true"><use href="#i-card"/></svg>Free &middot; No card</span>
+    </p>
+    <div class="cta" style="justify-content:center">
+      <a class="btn btn-primary" href="/start"><span class="btn-in">Create your first doc</span></a>
+    </div>
+  </section>
+
+  <footer>
+    <a href="https://github.com/tornado-doc/tdoc"><svg class="i" viewBox="0 0 24 24" aria-hidden="true"><use href="#i-github"/></svg>github.com/tornado-doc/tdoc</a>
+    &nbsp;·&nbsp; MIT &nbsp;·&nbsp; a Claude Code and Codex skill
+    <br><br>
+    This page is a tdoc. Highlight a sentence, or hover the grid, and leave a comment.
+  </footer>
+
+</div>
+</body>
+</html>

--- a/server/onboard.js
+++ b/server/onboard.js
@@ -121,10 +121,10 @@
   // ---- page 2: the line, with Copy inside the box ------------------------
   function stepPaste() {
     var bd = shell('Paste this into your AI', st.selfHost
-      ? 'It installs tdoc, builds your first doc, and sets up your own Cloudflare account to publish it. Two browser clicks, no card.'
+      ? 'Your AI installs tdoc, writes your first doc — a live, commentable web page, not a chat reply — and sets up your own Cloudflare to publish it, then hands back a link to share. Two browser clicks, no card.'
       : (st.hosted
-        ? 'It installs tdoc, builds your first doc, and publishes it.'
-        : 'It installs tdoc, builds your first doc, and publishes it to a free Cloudflare account you own. No card.'));
+        ? 'Your AI installs tdoc, writes your first doc — a live, commentable web page, not a chat reply — publishes it, and hands back a link you can share.'
+        : 'Your AI installs tdoc, writes your first doc — a live, commentable web page, not a chat reply — and publishes it to a free Cloudflare account you own, then hands back a link to share. No sign-up here, no card.'));
 
     var wrap = el('div', 'tdo-linewrap');
     var pre = el('div', 'tdo-line');

--- a/test/landing-demo-tabs.test.js
+++ b/test/landing-demo-tabs.test.js
@@ -1,13 +1,15 @@
-// The landing page's demo: four tdocs shown in the reader's own chrome.
+// The landing page's demo: three tdocs shown in the reader's own browser
+// chrome. It is a refined STATIC mock now (no live widget iframes) — the point
+// is to sell the value-prop loop (comment -> agent rewrites -> reply -> new
+// version), not to faithfully rebuild the product. See the `hd-` component in
+// landing/tornado-doc/vN/index.html.
 //
-// The whole point is that they are the SAME page the product renders, only the
-// subject changes, so this file diffs every stage against the first one and
-// fails on any drift between them.
-//
-// Two rules that are easy to break by accident:
-//   - the comment threads are static markup, no animation. Only the artifacts
-//     move, and they are sandboxed islands.
-//   - the tabs are Safari chrome, not a second row of calls to action.
+// Rules that are easy to break by accident:
+//   - three windows, each its own browser chrome, all commented by Jesse
+//     Pollak but answered by a DIFFERENT agent (Claude / Codex / Grok).
+//   - the demo auto-rotates the three until a tab is clicked, then pins one.
+//   - it is CSS-only: a published tdoc runs no author JavaScript.
+//   - the comment threads are static markup; nothing there animates.
 const fs = require('fs');
 const path = require('path');
 
@@ -21,176 +23,72 @@ const root = path.join(__dirname, '..');
 const meta = JSON.parse(fs.readFileSync(path.join(root, 'landing', 'tornado-doc', 'meta.json'), 'utf8'));
 const latest = meta.versions[meta.versions.length - 1].n;
 const work = fs.readFileSync(path.join(root, 'landing', 'tornado-doc', `v${latest}`, 'index.html'), 'utf8');
+// The demo is the self-contained `.hd` block. Scope every check to it so a
+// stray match elsewhere on the page cannot pass a demo assertion.
+const demo = work.slice(work.indexOf('<div class="hd" style'), work.indexOf('<p class="hd-cap"'));
 
 console.log('landing demo tabs');
 
-// tag+class sequence, ignoring text and attribute values
-function skeleton(html) {
-  const out = [];
-  const re = /<(\w+)([^>]*)>/g;
-  let m;
-  while ((m = re.exec(html))) {
-    const tag = m[1];
-    if (['svg', 'use', 'path', 'symbol', 'br'].includes(tag)) continue;
-    const cm = /class="([^"]*)"/.exec(m[2]);
-    const cls = cm ? cm[1].split(/\s+/).filter(Boolean).sort().join(' ') : '';
-    out.push(cls ? `${tag}.${cls}` : tag);
+t('three windows, each in its own browser chrome', () => {
+  const wins = [...demo.matchAll(/<div class="hd-win hd-w[123]">/g)];
+  assert(wins.length === 3, `expected 3 windows, found ${wins.length}`);
+  assert((demo.match(/<div class="hd-bar">/g) || []).length === 3, 'each window needs its own chrome bar');
+  assert((demo.match(/<div class="hd-canvas">/g) || []).length === 3, 'each window needs a doc canvas');
+  // Doc and thread are siblings in the canvas, not nested (a nested aside
+  // collapses the two-column grid to one — the v2/v3 bug on the old demo).
+  for (const cls of ['hd-doc', 'hd-notes']) {
+    assert((demo.match(new RegExp(`class="${cls}`, 'g')) || []).length === 3, `expected 3 .${cls}`);
   }
-  return out;
-}
-// What must match one to one is the reader's chrome and the comment thread —
-// the parts tdoc renders identically for every document. The doc BODY is the
-// document itself and is expected to differ: a growth report has more
-// paragraphs than a Conway explainer, and demanding an equal paragraph count
-// would be demanding that every tdoc say the same thing.
-function stageOf(html, from) {
-  const i = html.indexOf('<div class="tbar">', from);
-  const j = html.indexOf('</aside>', i);
-  let block = html.slice(i, j);
-  // Collapse the whole doc body to a marker. Prose before AND after the
-  // artifact is the document talking; the scaffolding around it is the part
-  // that has to match.
-  block = block.replace(/<div class="doc">[\s\S]*?(?=<aside class="stage-notes">)/,
-                        '<div class="doc">DOCBODY');
-  return { block, end: j };
-}
-
-t('every stage renders the reader and the thread the same way', () => {
-  let refSk = null, cursor = 0, seen = 0;
-  while (true) {
-    const i = work.indexOf('<div class="browser"', cursor);
-    if (i < 0) break;
-    const s = stageOf(work, i);
-    const sk = skeleton(s.block);
-    seen++;
-    if (!refSk) {
-      refSk = sk;
-      assert(refSk.length > 40, `first stage looks wrong: ${refSk.length} nodes`);
-      cursor = s.end;
-      continue;
-    }
-    assert(sk.length === refSk.length,
-      `stage ${seen} has ${sk.length} nodes, stage 1 has ${refSk.length}`);
-    for (let k = 0; k < refSk.length; k++) {
-      assert(sk[k] === refSk[k],
-        `stage ${seen} node ${k}: got ${sk[k]}, stage 1 has ${refSk[k]}`);
-    }
-    cursor = s.end;
-  }
-  assert(seen === 4, `expected 4 stages, found ${seen}`);
 });
 
-t('every commenter is Jesse Pollak, and the agents differ', () => {
-  const commenters = [...work.matchAll(/<div class="mc-login">([^<]+)<\/div>/g)].map(m => m[1]);
-  assert(commenters.length === 4, `expected 4 top-level commenters, found ${commenters.length}`);
-  assert(commenters.every(c => c === 'Jesse Pollak'), `not all Jesse: ${[...new Set(commenters)]}`);
-  const agents = [...work.matchAll(/mc-author[\s\S]{0,240}?<span class="mc-login">([^<]+)<\/span>/g)].map(m => m[1]);
-  assert(new Set(agents).size === 4, `agents should all differ, got ${agents}`);
-  for (const a of ['Claude', 'Codex', 'Grok', 'Cursor']) {
+t('every commenter is Jesse Pollak, and the three agents differ', () => {
+  const humans = (demo.match(/<b>Jesse Pollak<\/b>/g) || []).length;
+  assert(humans === 3, `expected 3 Jesse Pollak comments, found ${humans}`);
+  const agents = [...demo.matchAll(/<div class="hd-reply">[\s\S]*?<b>([^<]+)<\/b>/g)].map((m) => m[1]);
+  assert(agents.length === 3, `expected 3 agent replies, found ${agents.length}`);
+  assert(new Set(agents).size === 3, `agents must all differ, got ${agents}`);
+  for (const a of ['Claude', 'Codex', 'Grok']) {
     assert(agents.includes(a), `missing a ${a} reply`);
   }
+  assert((demo.match(/class="hd-chip b"[\s\S]{0,80}?applied/g) || []).length === 3,
+    'each agent reply must carry an "applied" chip');
 });
 
-t('the comment threads are static', () => {
-  // Only the artifacts may move. A transition or keyframe on any comment part
-  // means the mock is animating something the real reader does not.
-  const stage = stageOf(work, 0).block;
-  assert(!/animation|@keyframes|transition/i.test(stage),
-    'a comment stage carries animation; threads must be static markup');
-  // The switcher is CSS radio, not script — this page runs no author JS.
-  assert(!/<script\b/i.test(work), 'the page contains a <script>; CSP will not run it');
-  assert(/input type="radio" name="uc"/.test(work), 'the use-case switcher is not CSS radio');
+t('the demo is CSS-only and the threads are static', () => {
+  assert(!/<script\b/i.test(work), 'the page contains a <script>; a published tdoc runs none');
+  assert(/<input type="radio" name="hd"/.test(demo), 'the tab switcher is not CSS radio');
+  const threads = demo.match(/<aside class="hd-notes">[\s\S]*?<\/aside>/g) || [];
+  assert(threads.length === 3, `expected 3 threads, found ${threads.length}`);
+  for (const th of threads) {
+    assert(!/animation|transition|@keyframes/i.test(th), 'a comment thread is animating; threads must be static');
+  }
 });
 
-t('the demo cycles all four use cases, and clicking pins one', () => {
-  // One demo on a loop only ever sells one use case. Untouched it rotates;
-  // clicking a tab stops it where it was put.
-  for (const k of ['cyc1', 'cyc2', 'cyc3', 'cyc4']) {
+t('it auto-rotates the three, and clicking a tab pins one', () => {
+  for (const k of ['hcyc1', 'hcyc2', 'hcyc3']) {
     assert(new RegExp('@keyframes ' + k).test(work), `missing rotation keyframe ${k}`);
   }
-  assert(/:not\(:has\(input:checked\)\)/.test(work),
-    'rotation must stop once a tab is chosen');
+  assert(/\.hd:not\(:has\(input:checked\)\)/.test(work), 'rotation must stop once a tab is chosen');
+  assert(/#hd1:checked~\.hd-w1[\s\S]{0,120}animation:\s*none/.test(work),
+    'clicking a tab must pin its window and cancel the rotation');
   assert(/@supports not selector\(:has\(\*\)\)/.test(work),
-    'without :has support the page must still show a demo, not an empty frame');
-  assert(/prefers-reduced-motion[\s\S]{0,200}animation:none/.test(work),
-    'reduced motion must pin one use case instead of rotating');
-  // Rotation is the panel swapping. The threads inside stay static.
-  assert(!/animation/.test(stageOf(work, 0).block), 'a comment stage animates');
+    'without :has support the demo must still show a window, not an empty frame');
+  assert(/prefers-reduced-motion[\s\S]{0,260}animation:\s*none/.test(work),
+    'reduced motion must pin one window instead of rotating');
 });
 
-t('the four stages are siblings, not nested', () => {
-  // They were nested: each panel opened one more div than it closed, so
-  // .p-res sat inside .p-rep and so on. Rotation then animated an ancestor's
-  // opacity to 0 and every descendant composited away — the demo went blank
-  // after six seconds and on three of the four tabs, and the container grew
-  // to 2779px because static panels stack instead of sharing a grid cell.
-  const starts = [...work.matchAll(/<div class="uc-panel p-\w+">/g)].map((m) => m.index);
-  assert(starts.length === 4, `expected 4 panels, found ${starts.length}`);
-  // Measure the nesting depth of each panel inside .uc-panels rather than
-  // slicing to a sentinel elsewhere in the section: the old check anchored on
-  // a caption, so deleting that caption silently moved the boundary.
-  const container = work.indexOf('<div class="uc-panels"');
-  assert(container > -1, 'missing .uc-panels container');
-  const depths = starts.map((i) => {
-    const seg = work.slice(container, i);
-    return (seg.match(/<div\b/g) || []).length - (seg.match(/<\/div>/g) || []).length;
-  });
-  assert(depths.every((d) => d === depths[0]),
-    `panels sit at depths ${depths.join(', ')} — they must be siblings`);
-  assert(depths[0] === 1,
-    `panels must be direct children of .uc-panels, found depth ${depths[0]}`);
+t('the artifacts are crafted statics, not live iframes', () => {
+  assert(!/<iframe/i.test(work), 'the demo must not frame an iframe; it is a static mock now');
+  assert(/class="hd-bars"/.test(demo), 'the GTM window needs its crafted bar chart');
+  assert(/class="hd-scatter"/.test(demo), 'the competitor window needs its crafted quadrant');
+  assert(/class="hd-stack"/.test(demo), 'the design window needs its crafted context-window bar');
 });
 
-t('the stage is cropped like a screenshot', () => {
-  // The doc keeps going past the frame on purpose. Without the cap the stage
-  // ends early and leaves dead space under a short column — and this rule has
-  // already been deleted once by an unrelated rewrite of the block it used to
-  // sit in, with nothing to catch it.
-  assert(/\.doc-tail \{[^}]*max-height:104px/.test(work), 'the trailing prose is no longer capped');
-  // Only the tail may truncate: a cut ring or a cut comment card reads broken.
-  assert(!/\.stage(-doc)? \{[^}]*max-height/.test(work),
-    'capping the stage crops the artifact and the thread; cap .doc-tail instead');
-  // The thread must never be the thing that gets cut.
-  assert(/\.doc-tail:after \{[^}]*linear-gradient\(transparent,#fff\)/.test(work),
-    'the crop needs a fade, or it looks like the content simply stops');
-  assert(/\.doc-tail \{ max-height:78px/.test(work), 'no shorter cap on narrow screens');
-  // The margin column starves the artifact below ~900; the split has to give.
-  assert(/@media \(max-width:900px\) \{\s*\.stage \{ grid-template-columns:1fr; \}/.test(work),
-    'the stage must collapse to one column before the artifact is squeezed');
-});
-
-t('the artifacts are real sandboxed islands', () => {
-  const frames = [...work.matchAll(/<iframe[^>]*class="[^"]*\blife\b[^>]*>/g)].map(m => m[0]);
-  assert(frames.length === 4, `expected 4 artifacts, found ${frames.length}`);
-  for (const f of frames) {
-    assert(/sandbox="allow-scripts"/.test(f), `artifact missing sandbox: ${f.slice(0, 80)}`);
-    assert(!/allow-same-origin/.test(f), 'artifact must not get allow-same-origin');
-  }
-  const widgets = [...work.matchAll(/\/widget\/(\w+)"/g)].map(m => m[1]);
-  assert(new Set(widgets).size === 4, `each stage needs its own artifact, got ${widgets}`);
-  for (const w of widgets) {
-    const p = path.join(root, 'landing', 'tornado-doc', `v${latest}`, 'widgets', `${w}.html`);
-    assert(fs.existsSync(p), `missing widget file for ${w}`);
-    // Not every artifact needs to move. The growth report is a table on
-    // purpose — an animation there is decoration competing with the numbers.
-    // What matters is that it is a real island, served by the widget route.
-    const body = fs.readFileSync(p, 'utf8');
-    assert(/<html/i.test(body) && body.length > 200, `${w} is not a real page`);
-  }
-});
-
-t('the tabs are Safari chrome, and the page is indexable', () => {
-  // The tabs are Safari chrome, not a second row of CTAs: the accent colour
-  // belongs to the call to action, and a coloured tab competes with it.
-  assert(/\.sft\.on \{[^}]*background:#fff/.test(work),
-    'the active tab should read as a focused Safari tab, not as a button');
-  assert(!/\.sft[^}]*background:var\(--accent\)/.test(work),
-    'tabs must not take the CTA colour');
-  // Safari divides inactive tabs with hairlines and lifts the focused one.
-  assert(/\.sft \+ \.sft:before/.test(work), 'inactive tabs need Safari hairline dividers');
-  assert(/\.sft\.on \{[^}]*box-shadow/.test(work), 'the focused tab should lift off the bar');
-  // This is the homepage now. The experiment's noindex must not have ridden
-  // along with it.
+t('the tabs are browser chrome, and the page is indexable', () => {
+  assert(/\.hd-tab\.on\s*\{[^}]*background:#fff/.test(work), 'the active tab should read as a focused tab');
+  assert(!/\.hd-tab[^}]*background:var\(--accent\)/.test(work), 'tabs must not take the CTA colour');
+  assert(/#hd-fbars/.test(demo) && /#hd-fscan/.test(demo) && /#hd-fcode/.test(demo),
+    'tab favicons must be the glyph symbols, not emoji');
   assert(!/name="robots"[^>]*noindex/.test(work), 'the homepage must not carry noindex');
 });
 

--- a/test/tornado-doc-landing.test.js
+++ b/test/tornado-doc-landing.test.js
@@ -54,49 +54,19 @@ t('runs no author JavaScript', () => {
   assert(!hrefs.some((h) => /^javascript:/i.test(h)), 'page contains a javascript: URL');
 });
 
-t('hero artifact is a sandboxed widget island', () => {
-  // Anything that computes lives in a widget island, framed with
-  // sandbox="allow-scripts" and no allow-same-origin. The host stays
-  // script-free; the island is a unique origin.
-  assert(/<iframe\b[^>]*class="[^"]*\blife\b/.test(html), 'missing iframe.life');
-  assert(/src="\/d\/tornado-doc\/v\/\d+\/widget\/[a-z0-9-]+"/.test(html),
-    'iframe must point at a /widget/ route on this doc');
-  const iframe = html.match(/<iframe\b[^>]*class="[^"]*\blife\b[^>]*>/);
-  assert(iframe, 'could not isolate the life iframe');
-  assert(/sandbox="allow-scripts"/.test(iframe[0]),
-    `widget iframe sandbox must be allow-scripts only: ${iframe[0]}`);
-  assert(!/allow-same-origin/.test(iframe[0]),
-    'widget iframe must not include allow-same-origin');
-  const islands = [...html.matchAll(/\/widget\/([a-z0-9-]+)"/g)].map((m) => m[1]);
-  assert(islands.length, 'no widget island framed on the page');
-  const widgetPath = path.join(root, 'landing', 'tornado-doc', `v${latest}`, 'widgets', `${islands[0]}.html`);
-  assert(fs.existsSync(widgetPath), `missing ${widgetPath}`);
-  const widget = fs.readFileSync(widgetPath, 'utf8');
-  // The CSS-sprite workaround must stay gone on the host.
-  assert(!/<g class="glider"/.test(html), 'CSS-sprite glider group still in the host');
-  assert(!/@keyframes\s+glide/.test(html),
-    'host CSS still has the sprite @keyframes glide; the island does not use it');
-  // Dark mode is one invert on html. Reaction emoji are OS bitmaps and
-  // the agent mark is a brand colour, so both come back wrong unless
-  // flipped a second time (same restore as overlay .tdoc-emoji).
-  assert(/html\[data-tdoc-theme="dark"\]\s*\.emo/.test(html),
-    'dark mode must restore mock reaction emoji after the page invert');
-  assert(/html\[data-tdoc-theme="dark"\]\s*\.mc-av\.mc-logo/.test(html),
-    'dark mode must restore the terracotta agent mark after the page invert');
-  // The ring belongs to the artifact inside the island, never to the frame:
-  // ringing the frame encloses whatever control sits under the artifact.
-  assert(/iframe\.life\s*\{[^}]*background:\s*#fff/.test(html),
-    'island card must stay opaque (#fff); transparent iframe comes back white in dark mode');
-  assert(!/iframe\.life\s*\{[^}]*background:\s*transparent/.test(html),
-    'iframe.life must not be transparent');
-  assert(!/\.life\.anchored\s*\{/.test(html),
-    'host must not ring the whole island; that enclosed the play control');
-  // Demo chrome: blue is the page CTA. The mock bar uses a plain wordmark
-  // and a grey version pill so it does not steal those two buttons.
-  assert(!/\.tbar-mark\s*\{[^}]*background:\s*var\(--accent\)/.test(html),
-    'demo tbar-mark must not spend the CTA blue');
-  assert(/\.tbar-v\s*\{[^}]*background:\s*#f0f1f4/.test(html),
-    'demo version chip must be the reader grey pill, not a blue one');
+t('hero demo is a static mock, no iframe or author script', () => {
+  // The demo used to frame live widget islands. It is a refined STATIC mock
+  // now (crafted SVG/CSS charts), because the job is to sell the value-prop
+  // loop, not to rebuild the product. So: no iframe, no author <script>.
+  const demo = html.slice(html.indexOf('<div class="hd" style'), html.indexOf('<p class="hd-cap"'));
+  assert(demo.length > 1000, 'the hd demo block is missing');
+  assert(!/<iframe/i.test(html), 'the page frames an iframe; the demo is a static mock now');
+  assert(!/<script\b/i.test(html), 'a published tdoc runs no author script');
+  assert(/class="hd-bars"/.test(demo) && /class="hd-scatter"/.test(demo) && /class="hd-stack"/.test(demo),
+    'each demo window needs its crafted artifact (bars / scatter / stack)');
+  // The old CSS-sprite glider workaround must stay gone from the host.
+  assert(!/<g class="glider"/.test(html), 'CSS-sprite glider group still present');
+  assert(!/@keyframes\s+glide/.test(html), 'host CSS still has the sprite @keyframes glide');
 });
 
 t('carries the SEO head', () => {
@@ -142,81 +112,60 @@ t('links to the GitHub repo and install path', () => {
     'a CTA points at a raw GitHub file; that is a repo, not an onboarding');
 });
 
-t('hero stage-notes is a sibling of stage-doc', () => {
-  // Nesting the notes inside .stage-doc makes the two-column grid a no-op:
-  // the grid has one child, so the cards stack under the board. v2 and v3
-  // both shipped that bug. stage-doc must be closed before the aside.
-  const iDoc = html.indexOf('<div class="stage-doc">');
-  const iAside = html.indexOf('<aside class="stage-notes">');
-  assert(iDoc >= 0 && iAside > iDoc, 'missing stage-doc or stage-notes');
-  const mid = html.slice(iDoc + '<div class="stage-doc">'.length, iAside);
+t('demo doc and thread are siblings, not nested', () => {
+  // Nesting the thread inside the doc collapses the two-column canvas.
+  const demo = html.slice(html.indexOf('<div class="hd" style'), html.indexOf('<p class="hd-cap"'));
+  const iDoc = demo.indexOf('<div class="hd-doc">');
+  const iAside = demo.indexOf('<aside class="hd-notes">');
+  assert(iDoc >= 0 && iAside > iDoc, 'missing hd-doc or hd-notes');
+  const mid = demo.slice(iDoc + '<div class="hd-doc">'.length, iAside);
   const opens = (mid.match(/<div\b/g) || []).length;
   const closes = (mid.match(/<\/div>/g) || []).length;
-  assert(closes === opens + 1, `stage-doc still open when notes start (div net ${opens - closes})`);
+  assert(closes === opens + 1, `hd-doc still open when the thread starts (div net ${opens - closes})`);
 });
 
-t('phone rules actually override the desktop headline and CTA grid', () => {
+t('phone rules override the headline, and no redundant Star pill in the doc', () => {
   // Desktop is `h1.tagline { font-size:56px }` (specificity 0,1,1). A
-  // `@media { .tagline { font-size:38px } }` rule never wins, so v6
+  // `@media { .tagline { font-size:38px } }` rule never wins, so the headline
   // wrapped to three lines at 375px. The phone override must target
   // `h1.tagline`.
   const phone = html.match(/@media \(max-width:640px\)\s*\{([\s\S]*?)\n    \}/);
   assert(phone, 'missing @media (max-width:640px)');
   assert(/h1\.tagline\s*\{[^}]*font-size:\s*\d+px/.test(phone[1]),
     '640px breakpoint must set h1.tagline font-size, not just .tagline');
-  // v35: share the row. Two 232px tracks still overflow 375, so the
-  // columns become 1fr 1fr and ".btn-long" ("on GitHub") hides, leaving
-  // "Star 102". A lone 1fr restack is also overflow-safe but drops the
-  // second button under the first; lock the two-column share.
-  assert(/\.cta\s*\{[^}]*grid-template-columns:\s*1fr\s+1fr/.test(phone[1]),
-    '640px breakpoint must share the CTA row (1fr 1fr); 232+232 overflows 375');
-  assert(/\.btn-long\s*\{[^}]*display:\s*none/.test(phone[1]),
-    '640px must hide .btn-long so Star 102 fits the half-width track');
-  // v28: loop stayed 3 col (98px, one word per line), proof-wall stayed
-  // 3 col (min-content 164px, page scrollWidth 545), feature cards stayed
-  // 2 col (156px). All three must become one column with the CTAs.
+  // v43: one CTA, and the GitHub star moved to the top bar. There is no second
+  // pill to share the row, so the phone CTA is a single full-width 1fr track.
+  assert(/\.cta\s*\{[^}]*grid-template-columns:\s*1fr(\s|;|\})/.test(phone[1]),
+    '640px .cta must be a single 1fr track now that the hero has one CTA');
+  // v28: loop stayed 3 col (98px, one word per line), proof-wall stayed 3 col
+  // (164px), feature cards 2/3 col. All must become one column with the CTA.
   assert(/\.loop,\s*\.sm-grid,\s*\.proof-wall\s*\{[^}]*grid-template-columns:\s*1fr/.test(phone[1])
       || (/\.loop\s*\{[^}]*grid-template-columns:\s*1fr/.test(phone[1])
         && /\.sm-grid\s*\{[^}]*grid-template-columns:\s*1fr/.test(phone[1])
         && /\.proof-wall\s*\{[^}]*grid-template-columns:\s*1fr/.test(phone[1])),
     '640px breakpoint must restack .loop, .sm-grid and .proof-wall to 1fr');
-  // v12 lengthened the ghost label to "Star on GitHub 102". The v7 216px
-  // cap wraps that label (77px vs 52px). Phone max-width must match the
-  // desktop track (232px), or be absent so 1fr uses the wrap.
-  const ctaRule = phone[1].match(/\.cta\s*\{[^}]*\}/);
-  const maxW = ctaRule && ctaRule[0].match(/max-width:\s*(\d+)px/);
-  assert(!maxW || Number(maxW[1]) >= 232,
-    `640px .cta max-width is ${maxW && maxW[1]}px; "Star on GitHub 102" wraps below 232`);
-  // The GitHub mark is a <use> of a 24x24 symbol. Without a viewBox the
-  // used path overflows the 1em box and the grid row grows to ~77px.
-  // Matched inside the button rather than immediately after it: the contents
-  // are wrapped in one centring child now, so adjacency is not the invariant.
-  // The invariant is that the icon carries a viewBox.
-  const ghost = html.match(/<a class="btn btn-ghost"[\s\S]*?<\/a>/);
-  assert(ghost, 'ghost CTA not found');
-  assert(/<svg[^>]*viewBox="0 0 24 24"/.test(ghost[0]),
-    'Star button icon must set viewBox so the used mark cannot stretch the pill');
-  // v39 phone bug: icon / label / pill were direct flex children of the
-  // button. Hiding .btn-long left an anonymous text node that collected
-  // its own gap, so Star read as icon-left / pill-right. Contents must
-  // be one .btn-in child; the button then centres a single item.
+  // v43: the GitHub star is neither a hero CTA nor a pill in the doc body.
+  // The published overlay top bar already renders a GitHub button for the
+  // landing (cfg.isLanding in overlay.js), so an oversized "Star on GitHub"
+  // pill in the page is redundant (issue: "Should only have one CTA. Non
+  // technical should not open GitHub"). The repo link survives in the footer.
+  assert(!/class="btn btn-ghost"/.test(html),
+    'the GitHub Star must not be a page CTA');
+  assert(!/class="tb-star"/.test(html),
+    'no Star pill in the doc; the overlay top bar carries GitHub for the landing');
+  assert(/github\.com\/tornado-doc\/tdoc/.test(html),
+    'the repo link should still appear on the page (footer)');
+  // The single primary CTA still wraps its label in one .btn-in child and
+  // locks its pill height, so the used marks cannot stretch the row.
   assert(/\.btn-in\s*\{[^}]*display:\s*inline-flex/.test(html),
-    'CTA contents must sit in one .btn-in child so a hidden .btn-long cannot become a flex gap');
-  const ghosts = [...html.matchAll(/<a class="btn btn-ghost"[\s\S]*?<\/a>/g)].map((m) => m[0]);
-  assert(ghosts.length >= 2, `expected two ghost CTAs, found ${ghosts.length}`);
-  for (const g of ghosts) {
-    assert(/<span class="btn-in">/.test(g),
-      'ghost CTA must wrap icon+label+pill in .btn-in so the row stays centred on phones');
-  }
-  // v14 dropped height/nowrap. The used mark then overflowed 1em and the
-  // Star pill measured 77px (Create stretched with it on desktop). Lock both.
+    'CTA contents must sit in one .btn-in child');
   assert(/\.btn\s*\{[^}]*height:\s*52px/.test(html),
-    'CTA pills must lock height:52px; without it the used GitHub mark stretches Star to ~77px');
+    'CTA pills must lock height:52px');
   assert(/\.btn\s*\{[^}]*white-space:\s*nowrap/.test(html),
-    'CTA pills must nowrap so Star on GitHub 102 stays one line');
-  // Same class of bug as the original .tagline vs h1.tagline miss: an
-  // earlier 640px size is a no-op if a later 840px block also sets
-  // h1.tagline. The last media query that sets h1.tagline must be 640.
+    'CTA pills must nowrap');
+  // Same class of bug as the .tagline vs h1.tagline miss: an earlier 640px
+  // size is a no-op if a later 840px block also sets h1.tagline. The last
+  // media query that sets h1.tagline must be 640.
   const mediaH1 = [...html.matchAll(/@media \(max-width:(\d+)px\)\s*\{([\s\S]*?)\n    \}/g)]
     .filter((m) => /h1\.tagline\s*\{[^}]*font-size:/.test(m[2]));
   const last = mediaH1[mediaH1.length - 1];
@@ -224,36 +173,26 @@ t('phone rules actually override the desktop headline and CTA grid', () => {
     `last h1.tagline media query is ${last && last[1]}px; 640 must come last so phones do not inherit the 840px size`);
 });
 
-t('hero comment count matches the mock thread', () => {
-  // v8 nested Claude's answer as a reply. The notes column is one thread,
-  // so "2 comments" is a leftover from the sibling-card layout.
-  const notes = html.match(/<aside class="stage-notes">[\s\S]*?<\/aside>/);
-  assert(notes, 'missing stage-notes');
-  const threads = (notes[0].match(/<div class="mc">/g) || []).length;
-  const replies = (notes[0].match(/<div class="mc-reply">/g) || []).length;
-  assert(threads === 1, `expected 1 mock thread, found ${threads}`);
-  assert(replies === 1, `expected Claude's answer as a reply, found ${replies}`);
-  // v10: checked against the published conway-life doc. The real reader has
-  // no "N comments" header at all; the margin holds pins, and a pin opens the
-  // card. The mock follows that, so there is no label left to count.
-  assert(!/class="lbl-n"/.test(notes[0]), 'the real margin has no comment-count header');
-  assert(/move anchor/i.test(notes[0]), 'real cards lead with the move-anchor row');
-  assert(/mc-meta/.test(notes[0]), 'real cards carry a version and date meta row');
-  // Play/Pause lives in the board next to this card. Asking for the
-  // absence of that control reads as a bug, not a demo.
-  assert(!/without a play button/i.test(notes[0]),
-    'Anna must not ask for no play button while Pause sits in the island');
+t('each demo thread is one comment with one agent reply', () => {
+  const demo = html.slice(html.indexOf('<div class="hd" style'), html.indexOf('<p class="hd-cap"'));
+  const threads = demo.match(/<aside class="hd-notes">[\s\S]*?<\/aside>/g) || [];
+  assert(threads.length === 3, `expected 3 threads, found ${threads.length}`);
+  for (const th of threads) {
+    const humans = (th.match(/<b>Jesse Pollak<\/b>/g) || []).length;
+    const replies = (th.match(/<div class="hd-reply">/g) || []).length;
+    assert(humans === 1, `expected 1 human comment per thread, found ${humans}`);
+    assert(replies === 1, `expected 1 agent reply per thread, found ${replies}`);
+  }
 });
 
-t('agent avatar is a filled Claude disc, not a small glyph', () => {
-  // The sunburst path is hollow in the middle. v11/v12 put an 18–20px
-  // terracotta mark on a transparent disc; at 22px that reads as a broken
-  // image. The runtime tiles already use a filled disc.
-  assert(/mc-av mc-logo/.test(html), 'missing agent logo avatar');
-  assert(/\.mc-av\.mc-logo\s*\{[^}]*background:\s*#D97757/i.test(html),
-    'agent avatar disc must be Claude terracotta, not transparent');
-  assert(/\.mc-logo svg\s*\{[^}]*fill:\s*#fff/i.test(html),
-    'agent mark must be white on the terracotta disc');
+t('agent avatars are filled brand discs, not hollow glyphs', () => {
+  // The sunburst is hollow; on a transparent disc it reads as a broken image.
+  // Each agent mark sits filled-white on its own brand-coloured disc.
+  const demo = html.slice(html.indexOf('<div class="hd" style'), html.indexOf('<p class="hd-cap"'));
+  assert(/background:#d97757"><svg[^>]*><use href="#hd-claude"/.test(demo),
+    'Claude reply needs a terracotta disc with the claude mark');
+  assert(/#hd-openai/.test(demo) && /#hd-x/.test(demo), 'Codex and Grok marks must be present');
+  assert(/#hd-claude"[\s\S]*?fill="#fff"/.test(html), 'the claude mark must be white on its disc');
 });
 
 t('loop step 2 svg is well-formed', () => {
@@ -326,11 +265,8 @@ t('carries no unfinished placeholder content', () => {
   const drafts = (visible.match(/PLACEHOLDER/gi) || []).length;
   assert(drafts === 0, `${drafts} visible PLACEHOLDER line(s) on the latest version`);
 
-  // People stay. Quotes must mention tdoc-shaped work, not the leftover
-  // OpenTag wording. Trusted-by leftovers from that site must stay gone.
-  for (const name of ['Josh', 'Brandon', 'Angela F', 'Bruce Z', 'Sam H', 'Sammy']) {
-    assert(visible.includes(name), `missing ${name} on the proof wall`);
-  }
+  // The social-proof wall was removed; the OpenTag trusted-by leftovers must
+  // stay gone regardless.
   assert(!/Coinbase|ByteDance|GUAZI/i.test(visible), 'OpenTag trusted-by leftovers still visible');
   assert(/Works with/.test(visible), 'trusted-by label should be Works with, not a borrowed user list');
 });
@@ -419,16 +355,15 @@ t('homepage bar is site chrome, not a document toolbar', () => {
 console.log('tdoc.dev / release payload');
 
 t('bin/tdoc-landing-release writes a clean v1 with no review thread', () => {
-  // The working copy under landing/tornado-doc keeps 39 versions and the
-  // review thread. Publishing that as-is would put a version picker and
-  // somebody else's notes on tdoc.dev/. The release script copies only
-  // the latest HTML to v1, rewrites the widget iframe, and writes [].
+  // The working copy keeps every version and the review thread. Publishing
+  // that as-is would put a version picker and somebody else's notes on
+  // tdoc.dev/. The release script copies only the latest HTML to v1 and
+  // writes []. (The demo is a static mock now, so there is no widget island
+  // to rewrite or copy.)
   const { execFileSync } = require('child_process');
   const script = path.join(root, 'bin', 'tdoc-landing-release');
   const outDir = path.join(root, '.release', 'tornado-doc');
-  const previewDir = path.join(root, '.release', 'tdoc-home');
   execFileSync(process.execPath, [script], { cwd: root, encoding: 'utf8' });
-  execFileSync(process.execPath, [script, 'tdoc-home'], { cwd: root, encoding: 'utf8' });
 
   const ignore = fs.readFileSync(path.join(root, '.gitignore'), 'utf8');
   assert(/^\.release\/$/m.test(ignore), '.release/ must be gitignored so the payload cannot be committed by mistake');
@@ -437,7 +372,7 @@ t('bin/tdoc-landing-release writes a clean v1 with no review thread', () => {
   assert(Array.isArray(srcComments) && srcComments.length > 0,
     'working copy has no comments to strip; the release script would be a no-op');
   assert(meta.versions.length > 1,
-    'working copy is a single version; the v39→v1 collapse would be invisible');
+    'working copy is a single version; the vN->v1 collapse would be invisible');
 
   const relMeta = JSON.parse(fs.readFileSync(path.join(outDir, 'meta.json'), 'utf8'));
   const relComments = JSON.parse(fs.readFileSync(path.join(outDir, 'comments.json'), 'utf8'));
@@ -448,21 +383,11 @@ t('bin/tdoc-landing-release writes a clean v1 with no review thread', () => {
   assert(!fs.existsSync(path.join(outDir, 'v2')), 'release payload still has a v2 directory');
   assert(Array.isArray(relComments) && relComments.length === 0,
     `release comments.json must be empty, got ${relComments.length} thread(s)`);
-  assert(/src="\/d\/tornado-doc\/v\/1\/widget\/[a-z0-9-]+"/.test(relHtml),
-    'release iframe must point at /d/tornado-doc/v/1/widget/<name>');
-  assert(!new RegExp(`/d/tornado-doc/v/${latest}/widget/`).test(relHtml),
-    `release iframe still points at working-copy v${latest}`);
-  const relIslands = [...relHtml.matchAll(/\/widget\/([a-z0-9-]+)"/g)].map((m) => m[1]);
-  assert(relIslands.every((n) => fs.existsSync(path.join(outDir, 'v1', 'widgets', `${n}.html`))),
-    'release payload must copy every widget the page frames or the island 404s');
-
-  const previewHtml = fs.readFileSync(path.join(previewDir, 'v1', 'index.html'), 'utf8');
-  assert(/src="\/d\/tdoc-home\/v\/1\/widget\/[a-z0-9-]+"/.test(previewHtml),
-    'custom-slug release must rewrite the iframe to that slug');
+  // The static mock brings its own charts: the payload must not frame an iframe.
+  assert(!/<iframe/i.test(relHtml), 'release HTML frames an iframe; the demo is a static mock');
+  assert(/class="hd-win hd-w1"/.test(relHtml), 'release HTML lost the demo component');
 
   // tdoc-publish only attaches comments.json when it is a non-empty array.
-  // An empty file is the right local signal; it does not wipe a remote
-  // thread that already exists (preview). First publish to tdoc.dev is clean.
   const publish = fs.readFileSync(path.join(root, 'bin', 'tdoc-publish'), 'utf8');
   assert(/type == "array" and length > 0/.test(publish),
     'tdoc-publish must skip empty comments.json so the release payload does not send a dummy list');


### PR DESCRIPTION
Redesigns the tdoc.dev homepage (`landing/tornado-doc`, new **v43**) around the feedback pulled from the live page's comments and interviews. Merging this to `main` triggers `publish-landing` to ship it to `tdoc.dev/`.

## What changed
- **Value prop up front.** Leads with the workflow — *your agent writes the doc, you comment, your AI updates all of it* — instead of clever copy. Eyebrow positions it for the real use cases: deep research, reports, analysis.
- **One CTA.** The GitHub star is off the page CTAs (a non-technical visitor is never handed GitHub); it lives in the overlay top bar (`isLanding`).
- **New demo.** Replaces the heavy live widget-iframe demo with a refined, **flat** static mock: three examples (GTM report / Competitor analysis / Tech design doc), each a crafted chart plus the comment → agent-reply → new-version loop, answered by three different agents (Claude / Codex / Grok). Auto-rotates until a tab is clicked, then pins. Icons opt out of the overlay's forced `svg` margin.
- **Sections.** Adds a collaboration section (many people, many agents, one doc); trims the wordy "No setup"; swaps the host icons for a self-host GitHub link; removes the social-proof wall.
- **Onboarding copy** in `server/onboard.js` is more informative about what the pasted line does and what you get.
- Drops the font-picker example and the 02/CONTEXT feature card.

## Tests
- Rewrote `landing-demo-tabs` and the demo-coupled assertions in `tornado-doc-landing` for the new static-mock demo (no iframes; 3 windows; auto-rotate + pin; three agents; crafted charts).
- `npm test` — all 43 offline suites green. `node bin/tdoc-landing-release` builds the payload cleanly.

## Follow-ups (not in this PR)
- Demo **dark-mode** polish (reaction emoji / brand avatars invert oddly under the overlay's dark invert).
- Strip the now-dead old-demo / `.proof-*` / `.ns-marks` CSS from `<head>`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)