### PR TITLE
fix: tdoc-agent-reply resolves the hosted base from .base

### DIFF
--- a/bin/tdoc-agent-reply
+++ b/bin/tdoc-agent-reply
@@ -140,14 +140,24 @@ post_reply() {
 
 CONFIG_FILE="$HOME/.tdoc/published.json"
 if [ -f "$CONFIG_FILE" ]; then
+  # Resolve the API base for the configured platform: hosted/vercel configs store
+  # the URL directly in `.base`; cloudflare configs derive workers.dev. Matches
+  # tdoc-pull / tdoc-unpublish. Hosted used to fall into the cloudflare branch
+  # and read absent .subdomain/.worker, producing https://null.null.workers.dev
+  # and a 404 on every reply — silently, for every hosted user.
   PLATFORM="$(jq -r '.platform // "cloudflare"' "$CONFIG_FILE")"
   TOKEN="$(jq -r '.upload_token // empty' "$CONFIG_FILE")"
-  if [ "$PLATFORM" = "vercel" ]; then
+  if [ "$PLATFORM" = "hosted" ] || [ "$PLATFORM" = "vercel" ]; then
     BASE="$(jq -r '.base // empty' "$CONFIG_FILE")"
+    if [ "$BASE" = "null" ]; then BASE=""; fi
   else
-    SUBDOMAIN="$(jq -r .subdomain "$CONFIG_FILE")"
-    WORKER="$(jq -r .worker "$CONFIG_FILE")"
-    BASE="https://${WORKER}.${SUBDOMAIN}.workers.dev"
+    SUBDOMAIN="$(jq -r '.subdomain // empty' "$CONFIG_FILE")"
+    WORKER="$(jq -r '.worker // empty' "$CONFIG_FILE")"
+    if [ -n "$SUBDOMAIN" ] && [ -n "$WORKER" ]; then
+      BASE="https://${WORKER}.${SUBDOMAIN}.workers.dev"
+    else
+      BASE=""
+    fi
   fi
   if [ -n "$TOKEN" ] && [ -n "$BASE" ] && [ "$BASE" != "https://." ]; then
     post_reply "${BASE}/api/agent/reply" "$TOKEN" || exit 1

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -565,5 +565,67 @@ t('tdoc-agent-reply still exits 0 when the reply is accepted', () => {
   }
 });
 
+
+// ---- tdoc-agent-reply must resolve the hosted base from .base (#226) ----
+// Before the fix, `platform: "hosted"` fell into the cloudflare branch and read
+// absent .subdomain/.worker, producing https://null.null.workers.dev -> 404.
+
+t('tdoc-agent-reply posts to .base on a hosted config', () => {
+  const bin = path.join(BIN, 'tdoc-agent-reply');
+  const home = fs.mkdtempSync(path.join(os.tmpdir(), 'tdoc-reply-hosted-'));
+  const port = 8700 + Math.floor(Math.random() * 300);
+  fs.mkdirSync(path.join(home, '.tdoc'), { recursive: true });
+  // A real hosted config: .base and .upload_token, and deliberately NO
+  // .subdomain / .worker — that absence is what the bug tripped over.
+  fs.writeFileSync(path.join(home, '.tdoc', 'published.json'), JSON.stringify({
+    platform: 'hosted',
+    base: `http://127.0.0.1:${port}`,
+    public_host: '127.0.0.1',
+    upload_token: 'tok_test',
+  }));
+  // Record the path the reply actually arrives on, so a request that never
+  // leaves for the right host cannot pass.
+  const stub = spawn(process.execPath, ['-e',
+    `require('http').createServer((q,s)=>{` +
+    `s.writeHead(200,{'content-type':'application/json'});` +
+    `s.end(JSON.stringify({id:'c_hosted',path:q.url,replies:[],reactions:{}}));` +
+    `}).listen(${port},'127.0.0.1');`], { stdio: 'ignore' });
+  try {
+    const up = spawnSync('bash', ['-c',
+      `for i in $(seq 1 100); do curl -sS -o /dev/null --max-time 1 ` +
+      `-X POST http://127.0.0.1:${port}/ping && exit 0; sleep 0.05; done; exit 1`],
+      { encoding: 'utf8', timeout: 15000 });
+    assert(up.status === 0, 'stub server never came up');
+
+    const r = spawnSync(bin, ['--slug', 'tornado-doc', '--parent', 'c_1', '--text', 'ok'], {
+      env: { ...process.env, HOME: home }, encoding: 'utf8', timeout: 20000,
+    });
+    assert(r.status === 0, `hosted reply exited ${r.status}; stderr=${r.stderr}`);
+    assert(/"id":"c_hosted"/.test(r.stdout),
+      `reply did not reach the hosted base: stdout=${r.stdout} stderr=${r.stderr}`);
+    assert(/"path":"\/api\/agent\/reply"/.test(r.stdout),
+      `reply hit the wrong path: ${r.stdout}`);
+    assert(!/workers\.dev/.test(r.stdout + r.stderr),
+      `hosted config still derived a workers.dev host: ${r.stderr}`);
+  } finally {
+    stub.kill();
+    fs.rmSync(home, { recursive: true, force: true });
+  }
+});
+
+t('tdoc-agent-reply base resolution matches tdoc-pull across platforms', () => {
+  const src = readBin('tdoc-agent-reply');
+  // hosted and vercel both read .base; cloudflare/legacy still derive workers.dev.
+  assert(/\[ "\$PLATFORM" = "hosted" \] \|\| \[ "\$PLATFORM" = "vercel" \]/.test(src),
+    'hosted is not on the .base side of the platform branch');
+  assert(/BASE="https:\/\/\$\{WORKER\}\.\$\{SUBDOMAIN\}\.workers\.dev"/.test(src),
+    'cloudflare no longer derives the workers.dev base');
+  assert(/\.platform \/\/ "cloudflare"/.test(src),
+    'legacy configs without .platform no longer default to cloudflare');
+  // A missing field must not become the literal string "null" in a hostname.
+  assert(/'\.subdomain \/\/ empty'/.test(src) && /'\.worker \/\/ empty'/.test(src),
+    'subdomain/worker are read without an // empty guard, so jq can yield "null"');
+});
+
 console.log(`\n${pass} passed, ${fail} failed`);
 process.exit(fail ? 1 : 0);


