### PR TITLE
fix: let an agent comment status converge back to applied

### DIFF
--- a/test/event-convergence.test.js
+++ b/test/event-convergence.test.js
@@ -106,5 +106,75 @@ t('ORDERING: fold result is identical regardless of physical event order', () =>
   assert(inOrder.text === 'edited' && inOrder.status === 'applied');
 });
 
+
+// --- agent status is a toggle, and must converge back to applied (#229) ---
+// question/partial -> applied is the NORMAL progression: the agent asks, the
+// human answers, the agent applies. Under the old `<kind>:<at_version>` eid
+// that path could never converge, because marked_applied and marked_open sat
+// in two slots and dedupEvents re-seats each slot at its FIRST occurrence.
+
+t('marked_applied and marked_open share one eid slot (status is a toggle)', () => {
+  const applied = eventEid({ kind: 'marked_applied', at_version: 1 });
+  const open = eventEid({ kind: 'marked_open', at_version: 1 });
+  assert(applied === open,
+    `status kinds must share an eid, got ${applied} vs ${open}`);
+  // ...but not across versions, so snapshots stay immutable.
+  assert(eventEid({ kind: 'marked_open', at_version: 2 }) !== open,
+    'status eid must still include at_version');
+  // deleted is terminal, not a toggle — it keeps its own slot.
+  assert(eventEid({ kind: 'deleted', at_version: 1 }) !== open,
+    'deleted must not share the status slot');
+});
+
+t('CONVERGENCE: applied -> partial -> applied ends applied, not stuck open', () => {
+  const c = { id: 'c_1', created_in: 1, author: { login: 'u' }, text: 'q',
+    events: [{ kind: 'created', at_version: 1, at: 't0', eid: 'created:1' }] };
+  appendEvent(c, { kind: 'marked_applied', at_version: 1, at: 't1', applied_in: 1, by: 'claude', agent_status: 'applied' });
+  appendEvent(c, { kind: 'marked_open', at_version: 1, at: 't2', by: 'claude', agent_status: 'partial' });
+  appendEvent(c, { kind: 'marked_applied', at_version: 1, at: 't3', applied_in: 1, by: 'claude', agent_status: 'applied' });
+  const snap = snapshotAt(c, 1);
+  assert(snap.status === 'applied', `status stuck at "${snap.status}" after re-applying`);
+  assert(Object.keys(snap.reactions || {}).join('') === '✅',
+    `emoji is ${JSON.stringify(Object.keys(snap.reactions || {}))}, expected ✅`);
+});
+
+t('CONVERGENCE: question -> applied flips the verdict within one version', () => {
+  const c = { id: 'c_2', created_in: 2, author: { login: 'u' }, text: 'q',
+    events: [{ kind: 'created', at_version: 2, at: 't0', eid: 'created:2' }] };
+  appendEvent(c, { kind: 'marked_open', at_version: 2, at: 't1', by: 'claude', agent_status: 'question' });
+  appendEvent(c, { kind: 'marked_applied', at_version: 2, at: 't2', applied_in: 2, by: 'claude', agent_status: 'applied' });
+  const snap = snapshotAt(c, 2);
+  assert(snap.status === 'applied', `question->applied left status "${snap.status}"`);
+});
+
+t('a later marked_open still reopens an applied comment', () => {
+  // The toggle must work in both directions — converging must not mean
+  // "applied always wins".
+  const c = { id: 'c_3', created_in: 1, author: { login: 'u' }, text: 'q',
+    events: [{ kind: 'created', at_version: 1, at: 't0', eid: 'created:1' }] };
+  appendEvent(c, { kind: 'marked_applied', at_version: 1, at: 't1', applied_in: 1, by: 'claude', agent_status: 'applied' });
+  appendEvent(c, { kind: 'marked_open', at_version: 1, at: 't2', by: 'claude', agent_status: 'question' });
+  const snap = snapshotAt(c, 1);
+  assert(snap.status !== 'applied', 'a later marked_open must reopen the comment');
+});
+
+t('MIGRATION: events stored under the old <kind>:<version> eid are recomputed', () => {
+  // Real stored data: two status events written before this fix, each carrying
+  // the old eid. backfillEids must migrate both into the shared slot so the
+  // comment self-heals on the next fold rather than staying stuck.
+  const events = [
+    { kind: 'created', at_version: 1, at: 't0', eid: 'created:1' },
+    { kind: 'marked_applied', at_version: 1, at: 't1', applied_in: 1, by: 'claude', agent_status: 'applied', eid: 'marked_applied:1' },
+    { kind: 'marked_open', at_version: 1, at: 't2', by: 'claude', agent_status: 'partial', eid: 'marked_open:1' },
+    { kind: 'marked_applied', at_version: 1, at: 't3', applied_in: 1, by: 'claude', agent_status: 'applied', eid: 'marked_applied:1' },
+  ];
+  const changed = backfillEids(events);
+  assert(changed === true, 'backfillEids must report the eid format migration');
+  const statusEids = new Set(events.filter(e => e.kind.startsWith('marked_')).map(e => e.eid));
+  assert(statusEids.size === 1, `status events still in ${statusEids.size} slots: ${[...statusEids]}`);
+  const c = { id: 'c_4', created_in: 1, author: { login: 'u' }, text: 'q', events };
+  assert(snapshotAt(c, 1).status === 'applied', 'migrated legacy events did not converge');
+});
+
 console.log(`\n${pass} passed, ${fail} failed`);
 process.exit(fail ? 1 : 0);

