### PR TITLE
Reach version switching from the ⋯ menu on phones

### DIFF
--- a/server/overlay.js
+++ b/server/overlay.js
@@ -459,6 +459,17 @@
   .tdoc-menu button:hover, .tdoc-secondary-menu button:hover, .tdoc-version-menu button:hover { background: #f0f1f4; }
   .tdoc-version-menu button.current { color: var(--td-accent); font-weight: 600; }
 
+  /* Version switcher folded into the ⋯ overflow menu. The inline version chip
+     is hidden at <700px (phones), so surface the same list here — otherwise
+     there is no way to switch versions on a phone. Shown only at that width;
+     wider layouts keep the inline chip. */
+  .tdoc-secondary-menu .tdoc-sec-versions { display: none; }
+  @media (max-width: 700px) { .tdoc-secondary-menu .tdoc-sec-versions { display: block; } }
+  .tdoc-secondary-menu .tdoc-sec-label { padding: 6px 10px 2px; font: 600 11px system-ui, sans-serif; color: #8a8a8a; text-transform: uppercase; letter-spacing: .04em; }
+  .tdoc-secondary-menu .tdoc-sec-version { font-family: ui-monospace, "SF Mono", Menlo, monospace; }
+  .tdoc-secondary-menu .tdoc-sec-version.current { color: var(--td-accent); font-weight: 600; }
+  .tdoc-secondary-menu .tdoc-sec-sep { border-top: 1px solid #eee; margin: 4px 6px; }
+
   .tdoc-menu-wrap { position: relative; display: inline-block; }
   /* Overflow ⋯ button shows on narrow viewports. */
   .tdoc-bar .tdoc-secondary-toggle { display: none; padding: 6px 10px; }
@@ -1008,6 +1019,11 @@
     ${!isSiteBar && (isPublished || isFork) ? `<div class="tdoc-menu-wrap">
       <button class="tdoc-secondary-toggle" id="tdoc-more-btn" aria-label="More" title="More">⋯</button>
       <div class="tdoc-secondary-menu" id="tdoc-secondary-menu">
+        ${versions.length > 1 ? `<div class="tdoc-sec-versions" role="group" aria-label="Version">
+          <div class="tdoc-sec-label">Version</div>
+          ${versions.map(v => `<button role="option" data-version="${v.n}" class="tdoc-sec-version${v.n === version ? ' current' : ''}">v${v.n}${v.n === version ? ' · current' : ''}</button>`).join('')}
+          <div class="tdoc-sec-sep"></div>
+        </div>` : ''}
         ${isPublished ? '<button data-action="duplicate">Duplicate</button><button data-action="download">Download HTML</button><button data-action="download-pdf">Download PDF</button>' : ''}
         ${isFork ? '<button data-action="saveas">Download HTML</button><button data-action="download-pdf">Download PDF</button>' : ''}
       </div>
@@ -1273,6 +1289,12 @@
       b.onclick = (e) => {
         e.stopPropagation();
         secMenu.classList.remove('open');
+        // Version rows (folded in from the inline chip on phones) navigate.
+        if (b.dataset.version != null) {
+          const vn = Number(b.dataset.version);
+          if (Number.isFinite(vn) && vn !== version) location.href = `/d/${encodeURIComponent(slug)}/v/${vn}`;
+          return;
+        }
         if (b.dataset.action === 'duplicate') duplicateDoc();
         if (b.dataset.action === 'download' || b.dataset.action === 'saveas') downloadExport();
         if (b.dataset.action === 'download-pdf') startDownload('pdf');


### PR DESCRIPTION
## Problem

On the mobile top bar, the inline **version chip** (`v2 ▾`) is hidden at `<700px` — but the version list was never surfaced anywhere else. So on a phone there was **no way to switch versions** of a published doc.

(The other bar actions were already reachable on phones: Duplicate / Download HTML / Download PDF live in the `⋯` overflow menu, and the identity chip collapses to just the avatar.)

## Fix

Fold the version list into the `⋯` overflow menu, gated to the **same `<700px` breakpoint** where the inline chip hides — wider layouts keep the inline chip untouched. The current version is marked `· current`, and tapping a row navigates to `/d/<slug>/v/<n>`, exactly like the inline picker.

## Verification

- `node test/run.js` — all 43 offline suites green.
- Standalone Playwright drive at **375×812** against a published, 3-version fixture confirms:
  - inline version chip hidden ✅
  - `⋯` button visible ✅
  - opening `⋯` shows the version section with all 3 versions, current one marked ✅
  - tapping **v2** navigates to `/d/demo/v/2` ✅
- The 3 pre-existing `responsive.test.js` failures ("More button not visible" on the *local unpublished* fixture) are unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)