### PR TITLE
ci(preview): set preview upload token with versions secret put

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -124,7 +124,15 @@ jobs:
           TDOC_PREVIEW_UPLOAD_TOKEN: ${{ secrets.TDOC_PREVIEW_UPLOAD_TOKEN }}
         working-directory: worker
         run: |
-          printf '%s' "$TDOC_PREVIEW_UPLOAD_TOKEN" | wrangler secret put TDOC_UPLOAD_TOKEN --name tdoc-preview
+          # Must be the *versions* variant. Previews ship via `wrangler versions
+          # upload` (next step), which uploads a new version WITHOUT deploying
+          # it — so after the first PR the worker's latest version is never the
+          # deployed one. Plain `wrangler secret put` refuses in that state
+          # ("the latest version of your Worker isn't currently deployed",
+          # guarding against an accidental deploy), which failed this job on
+          # every PR. `versions secret put` updates the secret at the version
+          # level and is inherited by the version uploaded next.
+          printf '%s' "$TDOC_PREVIEW_UPLOAD_TOKEN" | wrangler versions secret put TDOC_UPLOAD_TOKEN --name tdoc-preview
 
       - name: Upload version with pr-N alias
         id: upload


### PR DESCRIPTION
## Problem

The **`publish PR preview`** check has failed on essentially every PR (after the first) with:

> Secret edit failed … the latest version of your Worker isn't currently deployed.

### Root cause

`.github/workflows/preview.yml` ships previews with **`wrangler versions upload`**, which uploads a new Worker version **without deploying it**. After the first PR, the preview Worker's *latest* version is therefore never the *deployed* one. Plain **`wrangler secret put`** refuses in exactly that state — editing a secret would implicitly deploy the not-yet-deployed latest version, so Cloudflare guards against it. That guard is what fails the job.

## Fix

Switch the token step to the **version-level** command:

```
wrangler versions secret put TDOC_UPLOAD_TOKEN --name tdoc-preview
```

It updates the secret at the version level (no deploy required) and is inherited by the version uploaded in the next step. **Infra/CI only — no product code change.**

## Verification

This PR modifies `preview.yml`, so **its own `publish PR preview` run exercises the fix directly** — a green check here is the verification. (The required `offline test suite` check is unaffected.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)