### PR TITLE
Wire /templates into the journey: landing, /start, /me

### DIFF
--- a/landing/tdoc-start/v1/index.html
+++ b/landing/tdoc-start/v1/index.html
@@ -454,6 +454,7 @@
           <div class="term"><div class="term-bar"><span class="term-dot r"></span><span class="term-dot y"></span><span class="term-dot g"></span><span class="term-title">claude &mdash; tdoc</span></div><div class="term-bd"><span class="p">&rsaquo; </span>Set up tdoc and make my first doc: https://github.com/tornado-doc/tdoc/blob/main/FIRST-DOC.md</div></div>
           <p class="hint">You get a Game of Life page with a live board, published to a link you can share.</p>
           <p style="margin:14px 0 0"><a class="btn btn-primary" href="/start" style="width:auto;display:inline-flex;padding:0 22px">Copy the line</a></p>
+          <p style="margin:8px 0 0;font-size:14px;color:#767c8b">or <a href="/templates" style="color:inherit">browse the looks</a> and start from a template.</p>
           <details class="more"><summary>Where does it get published?</summary><div class="inner">
             <p class="hint" style="margin:0 0 10px">To a free Cloudflare account you own. The first time, your agent walks you through it: you click <em>create account</em> and <em>enable R2</em> in your own browser. No card. About five minutes, once.</p>
             <p class="hint" style="margin:0">Only want it on your machine? Say <b>keep it local</b> and skip the account entirely.</p>

--- a/landing/tornado-doc/v43/index.html
+++ b/landing/tornado-doc/v43/index.html
@@ -612,6 +612,7 @@
     </p>
     <div class="cta">
       <a class="btn btn-primary" href="/start"><span class="btn-in">Create your first doc</span></a>
+      <p style="margin:10px 0 0;font-size:14px;color:#767c8b">or <a href="/templates" style="color:inherit">browse the looks</a> first.</p>
     </div>
 
     <!-- tdoc demo: refined static mock (self-contained, hd- namespaced).
@@ -1085,12 +1086,13 @@
     </p>
     <div class="cta" style="justify-content:center">
       <a class="btn btn-primary" href="/start"><span class="btn-in">Create your first doc</span></a>
+      <p style="margin:10px 0 0;font-size:14px;color:#767c8b">or <a href="/templates" style="color:inherit">browse the looks</a> first.</p>
     </div>
   </section>
 
   <footer>
     <a href="https://github.com/tornado-doc/tdoc"><svg class="i" viewBox="0 0 24 24" aria-hidden="true"><use href="#i-github"/></svg>github.com/tornado-doc/tdoc</a>
-    &nbsp;·&nbsp; MIT &nbsp;·&nbsp; a Claude Code and Codex skill
+    &nbsp;·&nbsp; <a href="/templates">Templates</a> &nbsp;·&nbsp; MIT &nbsp;·&nbsp; a Claude Code and Codex skill
     <br><br>
     This page is a tdoc. Highlight a sentence, or hover the grid, and leave a comment.
   </footer>

--- a/worker/worker.js
+++ b/worker/worker.js
@@ -1436,7 +1436,7 @@ async function indexHtml(env, session, origin, nonce) {
 </head><body>
 <div class="wrap">
 <div class="page-hd"><h1>My docs</h1><button class="mk-btn" id="mk-open" type="button">Create a doc</button></div>
-${rows.length === 0 ? '<p class="empty">No published docs yet. Hit <b>Create a doc</b> to see how.</p>' :
+${rows.length === 0 ? '<p class="empty">No published docs yet. Hit <b>Create a doc</b> to see how, or <a href="/templates">browse templates</a> for a look to start from.</p>' :
   `<div class="toolbar">
     <input type="search" id="doc-search" placeholder="Search title or slug…" autocomplete="off" aria-label="Search docs">
   </div>
@@ -1461,7 +1461,7 @@ ${rows.length === 0 ? '<p class="empty">No published docs yet. Hit <b>Create a d
         <li>Send the link to anyone. They comment on the page, and your AI answers them.</li>
       </ol>
     </div>
-    <div class="mk-ft">Not set up yet? <a href="/start">Start here</a>.</div>
+    <div class="mk-ft">Want a specific look first? <a href="/templates">Browse templates</a>. &nbsp;·&nbsp; Not set up yet? <a href="/start">Start here</a>.</div>
   </div>
 </div>
 <script${nonce ? ` nonce="${nonce}"` : ''}>


### PR DESCRIPTION
Refs #204. Follows #205 (the `/templates` route).

## What

The `/templates` route landed in #205 but nothing linked to it. This wires it
into the three natural authoring moments, so a user finds the gallery exactly
when they're about to make a doc.

| Where | Link added |
|---|---|
| `/me` empty state | "…or **browse templates** for a look to start from" |
| `/me` Create-a-doc modal | footer: "Want a specific look first? **Browse templates**." |
| `/start` (landing/tdoc-start) | under the "Copy the line" CTA: "or **browse the looks** and start from a template" |
| landing (landing/tornado-doc) | a **Templates** link in the footer, and "or **browse the looks** first" under each "Create your first doc" CTA |

## Safety

- **All additive link insertions** — no restructuring, no existing copy
  reworded. Lowest-conflict way to touch these files.
- `/me` links are worker-rendered HTML (contained).
- The landing/start docs publish with the landing workflow on deploy.
- `worker.js` passes `node --check`; all 43 offline suites green (the
  `tornado-doc-landing` and `tdoc-start` tests still pass).

## Journey, now complete

```
want a doc → tdoc.dev (landing / /start / /me)
           → "Browse templates" → /templates
           → copy a prompt (style + topic slot at the end)
           → paste to agent → generate → publish → comment → regenerate
```
