### PR TITLE
bar: make ⋯ the permanent home for Duplicate / Download

### DIFF
--- a/server/overlay.js
+++ b/server/overlay.js
@@ -471,8 +471,12 @@
   .tdoc-secondary-menu .tdoc-sec-sep { border-top: 1px solid #eee; margin: 4px 6px; }
 
   .tdoc-menu-wrap { position: relative; display: inline-block; }
-  /* Overflow ⋯ button shows on narrow viewports. */
-  .tdoc-bar .tdoc-secondary-toggle { display: none; padding: 6px 10px; }
+  /* Overflow ⋯ button is the single home for the secondary doc actions at
+     every width. Duplicate / Download / Save-as exist in the bar markup for
+     the export and fork chrome checks, but never show inline — the ⋯ menu
+     already carries the same actions. */
+  .tdoc-bar .tdoc-secondary-toggle { display: inline-flex; padding: 6px 10px; }
+  .tdoc-bar #tdoc-duplicate-btn, .tdoc-bar #tdoc-download-wrap, .tdoc-bar #tdoc-saveas-btn { display: none; }
   /* Identity chip — avatar + name (name hides on narrow). */
   .tdoc-chip { display: inline-flex; align-items: center; gap: 8px; padding: 3px 12px 3px 3px; background: #f0f1f4; border-radius: 999px; cursor: pointer; color: #1a1a1a; font: inherit; border: none; position: relative; }
   .tdoc-chip:hover { background: #e5e6ea; }
@@ -773,6 +777,8 @@
   /* Bar collapse breakpoints — tied to viewport width, not layout class.
      The bar progressively hides elements as the viewport tightens, so it
      stays elegant at every size.
+     ⋯ is present at every width and holds Duplicate / Download, so the bar
+     only ever sheds identity and breadcrumb detail as it tightens.
        ≥1100px: logo · slug · v · title ……………… identity · share · ⋯
        <1100px: logo ·      · v · title ……………… identity · share · ⋯  (slug hides)
        < 900px: logo ·      · v · title ……………… avatar   · share · ⋯  (name hides)
@@ -783,8 +789,6 @@
   @media (max-width: 900px) {
     .tdoc-chip .name { display: none; }
     .tdoc-chip { padding: 3px; }
-    .tdoc-bar #tdoc-duplicate-btn, .tdoc-bar #tdoc-download-wrap, .tdoc-bar #tdoc-saveas-btn { display: none; }
-    .tdoc-bar .tdoc-secondary-toggle { display: inline-flex; }
   }
   @media (max-width: 700px) {
     .tdoc-bar { padding: 0 8px; gap: 4px; }
@@ -796,8 +800,6 @@
 
   /* Narrow mode (drawer + FAB) — still driven by the layout evaluator so
      it can also kick in when the comment column would crowd the article. */
-  body.tdoc-narrow .tdoc-bar #tdoc-duplicate-btn, body.tdoc-narrow .tdoc-bar #tdoc-download-wrap, body.tdoc-narrow .tdoc-bar #tdoc-saveas-btn { display: none; }
-  body.tdoc-narrow .tdoc-bar .tdoc-secondary-toggle { display: inline-flex; }
   body.tdoc-narrow #tdoc-comment-layer { position: fixed; top: auto; left: 0; right: 0; bottom: 0; max-height: 70vh; width: 100%; pointer-events: auto; background: #fff; border-top: 1px solid #e5e5e5; box-shadow: 0 -4px 24px rgba(0,0,0,0.08); transform: translateY(100%); transition: transform .2s; overflow-y: auto; padding: 12px 12px 24px; box-sizing: border-box; z-index: 999998; }
   body.tdoc-narrow #tdoc-comment-layer.open { transform: translateY(0); }
   /* Backdrop scrim behind the mobile drawer. A dedicated element is what makes


### PR DESCRIPTION
Closes #230 (partially — see *Not in this PR* below).

## What & why

The ⋯ overflow menu already carried `duplicate` / `download` / `download-pdf` (and `saveas` on forks), but `.tdoc-secondary-toggle` was `display: none` by default and only revealed at `max-width: 900px` or under `body.tdoc-narrow`. Above 900px the bar instead carried Duplicate and a Download dropdown inline:

```
before (≥900px):  theme · Copy ▾ · Duplicate · Download ▾ · Share · avatar
after  (all):     theme · Copy ▾ · Share · ⋯ · avatar
```

Three secondary controls and two competing menus sat next to Share on desktop, while the phone layout already looked the way we'd want. This makes the phone behavior the behavior everywhere.

## The change

`server/overlay.js`, CSS only:

- `.tdoc-bar .tdoc-secondary-toggle` → `display: inline-flex` (was `none`)
- `.tdoc-bar #tdoc-duplicate-btn, #tdoc-download-wrap, #tdoc-saveas-btn` → `display: none`, unconditionally
- the two reveals that are now redundant are removed: the pair inside `@media (max-width: 900px)`, and the `body.tdoc-narrow` pair
- the breakpoint-ladder comment gains a line saying ⋯ is unconditional

Net −6 / +8 lines, no JS touched.

The inline buttons stay in the markup rather than being deleted. `test/duplicate-download.test.js` asserts the overlay source contains `id="tdoc-duplicate-btn"` / `id="tdoc-download-btn"`, `ui.test.js` asserts they exist with the right labels on published chrome, and `hosted-oob-behavior.test.js` asserts they are *absent* from an exported file. Hiding rather than removing keeps all three contracts intact.

## Tests

`npm test` — 43/43 suites green, which is what `test.yml` runs on `pull_request`.

The browser suites could not be run locally: `npx playwright install chromium` fails with `Playwright does not support chromium on mac13-arm64`. Reviewing what they would have covered:

- `responsive.test.js` asserts ⋯ **is** visible in narrow mode (still true) and never asserts it is hidden in wide mode, so the change is compatible.
- `ui.test.js` reaches Duplicate/Download with `page.$` and reads `textContent` — presence and labels only, no visibility check and no click — so hiding them keeps it green.
- Both suites' published-chrome assertions are `tPub`, which skips against the local fixture anyway.

If a maintainer with a working Playwright install can run `npm run test:all`, that would be worth confirming rather than taking my reading of it.

## Not in this PR

Step 3 of #230 — folding Copy's two modes into ⋯ and dropping the standalone control. It needs `#tdoc-copy-md-menu`'s `data-mode` handler reachable from `#tdoc-secondary-menu`, and it changes `ui.test.js`, which drives `#tdoc-copy-md-btn` with `page.click` and therefore needs it visible. That is a JS + test change and reviews better on its own.

Also left alone deliberately: the version group inside ⋯ stays hidden above 700px (`overlay.js:466-467`), so the inline version chip remains the desktop affordance. Switching versions is a reading action; Duplicate and Download are management actions. Happy to change that if you'd rather ⋯ owned it outright.

## Verification note

I could not produce a live screenshot of the result. Published chrome (`mode: 'published'`) only comes from the worker — `server/server.js:323` hardcodes `mode: 'local'`, `/fork` is a worker-only route, and `preview.yml` needs Cloudflare secrets that a fork PR cannot see. The change is confirmed at the CSS level by diffing the overlay served by a patched local server against a stock one.