### PR DESCRIPTION
## What & why

Fixes #226.

`bin/tdoc-agent-reply` branched on `vercel` vs everything-else, so `platform: "hosted"` fell into the cloudflare branch and read `.subdomain` / `.worker` — keys a hosted `~/.tdoc/published.json` does not have. `jq -r` returns the string `null` for a missing key, so the base became `https://null.null.workers.dev` and every reply 404'd.

That is silent breakage of the mandatory reply step in `/tdoc edit`, for every user on the default publish target. Before #216 it also exited 0, so it looked like it had worked.

`bin/tdoc-pull` and `bin/tdoc-unpublish` already resolve this correctly and carry an identical explanatory comment. This aligns the one sibling that never got the hosted branch — it copies the existing convention rather than inventing a parallel one.

Also guards the cloudflare branch with `// empty`, so a config missing its fields resolves to empty and falls back to localhost instead of fabricating a hostname out of two `null`s.

Resolution verified across every config shape:

| config | resolved base |
|---|---|
| `platform: hosted` | `https://tdoc.dev` |
| `platform: cloudflare` | `https://tdoc.acme.workers.dev` |
| `platform: vercel` | `https://tdoc-x.vercel.app` |
| legacy, no `platform` key | `https://tdoc.acme.workers.dev` (unchanged) |
| cloudflare missing fields | empty → localhost fallback |

### Tests

Two regression tests in `test/cli.test.js`, in the same style as the existing #141 block:

- **behavioural, hermetic, offline** — a hosted config whose `.base` points at a stub server; the reply must arrive at `/api/agent/reply` on that base, and nothing may mention `workers.dev`.
- **static** — hosted sits on the `.base` side of the branch, cloudflare/legacy still derive `workers.dev`, and both fields are read with an `// empty` guard.

Both fail against the pre-fix script (verified by reverting the fix: `29 passed, 2 failed`) and pass with it.

## Checklist

- [x] `npm test` passes locally (offline suite) — `PASS — all 43 suite(s) green`.
- [x] Browser-facing / worker code untouched — this is a `bin/` script only, so the gated Playwright suites do not apply.
- [x] `SKILL.md` not edited, so no copy to `skills/tdoc/SKILL.md` needed.
- [x] No version change.

## Security note

Touches `bin/tdoc-agent-reply`, which handles the upload token. The change is confined to choosing the destination host; it does not alter how the token is read, stored, or attached. It strictly narrows where the token can be sent: previously a hosted config produced an attacker-registrable third-party hostname (`null.null.workers.dev`) and POSTed the `Authorization` header to it. Now hosted sends only to the operator-configured `.base`, and a malformed cloudflare config resolves to empty and falls back to localhost rather than to a fabricated host. No change to untrusted-input handling or to the reply body.