### PR TITLE
fix: tdoc-agent-reply exits non-zero when a reply is rejected

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -96,6 +96,12 @@ file and `.claude-plugin/plugin.json`.
 
 ### Fixed
 
+- **`tdoc-agent-reply` fails loudly.** A rejected reply used to exit 0, so a
+  comment that was never answered looked answered. `curl -sS` exits 0 on HTTP
+  4xx/5xx, and the server also reports rejections as a 200 body with an
+  `error` key, so a `post_reply` helper now gates on both and both transports
+  propagate its failure. Accepted replies still exit 0 and still print the
+  server body. `#141`.
 - **Notification clicks open the target doc and comment.** Inbox rows
   go to `/d/<slug>/v/<n>?comment=<id>` (including from `/me` and `/`).
   Same-doc clicks no longer pin the card and then immediately unpin it

--- a/bin/tdoc-agent-reply
+++ b/bin/tdoc-agent-reply
@@ -105,6 +105,39 @@ PAYLOAD="$(jq -n \
   + (if $avatar != "" then {agent_avatar_url: $avatar} else {} end)
 ')"
 
+# Post the reply and gate on the outcome.
+#
+# Two things have to be checked or a rejected reply is indistinguishable from a
+# posted one: `curl -sS` exits 0 on HTTP 4xx/5xx (no --fail), and the server
+# also reports rejections as a 200 body carrying an "error" key
+# (e.g. {"error":"parent_not_found"}). Same shape as cf_api() in tdoc-publish.
+post_reply() {
+  local url="$1" tok="${2:-}"
+  local resp http body
+  if [ -n "$tok" ]; then
+    resp="$(curl -sS --max-time 20 -w $'\n%{http_code}' \
+      -X POST "$url" -H "Authorization: Bearer $tok" \
+      -H "Content-Type: application/json" -d "$PAYLOAD" 2>&1)" || {
+        echo "[tdoc] agent reply NOT posted: network error calling $url" >&2; return 1; }
+  else
+    resp="$(curl -sS --max-time 20 -w $'\n%{http_code}' \
+      -X POST "$url" -H "Content-Type: application/json" -d "$PAYLOAD" 2>&1)" || {
+        echo "[tdoc] agent reply NOT posted: network error calling $url" >&2; return 1; }
+  fi
+  http="${resp##*$'\n'}"        # last line = status code
+  body="${resp%$'\n'*}"         # everything before it = body
+  printf '%s\n' "$body"
+  if ! printf '%s' "$http" | grep -qE '^2[0-9][0-9]$'; then
+    echo "[tdoc] agent reply NOT posted: $url returned HTTP $http" >&2
+    return 1
+  fi
+  if printf '%s' "$body" | jq -e 'type == "object" and has("error")' >/dev/null 2>&1; then
+    echo "[tdoc] agent reply NOT posted: $(printf '%s' "$body" | jq -r '.error')" >&2
+    return 1
+  fi
+  return 0
+}
+
 CONFIG_FILE="$HOME/.tdoc/published.json"
 if [ -f "$CONFIG_FILE" ]; then
   PLATFORM="$(jq -r '.platform // "cloudflare"' "$CONFIG_FILE")"
@@ -117,17 +150,10 @@ if [ -f "$CONFIG_FILE" ]; then
     BASE="https://${WORKER}.${SUBDOMAIN}.workers.dev"
   fi
   if [ -n "$TOKEN" ] && [ -n "$BASE" ] && [ "$BASE" != "https://." ]; then
-    curl -sS --max-time 20 -X POST "${BASE}/api/agent/reply" \
-      -H "Authorization: Bearer $TOKEN" \
-      -H "Content-Type: application/json" \
-      -d "$PAYLOAD"
-    echo
+    post_reply "${BASE}/api/agent/reply" "$TOKEN" || exit 1
     exit 0
   fi
 fi
 
 TDOC_PORT="${TDOC_PORT:-7878}"