--- a/worker/worker.js
+++ b/worker/worker.js
@@ -2098,7 +2098,8 @@ function ensureMigrated(list) {
 // DETERMINISTIC eid so a concurrent duplicate collapses to one:
 //   reaction add/remove → reaction:<emoji>:<by>:<at_version>      (toggle converges)
 //   reply reaction      → rreaction:<reply_id>:<emoji>:<by>:<at_version>
-//   marked_applied/open/deleted → <kind>:<at_version>       (state, not history)
+//   marked_applied/marked_open  → status:<at_version>       (state, not history)
+//   deleted                     → deleted:<at_version>      (terminal, not a toggle)
 // One-shot events (created, reply_added, text_edited, anchor_changed) get a
 // unique eid so each is preserved.
 //
@@ -2110,6 +2111,16 @@ function ensureMigrated(list) {
 //   - including at_version keeps each version's reaction independent, so a
 //     reaction on v1 and a different toggle on v3 don't clobber each other
 //     (snapshots stay immutable).
+//
+// Agent status eids drop the kind for the SAME reason (#229). marked_applied
+// and marked_open are a toggle, not two facts: an agent that answers a comment
+// with `question`, gets a reply, and then applies it emits [applied, open,
+// applied]. Under `<kind>:<at_version>` those landed in two slots, and because
+// dedupEvents re-seats each slot at its FIRST occurrence, the newest verdict
+// was carried but placed ahead of the older one — so `open` folded last and
+// won. The verdict could never converge back to applied within one version,
+// and question→applied is the normal progression, so ✅/🟡/❓ lied permanently.
+// `deleted` keeps its own slot: it is terminal, not a toggle.
 function eventEid(e) {
   switch (e.kind) {
     case 'reaction_added':
@@ -2120,6 +2131,7 @@ function eventEid(e) {
       return `rreaction:${e.reply_id}:${e.emoji}:${e.by}:${e.at_version}`;
     case 'marked_applied':
     case 'marked_open':
+      return `status:${e.at_version}`;
     case 'deleted':
       return `${e.kind}:${e.at_version}`;
     default:


### PR DESCRIPTION
## What & why

Fixes #229.

`marked_applied` and `marked_open` are a **toggle**, not two independent facts, but `eventEid` keyed them as `` `${e.kind}:${e.at_version}` `` — two separate slots. `dedupEvents` refreshes a slot's *value* with the last matching event but emits it at the *first* occurrence's position:

```js
for (const e of events) { if (e && e.eid) lastByEid.set(e.eid, e); }  // last value
...
  if (emitted.has(id)) continue;
  emitted.add(id);
  out.push(lastByEid.get(id));                                        // first position
```

So `applied(t1) → open(t2) → applied(t3)` folded to `[applied(t3), open(t2)]`: the newest verdict was carried, but re-seated *ahead* of the older one, so `open` ended up last and won.

The verdict could never converge back to applied within one version. `question → applied` is the normal progression — the agent asks, the human answers, the agent applies — so ✅/🟡/❓ could lie permanently, and that emoji is exactly what `/tdoc edit` relies on to tell a reviewer what happened.

The fix drops the kind from the eid, the same way reaction toggles already converge (the rationale comment above `eventEid` had described that fix for reactions but status never got it). `deleted` keeps its own slot — it is terminal, not a toggle.

### Migration is already handled

`marked_applied` / `marked_open` are in `DETERMINISTIC_EID_KINDS`, and `backfillEids` **recomputes** — not merely backfills — deterministic eids whose format changed. Existing stuck comments therefore self-heal on the next fold. There is a test for exactly this, driving events that carry the old `marked_applied:1` / `marked_open:1` eids.

Nothing anywhere parses or prefix-matches an eid — the only consumer is `const id = e.eid` as a Map key — so the format change is contained.

### Tests

Five cases added to `test/event-convergence.test.js`:

| case | fails before fix |
|---|---|
| status kinds share one eid slot; `deleted` does not; version still separates | yes |
| `applied → partial → applied` ends applied | yes |
| migration: legacy events under the old eid converge | yes |
| `question → applied` flips the verdict | no — guard |
| a later `marked_open` still reopens an applied comment | no — guard |

The last two pass either way and are direction guards, not regression proofs: the bug needs the *same* kind to repeat around the other (`[A, B, A]`). Verified by reverting only the eid change — `8 passed, 3 failed`.

## Checklist

- [x] `npm test` passes locally — `PASS — all 43 suite(s) green`.
- [x] Worker touched. `npm run test:all` was run; the Playwright suites (`ui`, `responsive`, `csp-xss`) skip loudly because Playwright is not installed here, and `publish.test.js` errors on `require('playwright')` at module top — **both reproduce identically on clean `main`**, so neither is from this change. The change is a pure string-returning switch in the event-fold layer with no DOM, CSP, or publish-path surface.
- [x] `SKILL.md` not edited.
- [x] No version change.
- [x] `worker/_worker.bundled.js` is not committed; CI regenerates it via `node bin/tdoc-bundle` on deploy, so no bundle refresh is needed here.

## Security note

Touches `worker/worker.js`, but only `eventEid`, which turns an event into a dedup key. It reads no request input, performs no auth decision, and emits no markup — `at_version` is already coerced by `coerceBodyVersion` upstream. No change to what a caller can write: the `/api/agent/reply` handler still gates on the upload token and on `parent_not_found` exactly as before. The effect is confined to which stored events collapse together during the fold.