### PR TITLE
header: live GitHub star count on the landing

### DIFF
--- a/server/overlay.js
+++ b/server/overlay.js
@@ -422,9 +422,10 @@
   /* Site mark — the tdoc logo (same asset as the favicon), not a text pill. */
   .tdoc-bar button.tdoc-bar-mark { width: 32px; height: 32px; padding: 0; border-radius: 8px; background: transparent; }
   .tdoc-bar-mark img { width: 24px; height: 24px; display: block; }
-  .tdoc-bar .tdoc-github-btn { display: inline-flex; align-items: center; justify-content: center; width: 32px; height: 32px; padding: 0; border-radius: 8px; color: #555; }
+  .tdoc-bar .tdoc-github-btn { display: inline-flex; align-items: center; gap: 5px; height: 32px; padding: 0 9px; border-radius: 8px; color: #555; font: 600 12.5px/1 -apple-system, system-ui, sans-serif; }
   .tdoc-bar .tdoc-github-btn:hover { background: #f0f1f4; color: #1a1a1a; }
   .tdoc-bar .tdoc-github-btn svg { display: block; }
+  .tdoc-bar .tdoc-gh-stars { color: #444; }
 
   /* Breadcrumb: workspace · slug · v3 — separated by " / ". */
   .tdoc-bar .crumb { color: #555; font-weight: 500; padding: 4px 6px; border-radius: 6px; max-width: 24ch; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
@@ -980,9 +981,11 @@
       <svg class="tdoc-theme-icon-sun" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="4"/><path d="M12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M4.93 19.07l1.41-1.41M17.66 6.34l1.41-1.41"/></svg>
     </button>`;
 
+  const ghStars = (typeof cfg.stars === 'number' && cfg.stars >= 0) ? cfg.stars : null;
+  const ghStarText = ghStars === null ? '' : (ghStars >= 1000 ? (ghStars / 1000).toFixed(1).replace(/\.0$/, '') + 'k' : String(ghStars));
   const githubBtnHtml = `
-    <a class="tdoc-github-btn" id="tdoc-github-btn" href="https://github.com/tornado-doc/tdoc" target="_blank" rel="noopener" title="tdoc on GitHub" aria-label="tdoc on GitHub">
-      <svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27s1.36.09 2 .27c1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.01 8.01 0 0 0 16 8c0-4.42-3.58-8-8-8z"/></svg>
+    <a class="tdoc-github-btn" id="tdoc-github-btn" href="https://github.com/tornado-doc/tdoc" target="_blank" rel="noopener" title="${ghStars === null ? 'tdoc on GitHub' : ghStars + ' stars on GitHub'}" aria-label="tdoc on GitHub">
+      <svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27s1.36.09 2 .27c1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.01 8.01 0 0 0 16 8c0-4.42-3.58-8-8-8z"/></svg>${ghStarText ? `<span class="tdoc-gh-stars">${ghStarText}</span>` : ''}
     </a>`;
 
   const rightHtml = `

--- a/server/server.js
+++ b/server/server.js
@@ -274,6 +274,17 @@ function forceWidgetSandbox(html) {
   });
 }
 
+// Local preview of the landing header's live star count. Production fetches
+// this in the Cloudflare Worker (edge-cached); here we just refresh hourly.
+let cachedStars = null;
+async function refreshStars() {
+  try {
+    const r = await fetch('https://api.github.com/repos/tornado-doc/tdoc', { headers: { 'User-Agent': 'tdoc-local', 'Accept': 'application/vnd.github+json' } });
+    if (r.ok) { const d = await r.json(); const n = Number(d && d.stargazers_count); if (Number.isFinite(n)) cachedStars = n; }
+  } catch {}
+}
+refreshStars(); const _starTimer = setInterval(refreshStars, 3600e3); if (_starTimer.unref) _starTimer.unref();
+
 function injectOverlay(html, slug, version, nonce) {
   html = forceWidgetSandbox(html);
   if (ONBOARD_SLUGS.has(slug)) {
@@ -310,6 +321,8 @@ function injectOverlay(html, slug, version, nonce) {
     identity: ident,
     isOwner: !!(ident && E2E_OWNER && ident.login.toLowerCase() === E2E_OWNER.toLowerCase()),
     authConfigured: !!ident, mode: 'local', versions,
+    isLanding: slug === 'tornado-doc',
+    stars: cachedStars,
   })};</script>`;
   const inject = `${cfg}\n<script${nonceAttr}>${overlay}</script>`;
   if (html.includes('</body>')) return html.replace('</body>', `${inject}\n</body>`);

--- a/worker/worker.js
+++ b/worker/worker.js
@@ -1100,7 +1100,7 @@ function injectReaderCss(html, css) {
   return tag + html;
 }
 
-function injectOverlay(rawHtml, slug, version, identity, versions, isOwner, ownerManage, nonce, isLanding, canSeeMyDocsFlag, isCatalog, webAuth) {
+function injectOverlay(rawHtml, slug, version, identity, versions, isOwner, ownerManage, nonce, isLanding, canSeeMyDocsFlag, isCatalog, webAuth, stars) {
   // The onboarding modal is product UI, so it ships from here under the page
   // nonce. The doc's own <script> would never run (#138), which is why the
   // landing CTA still carries a plain href: with scripting off the visitor
@@ -1123,6 +1123,8 @@ function injectOverlay(rawHtml, slug, version, identity, versions, isOwner, owne
     // version number are storage detail; printing them in the bar tells a
     // first-time visitor they are looking at somebody's document.
     isLanding: !!isLanding,
+    // Live GitHub star count for the landing header (null when unknown).
+    stars: (typeof stars === 'number' ? stars : null),
     // /me catalog: same overlay bar, no Share / Duplicate / Copy.
     isCatalog: !!isCatalog,
     // Always null for non-owners (never just omitted-but-truthy-elsewhere) so
@@ -1165,6 +1167,27 @@ const SIGNIN_JS = `__TDOC_SIGNIN_JS__`;
 // Returns { ok, response }. `ok:false` carries the real 401/403/404 response
 // for the /d/ route to pass through; the homepage ignores it and falls back to
 // the neutral page, because `/` must never dead-end on an access screen.
+// Live GitHub star count for the landing header. Fetched server-side because
+// the doc CSP (default-src 'none') blocks a browser fetch to api.github.com.
+// Cached at the edge for an hour via cf.cacheTtl, so it is one refresh per hour
+// per POP, not per pageview — GitHub's rate limit is never in play. Best-effort:
+// any failure returns null and the header simply shows the mark with no count.
+async function fetchStars(env) {
+  const repo = (env && env.GITHUB_REPO) || 'tornado-doc/tdoc';
+  try {
+    const r = await fetch(`https://api.github.com/repos/${repo}`, {
+      headers: { 'User-Agent': 'tdoc-landing', 'Accept': 'application/vnd.github+json' },
+      cf: { cacheTtl: 3600, cacheEverything: true },
+    });
+    if (!r.ok) return null;
+    const d = await r.json();
+    const n = Number(d && d.stargazers_count);
+    return Number.isFinite(n) ? n : null;
+  } catch {
+    return null;
+  }
+}
+
 async function serveDocVersion(env, req, slug, version, isLanding) {
   const gate = await enforceDocAccess(env, req, slug, version);
   if (!gate.ok) return { ok: false, response: gate.response };
@@ -1204,9 +1227,10 @@ async function serveDocVersion(env, req, slug, version, isLanding) {
     ownerManage = { access: gate.access, versionCount: versions.length, commentCount };
   }
   const nonce = rand(16);
+  const stars = isLanding ? await fetchStars(env) : null;
   return {
     ok: true,
-    response: html(injectOverlay(raw, slug, version, identity, versions, isOwner, ownerManage, nonce, isLanding, canSeeMyDocs(env, session, requestOrigin(req)), false, !!env.GITHUB_CLIENT_SECRET), {
+    response: html(injectOverlay(raw, slug, version, identity, versions, isOwner, ownerManage, nonce, isLanding, canSeeMyDocs(env, session, requestOrigin(req)), false, !!env.GITHUB_CLIENT_SECRET, stars), {
       headers: { 'Content-Security-Policy': cspHeader(nonce) },
     }),
   };


### PR DESCRIPTION
The landing header showed a bare GitHub mark; now it shows the repo's **live star count** (`★ N`).

The doc CSP is `default-src 'none'`, so a browser fetch to `api.github.com` is blocked. The count is fetched **server-side** instead:
- **`worker.js`** — `fetchStars()` calls the GitHub API, **edge-cached ~1h** via `cf.cacheTtl` (one refresh per hour per POP, nowhere near the rate limit), and injects it into the overlay config as `stars`, for the landing only.
- **`overlay.js`** — the header GitHub button renders the count (k-formatted) after the mark.
- **`server.js`** — the local dev server fetches + injects the same, so it's previewable locally (verified: shows `103`).

Best-effort: any failure leaves `stars` null and the button falls back to the bare mark. `npm test` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)