-curl -sS --max-time 20 -X POST "http://localhost:${TDOC_PORT}/api/agent/reply" \
-  -H "Content-Type: application/json" \
-  -d "$PAYLOAD"
-echo
+post_reply "http://localhost:${TDOC_PORT}/api/agent/reply" || exit 1

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -13,7 +13,7 @@
 const fs = require('fs');
 const os = require('os');
 const path = require('path');
-const { execFileSync, spawnSync } = require('child_process');
+const { execFileSync, spawn, spawnSync } = require('child_process');
 
 let pass = 0, fail = 0;
 function ok(n) { console.log(`  ✓ ${n}`); pass++; }
@@ -343,6 +343,87 @@ t('tdoc-update-nag real git: ahead-only is silent, behind nags, both diverge', (
     } finally {
       fs.rmSync(root, { recursive: true, force: true });
     }
+  }
+});
+
+// ---- tdoc-agent-reply must not report success on a rejected reply (#141) ----
+
+t('tdoc-agent-reply gates on HTTP status and on 200-with-error bodies', () => {
+  const src = readBin('tdoc-agent-reply');
+  assert(/post_reply\(\)/.test(src), 'post_reply helper missing');
+  assert(/http_code/.test(src) && /grep -qE '\^2/.test(src),
+    'post_reply does not gate on 2xx HTTP status');
+  assert(/has\("error"\)/.test(src),
+    'post_reply does not reject a 200 body carrying an "error" key');
+  // Both transports must go through the helper and propagate its failure.
+  const calls = src.split('\n').filter(l => /^\s*post_reply /.test(l));
+  assert(calls.length === 2, `expected 2 post_reply call sites, got ${calls.length}`);
+  for (const c of calls) assert(/\|\| exit 1/.test(c), `call site swallows failure: ${c.trim()}`);
+  // No raw curl POST to the reply endpoint left outside the helper.
+  const raw = src.split('\n').filter(l =>
+    /\bcurl\b/.test(l) && /api\/agent\/reply/.test(l) && !l.trim().startsWith('#'));
+  assert(raw.length === 0, `raw curl to /api/agent/reply outside post_reply:\n      ${raw.join('\n      ')}`);
+});
+
+t('tdoc-agent-reply exits non-zero when the server rejects the reply', () => {
+  const bin = path.join(BIN, 'tdoc-agent-reply');
+  const home = fs.mkdtempSync(path.join(os.tmpdir(), 'tdoc-reply-home-'));
+  const port = 7900 + Math.floor(Math.random() * 300);
+  // Stub the reply endpoint: 200 with an error body, exactly what the server
+  // returns for an unknown parent. That is the case the bug reported.
+  const stub = spawn(process.execPath, ['-e',
+    `require('http').createServer((q,s)=>{` +
+    `s.writeHead(200,{'content-type':'application/json'});` +
+    `s.end(JSON.stringify({error:'parent_not_found'}));` +
+    `}).listen(${port},'127.0.0.1');`], { stdio: 'ignore' });
+  try {
+    const up = spawnSync('bash', ['-c',
+      `for i in $(seq 1 100); do curl -sS -o /dev/null --max-time 1 ` +
+      `-X POST http://127.0.0.1:${port}/ping && exit 0; sleep 0.05; done; exit 1`],
+      { encoding: 'utf8', timeout: 15000 });
+    assert(up.status === 0, 'stub server never came up');
+
+    const r = spawnSync(bin, ['--slug', 'tornado-doc', '--parent', 'c_missing',
+      '--text', 'applied', '--status', 'applied'], {
+      env: { ...process.env, HOME: home, TDOC_PORT: String(port) },
+      encoding: 'utf8', timeout: 20000,
+    });
+    assert(r.status !== 0,
+      `rejected reply still exited ${r.status}; stdout=${r.stdout} stderr=${r.stderr}`);
+    assert(/parent_not_found/.test(r.stdout + r.stderr),
+      `server error not surfaced: ${r.stdout} ${r.stderr}`);
+    assert(/NOT posted/.test(r.stderr), `no failure line on stderr: ${r.stderr}`);
+  } finally {
+    stub.kill();
+    fs.rmSync(home, { recursive: true, force: true });
+  }
+});
+
+t('tdoc-agent-reply still exits 0 when the reply is accepted', () => {
+  const bin = path.join(BIN, 'tdoc-agent-reply');
+  const home = fs.mkdtempSync(path.join(os.tmpdir(), 'tdoc-reply-home-'));
+  const port = 8300 + Math.floor(Math.random() * 300);
+  const stub = spawn(process.execPath, ['-e',
+    `require('http').createServer((q,s)=>{` +
+    `s.writeHead(200,{'content-type':'application/json'});` +
+    `s.end(JSON.stringify({id:'c_1',replies:[],reactions:{}}));` +
+    `}).listen(${port},'127.0.0.1');`], { stdio: 'ignore' });
+  try {
+    const up = spawnSync('bash', ['-c',
+      `for i in $(seq 1 100); do curl -sS -o /dev/null --max-time 1 ` +
+      `-X POST http://127.0.0.1:${port}/ping && exit 0; sleep 0.05; done; exit 1`],
+      { encoding: 'utf8', timeout: 15000 });
+    assert(up.status === 0, 'stub server never came up');
+
+    const r = spawnSync(bin, ['--slug', 'tornado-doc', '--parent', 'c_1', '--text', 'ok'], {
+      env: { ...process.env, HOME: home, TDOC_PORT: String(port) },
+      encoding: 'utf8', timeout: 20000,
+    });
+    assert(r.status === 0, `accepted reply exited ${r.status}; stderr=${r.stderr}`);
+    assert(/"id":"c_1"/.test(r.stdout), `server body not passed through: ${r.stdout}`);
+  } finally {
+    stub.kill();
+    fs.rmSync(home, { recursive: true, force: true });
   }
 });
 


### PR DESCRIPTION
Refs #141.

## The bug

```
$ ./bin/tdoc-agent-reply --slug tornado-doc --parent c_1786849762647 --text "..."
{"error":"parent_not_found"}
$ echo $?
0
```

A comment that was never answered is indistinguishable from one that was.

## Why it happened — two independent reasons

1. **`curl -sS` has no `--fail`**, so it exits 0 on HTTP 4xx/5xx. `set -e` cannot catch what curl reports as success.
2. **The server also rejects with a 200** carrying an `error` key (`{"error":"parent_not_found"}`), which no exit code reflects at all.

On top of both, each transport ended with an unconditional `exit 0` (hosted, `:125`) or fell off the end of the script (localhost), discarding curl's status either way.

## The fix

A `post_reply` helper, deliberately the **same shape as `cf_api` in `tdoc-publish`** rather than a parallel invention — captures the body plus `%{http_code}`, prints the body on stdout exactly as before, and returns non-zero on a non-2xx status **or** on a 200 body with an `error` key. Both transports call it and propagate failure with `|| exit 1`.

Failure lines go to **stderr** and are prefixed `[tdoc] agent reply NOT posted:`, so stdout stays parseable for callers that read the JSON.

**Accepted replies are unchanged:** exit 0, server body on stdout.

## Tests

| Test | Covers |
|---|---|
| `gates on HTTP status and on 200-with-error bodies` | helper exists, gates on 2xx and on the `error` key, both call sites use it, no raw curl to `/api/agent/reply` left behind |
| `exits non-zero when the server rejects the reply` | stub returns 200 + `{"error":"parent_not_found"}` → non-zero exit, reason surfaced |
| `still exits 0 when the reply is accepted` | guards against over-correcting into false failures |

**Negative control:** the two new failing-path tests were run against the pre-fix script and do fail there (`20 passed, 2 failed`), so they are testing the fix and not passing vacuously.

`npm test` — 43 suites green. `shellcheck --severity=warning --exclude=SC2034` clean on the changed script.

## Not doing

- Adding `bin/tdoc-agent-reply` to the CI shellcheck list — it is currently absent from that gate, but that is a separate change and shellcheck would not have caught this bug anyway.
- Auditing the other `bin/*` scripts for the same pattern.