### PR TITLE
Make tdoc-doctor target-aware so hosted users skip Cloudflare setup

### DIFF
--- a/FIRST-DOC.md
+++ b/FIRST-DOC.md
@@ -10,17 +10,27 @@ Follow [ONBOARDING.md](ONBOARDING.md) end-to-end first. Do not skip it and do
 not ask the human which runtime they use; that file tells you how to install
 yourself and how to authenticate.
 
-Publishing is hosted by default. If the CLI asks the human to sign in with
+Publishing is hosted by default and needs no Cloudflare account, no card, and
+nothing to click in a dashboard. If the CLI asks the human to sign in with
 GitHub, print the code and the URL and wait for them. Do not ask them for a
 token; there is nothing for them to paste.
 
-**If the human said to publish to their own Cloudflare** — the line they pasted
-will say so — do that instead, and do not sign them into the hosted service.
-ONBOARDING.md step 4 covers it: install wrangler, `wrangler login`, then two
-things only they can click in a browser (claim a workers.dev subdomain, enable
-R2). Print each URL, say what to click, and wait for them to confirm before
-re-probing with `bin/tdoc-doctor`. It is about five minutes the first time and
-free. Their account, their bill, no card.
+Do not install wrangler, and do not send them to the Cloudflare dashboard. If
+`bin/tdoc-doctor` is asking for either, read its `.target` field first — on the
+hosted default it never should.
+
+<details>
+<summary><b>Only if the human said to publish to their own Cloudflare</b> — the
+line they pasted will say so</summary>
+
+Do that instead, and do not sign them into the hosted service. The self-hosting
+appendix at the end of ONBOARDING.md covers it: install wrangler,
+`wrangler login`, then two things only they can click in a browser (claim a
+workers.dev subdomain, enable R2). Print each URL, say what to click, and wait
+for them to confirm before re-probing with `bin/tdoc-doctor --platform
+cloudflare`. It is about five minutes the first time and free. Their account,
+their bill, no card.
+</details>
 
 ## Step 2 — make the doc
 

--- a/ONBOARDING.md
+++ b/ONBOARDING.md
@@ -7,10 +7,10 @@
 `tdoc` is a Claude Code skill that gives the user prompt-native HTML documents with text- and artifact-anchored comments. After install + onboarding, the user can:
 
 - `/tdoc new <prompt>` → generate a commentable HTML doc
-- `/tdoc publish <slug>` → publish (default target is hosted tdoc.dev; first publish signs in with GitHub)
+- `/tdoc publish <slug>` → publish to **hosted tdoc.dev**; the first publish signs in with GitHub once
 - Share the live URL; commenters sign in with GitHub
 
-Install + onboarding takes ~3 minutes on a clean machine. Most steps are automatic. The user only has to click ~2 things in a browser.
+**Publishing is hosted by default and needs no Cloudflare account, no card, and nothing to click in a dashboard.** On a machine that already has Node, there is usually nothing to install at all. Self-hosting on your own Cloudflare or Vercel is still fully supported — it is at the end of this file, and you only go there if the user asks for it.
 
 ## Step 1 — Install the skill (if not already installed)
 
@@ -62,14 +62,21 @@ Both files must exist. If either is missing, the clone failed — re-run Step 1.
 ~/.claude/skills/tdoc/bin/tdoc-doctor
 ```
 
+The doctor is **target-aware**: it assesses readiness for the platform the user will actually publish to, and reports which one that was under `.target`. Unless the user said otherwise, that is `hosted`, and the Cloudflare block will be empty because it is never probed.
+
+Pass `--platform cloudflare` (or `vercel`) only when the user has asked to self-host.
+
 The JSON has these fields you care about:
 
 ```jsonc
 {
+  "target": "hosted",          // what readiness below was assessed against
   "deps": {
     "node":     { "ok": true/false, "version": "v22.x" },
-    "wrangler": { "ok": true/false, "version": "4.x" },
+    "curl":     { "ok": true/false },
     "jq":       { "ok": true/false },
+    "wrangler": { "ok": true/false, "version": "4.x" },  // self-host only
+    "vercel":   { "ok": true/false },                    // self-host only
     "gh":       { "ok": true/false }
   },
   "cloudflare": {
@@ -99,7 +106,7 @@ The JSON has these fields you care about:
 
 ## Step 4 — Walk the user through `missing_steps`
 
-If `ready_to_publish` is `true` and `published.ok` is `true`, skip to Step 5 — they're already set up.
+**On the hosted default this list is usually empty** — hosted publishing needs only Node 18+, curl and jq. If `ready_to_publish` is `true`, go straight to Step 5. Do not install wrangler, do not run `wrangler login`, and do not send the user to the Cloudflare dashboard; none of that is part of publishing to tdoc.dev.
 
 Otherwise, iterate over `missing_steps` **in order**. Each step has a `kind`:
 
@@ -111,12 +118,7 @@ Otherwise, iterate over `missing_steps` **in order**. Each step has a `kind`:
 
 Always re-run `bin/tdoc-doctor` between steps. State changes — what was missing in iteration N may be resolved in N+1.
 
-**The two `click` steps you'll encounter most:**
-
-1. **Claim a workers.dev subdomain** — one-time pick. URL: `https://dash.cloudflare.com/?to=/:account/workers-and-pages`. On the Workers & Pages page Cloudflare prompts for a subdomain; user chooses any name (typically their handle). Free.
-2. **Enable R2** — one-time click. URL: `https://dash.cloudflare.com/<account_id>/r2`. Free tier is 10 GB. Requires acknowledging Cloudflare's pricing page.
-
-Don't surprise the user — explain briefly *why* before you ask them to click.
+`click` steps only ever appear on the self-host path. If you are seeing one on the hosted default, something is wrong — re-read `.target` before sending anyone to a dashboard.
 
 ## Step 5 — Offer a sample doc
 
@@ -145,7 +147,7 @@ echo '[]' > ~/tdocs/$SLUG/comments.json
 ~/.claude/skills/tdoc/bin/tdoc-publish $SLUG
 ```
 
-The script prints the live URL. Show it to the user.
+The script prints the live URL. Show it to the user, and say what it is: the doc is **unlisted** — anyone with the link can read it, and it is never listed anywhere. Don't assume they already know that; they may never have seen a tdoc page before.
 
 ## Step 6 — Wrap up
 
@@ -159,6 +161,25 @@ Tell the user:
 ## Idempotency
 
 Every step is safe to re-run. The doctor reads state; the publish script checks for existing resources before creating. The user can interrupt and resume at any point.
+
+## Appendix — self-hosting on your own Cloudflare or Vercel
+
+Only do this when the user has explicitly said they want to host it themselves. It is not the default and not the recommended path for someone new.
+
+Re-probe with the target named, so the checklist is the right one:
+
+```bash
+~/.claude/skills/tdoc/bin/tdoc-doctor --platform cloudflare
+```
+
+Then walk `missing_steps` as in Step 4. On Cloudflare the two `click` steps you'll hit are:
+
+1. **Claim a workers.dev subdomain** — one-time pick. URL: `https://dash.cloudflare.com/?to=/:account/workers-and-pages`. On the Workers & Pages page Cloudflare prompts for a subdomain; the user chooses any name (typically their handle). Free.
+2. **Enable R2** — one-time click. URL: `https://dash.cloudflare.com/<account_id>/r2`. Free tier is 10 GB. Requires acknowledging Cloudflare's pricing page.
+
+Don't surprise the user — explain briefly *why* before you ask them to click. Budget about five minutes the first time. Their account, their bill, no card.
+
+Publish with the platform named: `bin/tdoc-publish --platform cloudflare <slug>` (or `--platform vercel`). The choice is saved in `~/.tdoc/published.json` and becomes their default from then on.
 
 ## What to skip if the user just wants local
 
@@ -176,6 +197,7 @@ node --version  # should be v18 or higher
 |--------------------------------------------------|----------------------------------------------------------------|
 | `R2 not enabled` even after the user clicked      | Wait 10s, re-run doctor. Cloudflare's API is briefly stale.    |
 | `wrangler` works in terminal but doctor says no   | Path issue. Tell user to restart their terminal.               |
+| Doctor asks for Cloudflare things on a hosted user | Check `.target`. Something set `TDOC_PLATFORM` or `published.json` to cloudflare. |
 | Worker deploys but `/api/upload` returns 401      | The new TDOC_UPLOAD_TOKEN secret hasn't propagated. Wait 15s, retry. |
 | `gh` is missing                                   | Optional — `tdoc` doesn't need it. Skip.                       |
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -586,20 +586,29 @@ installed, or might be partway through. You **must** drive the flow from
 **Algorithm:**
 
 1. Run `"$SKILL_DIR/bin/tdoc-doctor"` and parse the JSON. This is non-destructive.
+   The doctor is target-aware and reports what it assessed under `.target`.
+   The default is `hosted` (tdoc.dev), which needs Node 18+, curl and jq —
+   **no Cloudflare account, no wrangler, nothing to click in a dashboard.**
+   Only pass `--platform cloudflare` / `--platform vercel` when the user has
+   asked to self-host.
 2. If `.ready_to_publish == true` AND `.published.ok == true` → tell the user
    they are fully set up, and offer to run `/tdoc new <prompt>` or to test
    publishing with a sample doc.
 3. If `.ready_to_publish == true` AND `.published.ok == false` → they have all
    deps but haven't published yet. Offer to create a quick sample doc with
    `/tdoc new` and then `/tdoc publish` it.
-4. Otherwise, walk through `.missing_steps` in order. For each step:
-   - **kind == "install"**: run the `cmd` for them via Bash (e.g. `npm i -g wrangler`,
-     `brew install jq`). After install, re-run `tdoc-doctor` to confirm.
+4. Otherwise, walk through `.missing_steps` in order. On the hosted default
+   this list is usually empty. For each step:
+   - **kind == "install"**: run the `cmd` for them via Bash (e.g. `brew install jq`).
+     After install, re-run `tdoc-doctor` to confirm.
    - **kind == "login"**: explain that this opens a browser, then run the `cmd`.
      `wrangler login` is interactive — print clear instructions and wait.
    - **kind == "click"**: you cannot click for the user. Print the URL clearly
      and tell them what to do ("Open this and click 'Enable R2'"). Then wait
      for the user to say "done", then re-run `tdoc-doctor` to verify.
+     `login` and `click` steps are **self-host only**. If one appears for a
+     user who never asked to self-host, re-read `.target` before sending them
+     to a dashboard.
 5. After every step, re-run `tdoc-doctor` and continue from the new state.
 6. When `.ready_to_publish == true`, congratulate and offer to create + publish
    a sample doc.
@@ -608,6 +617,8 @@ installed, or might be partway through. You **must** drive the flow from
 
 - NEVER skip the doctor check before suggesting a step. State changes between
   steps (e.g. R2 takes a few seconds after enabling).
+- NEVER walk a hosted user through Cloudflare setup. Publishing to tdoc.dev
+  does not use wrangler, a workers.dev subdomain, or R2.
 - ALWAYS show the user what you're running. Print the JSON status if helpful.
 - If a "click" step doesn't take effect after the user says "done", offer to
   re-check after waiting 10s (Cloudflare API can be slow to reflect changes).

--- a/bin/tdoc-doctor
+++ b/bin/tdoc-doctor
@@ -16,6 +16,16 @@
 #   TDOC_MOCK_NO_R2=1               # R2 not enabled
 #   TDOC_MOCK_NO_PUBLISH_TOKEN=1    # logged in but stored OAuth token unreadable
 #   TDOC_MOCK_NOT_PUBLISHED=1       # no ~/.tdoc/published.json
+#   TDOC_MOCK_NO_CURL=1
+#
+# The probe is TARGET-AWARE. tdoc publishes to hosted tdoc.dev by default
+# (see tdoc-publish), so readiness is assessed against the platform the user
+# will actually publish to, not against Cloudflare for everyone. Resolution
+# order matches the rest of the CLI:
+#   --platform <hosted|cloudflare|vercel>  >  $TDOC_PLATFORM  >
+#   .platform in ~/.tdoc/published.json    >  hosted
+# Cloudflare is only probed when the target is cloudflare, so the common path
+# also stops making two Cloudflare API round-trips it never needed.
 #
 # Exit code is always 0; consumers read the JSON.
 
@@ -23,6 +33,27 @@ set -uo pipefail
 
 SKILL_DIR="${SKILL_DIR:-$HOME/.claude/skills/tdoc}"
 CONFIG_FILE="${TDOC_CONFIG_FILE:-$HOME/.tdoc/published.json}"
+
+# --- target platform ---
+PLATFORM_FLAG=""
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --platform)   PLATFORM_FLAG="${2:-}"; shift 2 ;;
+    --platform=*) PLATFORM_FLAG="${1#--platform=}"; shift ;;
+    *) shift ;;
+  esac
+done
+
+target="${PLATFORM_FLAG:-${TDOC_PLATFORM:-}}"
+if [ -z "$target" ] && [ -z "${TDOC_MOCK_NOT_PUBLISHED:-}" ] && [ -f "$CONFIG_FILE" ]; then
+  # Read .platform without depending on jq — jq itself is a dep we report on,
+  # so the target must resolve even when jq is missing.
+  target="$(sed -n 's/.*"platform"[[:space:]]*:[[:space:]]*"\([a-z]*\)".*/\1/p' "$CONFIG_FILE" | head -1)"
+fi
+case "$target" in
+  hosted|cloudflare|vercel) ;;
+  *) target="hosted" ;;
+esac
 
 # --- helpers ---
 # (Removed unused have() helper — dead code from an abandoned rewrite.)
@@ -79,6 +110,14 @@ jq_ok=false
 gh_ok=false
 [ -z "${TDOC_MOCK_NO_GH:-}" ] && command -v gh >/dev/null 2>&1 && gh_ok=true
 
+# curl carries every hosted upload and every Cloudflare probe, and was never
+# reported even though a machine without it cannot publish at all.
+curl_ok=false
+[ -z "${TDOC_MOCK_NO_CURL:-}" ] && command -v curl >/dev/null 2>&1 && curl_ok=true
+
+vercel_ok=false
+[ -z "${TDOC_MOCK_NO_VERCEL:-}" ] && command -v vercel >/dev/null 2>&1 && vercel_ok=true
+
 # --- Cloudflare state ---
 # Only probe if wrangler is present and not mocked away.
 cf_logged_in=false
@@ -88,7 +127,7 @@ cf_subdomain_ok=false
 cf_r2_enabled=false
 cf_publish_token_ok=false
 
-if $wrangler_ok && [ -z "${TDOC_MOCK_NO_CF_LOGIN:-}" ]; then
+if [ "$target" = "cloudflare" ] && $wrangler_ok && [ -z "${TDOC_MOCK_NO_CF_LOGIN:-}" ]; then
   if wrangler whoami >/dev/null 2>&1; then
     cf_logged_in=true
     cf_account_id="$(wrangler whoami 2>/dev/null | grep -Eo '[a-f0-9]{32}' | head -1 || true)"
@@ -142,11 +181,22 @@ if [ -z "${TDOC_MOCK_NOT_PUBLISHED:-}" ] && [ -f "$CONFIG_FILE" ]; then
   fi
 fi
 
-# --- ready_to_publish derived flag ---
+# --- ready_to_publish derived flag (per target) ---
+# Publishing to hosted tdoc.dev needs Node, curl and jq. It does NOT need
+# wrangler, a Cloudflare login, a workers.dev subdomain, or R2 — demanding
+# those of a hosted user was #236.
 ready_to_publish=false
-if $node_ok && $wrangler_ok && $jq_ok && $cf_logged_in && $cf_publish_token_ok && $cf_subdomain_ok && $cf_r2_enabled; then
-  ready_to_publish=true
-fi
+case "$target" in
+  hosted)
+    if $node_ok && $curl_ok && $jq_ok; then ready_to_publish=true; fi ;;
+  vercel)
+    if $node_ok && $curl_ok && $jq_ok && $vercel_ok; then ready_to_publish=true; fi ;;
+  cloudflare)
+    if $node_ok && $curl_ok && $jq_ok && $wrangler_ok && $cf_logged_in \
+       && $cf_publish_token_ok && $cf_subdomain_ok && $cf_r2_enabled; then
+      ready_to_publish=true
+    fi ;;
+esac
 
 # --- missing_steps: ordered checklist of what the user still needs to do ---
 # Each entry has: id, label, action_kind ("install"|"login"|"click"|"automatic"), command_or_url
@@ -156,9 +206,18 @@ if $jq_ok; then
   # mechanism + a duplicate `cmds="."` init were dead code — removed.)
   cmds="."
   $node_ok || cmds="$cmds | . + [{id:\"node\",label:\"Install Node 18+\",kind:\"install\",cmd:\"brew install node\"}]"
-  $wrangler_ok || cmds="$cmds | . + [{id:\"wrangler\",label:\"Install wrangler CLI\",kind:\"install\",cmd:\"npm i -g wrangler\"}]"
+  $curl_ok || cmds="$cmds | . + [{id:\"curl\",label:\"Install curl\",kind:\"install\",cmd:\"brew install curl\"}]"
   $jq_ok || cmds="$cmds | . + [{id:\"jq\",label:\"Install jq\",kind:\"install\",cmd:\"brew install jq\"}]"
-  if ! $cf_logged_in; then
+  # Everything below is self-host setup. A hosted user needs none of it, so it
+  # is never offered to them.
+  if [ "$target" = "vercel" ] && ! $vercel_ok; then
+    cmds="$cmds | . + [{id:\"vercel\",label:\"Install the vercel CLI\",kind:\"install\",cmd:\"npm i -g vercel\"}]"
+  fi
+  if [ "$target" = "cloudflare" ]; then
+  $wrangler_ok || cmds="$cmds | . + [{id:\"wrangler\",label:\"Install wrangler CLI\",kind:\"install\",cmd:\"npm i -g wrangler\"}]"
+  if ! $wrangler_ok; then
+    :
+  elif ! $cf_logged_in; then
     cmds="$cmds | . + [{id:\"cf_login\",label:\"Log into Cloudflare\",kind:\"login\",cmd:\"wrangler login\"}]"
   elif ! $cf_publish_token_ok; then
     # Logged in (wrangler whoami works) but we couldn't read the stored OAuth
@@ -173,6 +232,7 @@ if $jq_ok; then
     if ! $cf_r2_enabled; then
       cmds="$cmds | . + [{id:\"cf_r2\",label:\"Enable R2 on your Cloudflare account (one click, free up to 10GB)\",kind:\"click\",cmd:\"https://dash.cloudflare.com/$cf_account_id/r2\"}]"
     fi
+  fi
   fi
   missing_json="$(echo '[]' | jq "$cmds")"
 fi
@@ -189,6 +249,9 @@ if $jq_ok; then
     --arg wrangler_ver "$wrangler_ver" \
     --argjson jq_ok "$jq_ok" \
     --argjson gh_ok "$gh_ok" \
+    --argjson curl_ok "$curl_ok" \
+    --argjson vercel_ok "$vercel_ok" \
+    --arg target "$target" \
     --argjson cf_logged_in "$cf_logged_in" \
     --argjson cf_publish_token_ok "$cf_publish_token_ok" \
     --arg cf_account_id "$cf_account_id" \
@@ -202,8 +265,11 @@ if $jq_ok; then
     --argjson missing_steps "$missing_json" \
     --argjson update "$update_json" \
     '{
+      target: $target,
       deps: { node: { ok: $node_ok, version: $node_ver },
+              curl: { ok: $curl_ok },
               wrangler: { ok: $wrangler_ok, version: $wrangler_ver },
+              vercel: { ok: $vercel_ok },
               jq: { ok: $jq_ok },
               gh: { ok: $gh_ok } },
       cloudflare: { logged_in: $cf_logged_in, publish_token_ok: $cf_publish_token_ok,
@@ -218,6 +284,6 @@ if $jq_ok; then
 else
   # Minimal JSON fallback if jq isn't installed (we still report the lack of jq).
   cat <<EOF
-{"deps":{"node":{"ok":$node_ok,"version":"$node_ver"},"wrangler":{"ok":$wrangler_ok,"version":"$wrangler_ver"},"jq":{"ok":false},"gh":{"ok":$gh_ok}},"cloudflare":{"logged_in":false,"account_id":""},"published":{"ok":false},"ready_to_publish":false,"missing_steps":[{"id":"jq","label":"Install jq","kind":"install","cmd":"brew install jq"}]}
+{"target":"$target","deps":{"node":{"ok":$node_ok,"version":"$node_ver"},"curl":{"ok":$curl_ok},"wrangler":{"ok":$wrangler_ok,"version":"$wrangler_ver"},"vercel":{"ok":$vercel_ok},"jq":{"ok":false},"gh":{"ok":$gh_ok}},"cloudflare":{"logged_in":false,"account_id":""},"published":{"ok":false},"ready_to_publish":false,"missing_steps":[{"id":"jq","label":"Install jq","kind":"install","cmd":"brew install jq"}]}
 EOF
 fi

--- a/skills/tdoc/SKILL.md
+++ b/skills/tdoc/SKILL.md
@@ -586,20 +586,29 @@ installed, or might be partway through. You **must** drive the flow from
 **Algorithm:**
 
 1. Run `"$SKILL_DIR/bin/tdoc-doctor"` and parse the JSON. This is non-destructive.
+   The doctor is target-aware and reports what it assessed under `.target`.
+   The default is `hosted` (tdoc.dev), which needs Node 18+, curl and jq —
+   **no Cloudflare account, no wrangler, nothing to click in a dashboard.**
+   Only pass `--platform cloudflare` / `--platform vercel` when the user has
+   asked to self-host.
 2. If `.ready_to_publish == true` AND `.published.ok == true` → tell the user
    they are fully set up, and offer to run `/tdoc new <prompt>` or to test
    publishing with a sample doc.
 3. If `.ready_to_publish == true` AND `.published.ok == false` → they have all
    deps but haven't published yet. Offer to create a quick sample doc with
    `/tdoc new` and then `/tdoc publish` it.
-4. Otherwise, walk through `.missing_steps` in order. For each step:
-   - **kind == "install"**: run the `cmd` for them via Bash (e.g. `npm i -g wrangler`,
-     `brew install jq`). After install, re-run `tdoc-doctor` to confirm.
+4. Otherwise, walk through `.missing_steps` in order. On the hosted default
+   this list is usually empty. For each step:
+   - **kind == "install"**: run the `cmd` for them via Bash (e.g. `brew install jq`).
+     After install, re-run `tdoc-doctor` to confirm.
    - **kind == "login"**: explain that this opens a browser, then run the `cmd`.
      `wrangler login` is interactive — print clear instructions and wait.
    - **kind == "click"**: you cannot click for the user. Print the URL clearly
      and tell them what to do ("Open this and click 'Enable R2'"). Then wait
      for the user to say "done", then re-run `tdoc-doctor` to verify.
+     `login` and `click` steps are **self-host only**. If one appears for a
+     user who never asked to self-host, re-read `.target` before sending them
+     to a dashboard.
 5. After every step, re-run `tdoc-doctor` and continue from the new state.
 6. When `.ready_to_publish == true`, congratulate and offer to create + publish
    a sample doc.
@@ -608,6 +617,8 @@ installed, or might be partway through. You **must** drive the flow from
 
 - NEVER skip the doctor check before suggesting a step. State changes between
   steps (e.g. R2 takes a few seconds after enabling).
+- NEVER walk a hosted user through Cloudflare setup. Publishing to tdoc.dev
+  does not use wrangler, a workers.dev subdomain, or R2.
 - ALWAYS show the user what you're running. Print the JSON status if helpful.
 - If a "click" step doesn't take effect after the user says "done", offer to
   re-check after waiting 10s (Cloudflare API can be slow to reflect changes).

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -30,7 +30,12 @@ console.log('cli (Batch D resilience)');
 t('every curl call carries --max-time (no unbounded hang)', () => {
   for (const f of ['tdoc-publish', 'tdoc-pull', 'tdoc-doctor', 'tdoc-agent-reply']) {
     const src = readBin(f);
-    const curls = src.split('\n').filter(l => /\bcurl\b/.test(l) && !l.trim().startsWith('#'));
+    // Actual invocations only: `curl` followed by a flag, a quote or a $var.
+    // A bare substring match also hit `curl_ok`, `command -v curl`, and the
+    // literal "brew install curl" inside a missing_steps entry — none of which
+    // issue a request, so none of which can hang.
+    const curls = src.split('\n').filter(l => /\bcurl\s+(-|["'$])/.test(l)
+      && !l.trim().startsWith('#'));
     for (const line of curls) {
       assert(/--max-time/.test(line), `${f}: curl without --max-time:\n      ${line.trim()}`);
     }

--- a/test/onboarding.test.js
+++ b/test/onboarding.test.js
@@ -19,7 +19,10 @@ const path = require('path');
 const fs = require('fs');
 const os = require('os');
 
-const SKILL_DIR = path.join(os.homedir(), '.claude/skills/tdoc');
+// Resolve from the checkout under test, NOT ~/.claude/skills/tdoc — otherwise
+// this suite silently probes whatever build happens to be installed and a
+// broken working tree still goes green.
+const SKILL_DIR = path.join(__dirname, '..');
 const DOCTOR = path.join(SKILL_DIR, 'bin/tdoc-doctor');
 
 let pass = 0, fail = 0;
@@ -28,7 +31,9 @@ function bad(name, err) { console.log(`  ✗ ${name}\n    ${err}`); fail++; }
 async function t(name, fn) { try { await fn(); ok(name); } catch (e) { bad(name, e.message); } }
 
 function runDoctor(envOverrides = {}) {
-  const env = { ...process.env, ...envOverrides };
+  // TDOC_PLATFORM is inherited from the caller's shell otherwise, which would
+  // silently retarget every scenario.
+  const env = { ...process.env, TDOC_PLATFORM: '', ...envOverrides };
   const out = execFileSync(DOCTOR, [], { env, encoding: 'utf8' });
   return JSON.parse(out);
 }
@@ -40,8 +45,8 @@ function getStep(report, id) {
 (async () => {
   console.log('--- Mocked onboarding scenarios ---');
 
-  await t('Scenario A: no wrangler installed → missing_steps starts with wrangler', () => {
-    const r = runDoctor({ TDOC_MOCK_NO_WRANGLER: '1' });
+  await t('Scenario A [cloudflare]: no wrangler installed → missing_steps starts with wrangler', () => {
+    const r = runDoctor({ TDOC_PLATFORM: 'cloudflare', TDOC_MOCK_NO_WRANGLER: '1' });
     if (r.deps.wrangler.ok) throw new Error('wrangler should be mocked-missing');
     if (r.ready_to_publish) throw new Error('cannot be ready without wrangler');
     if (!getStep(r, 'wrangler')) throw new Error('missing_steps should include id:wrangler');
@@ -55,8 +60,8 @@ function getStep(report, id) {
     if (!r.missing_steps.find(s => s.id === 'jq')) throw new Error('jq step missing');
   });
 
-  await t('Scenario C: wrangler OK but no R2 → R2 step appears with click URL', () => {
-    const r = runDoctor({ TDOC_MOCK_NO_R2: '1' });
+  await t('Scenario C [cloudflare]: wrangler OK but no R2 → R2 step appears with click URL', () => {
+    const r = runDoctor({ TDOC_PLATFORM: 'cloudflare', TDOC_MOCK_NO_R2: '1' });
     if (r.cloudflare.r2_enabled) throw new Error('R2 should be mocked-disabled');
     const step = getStep(r, 'cf_r2');
     if (!step) throw new Error('cf_r2 step missing');
@@ -64,8 +69,8 @@ function getStep(report, id) {
     if (!step.cmd.startsWith('https://dash.cloudflare.com/')) throw new Error(`expected dashboard URL, got "${step.cmd}"`);
   });
 
-  await t('Scenario D: subdomain not claimed → step with onboarding URL', () => {
-    const r = runDoctor({ TDOC_MOCK_NO_SUBDOMAIN: '1' });
+  await t('Scenario D [cloudflare]: subdomain not claimed → step with onboarding URL', () => {
+    const r = runDoctor({ TDOC_PLATFORM: 'cloudflare', TDOC_MOCK_NO_SUBDOMAIN: '1' });
     if (r.cloudflare.subdomain.ok) throw new Error('subdomain should be mocked-unclaimed');
     const step = getStep(r, 'cf_subdomain');
     if (!step) throw new Error('cf_subdomain step missing');
@@ -73,8 +78,8 @@ function getStep(report, id) {
     if (!step.cmd.includes('/workers-and-pages')) throw new Error(`expected workers-and-pages URL, got "${step.cmd}"`);
   });
 
-  await t('Scenario E: not logged into Cloudflare → cf_login step (login kind)', () => {
-    const r = runDoctor({ TDOC_MOCK_NO_CF_LOGIN: '1' });
+  await t('Scenario E [cloudflare]: not logged into Cloudflare → cf_login step (login kind)', () => {
+    const r = runDoctor({ TDOC_PLATFORM: 'cloudflare', TDOC_MOCK_NO_CF_LOGIN: '1' });
     if (r.cloudflare.logged_in) throw new Error('cf should be mocked-logged-out');
     const step = getStep(r, 'cf_login');
     if (!step) throw new Error('cf_login step missing');
@@ -82,8 +87,8 @@ function getStep(report, id) {
     if (step.cmd !== 'wrangler login') throw new Error(`expected 'wrangler login', got "${step.cmd}"`);
   });
 
-  await t('Scenario E2: logged in but token unreadable → cf_token step, publish_token_ok false, not ready', () => {
-    const r = runDoctor({ TDOC_MOCK_NO_PUBLISH_TOKEN: '1' });
+  await t('Scenario E2 [cloudflare]: logged in but token unreadable → cf_token step, publish_token_ok false, not ready', () => {
+    const r = runDoctor({ TDOC_PLATFORM: 'cloudflare', TDOC_MOCK_NO_PUBLISH_TOKEN: '1' });
     // The token read happens only inside the "wrangler whoami succeeds" block,
     // so this scenario can only exercise the real elif branch when the host is
     // actually logged into Cloudflare. On a logged-out box (typical CI), the
@@ -117,8 +122,9 @@ function getStep(report, id) {
     }
   });
 
-  await t('Scenario G: everything missing → ordered list, install first, click last', () => {
+  await t('Scenario G [cloudflare]: everything missing → ordered list, install first, click last', () => {
     const r = runDoctor({
+      TDOC_PLATFORM: 'cloudflare',
       TDOC_MOCK_NO_WRANGLER: '1',
       TDOC_MOCK_NO_JQ: '1',
       TDOC_MOCK_NO_CF_LOGIN: '1',
@@ -129,6 +135,69 @@ function getStep(report, id) {
     // jq missing falls through to the simple emission path so structure differs.
     const ids = r.missing_steps.map(s => s.id);
     if (!ids.includes('jq')) throw new Error(`expected jq, got [${ids.join(',')}]`);
+  });
+
+  console.log('\n--- Hosted target (#236) ---');
+
+  await t('H1: hosted is the default target when nothing says otherwise', () => {
+    const r = runDoctor({ TDOC_MOCK_NOT_PUBLISHED: '1' });
+    if (r.target !== 'hosted') throw new Error(`expected target hosted, got ${r.target}`);
+  });
+
+  await t('H2: a machine with no Cloudflare tooling at all is READY for hosted', () => {
+    // The bug: this exact machine was told to install wrangler, log into
+    // Cloudflare, claim a subdomain and enable R2 — none of which hosted needs.
+    const r = runDoctor({
+      TDOC_MOCK_NOT_PUBLISHED: '1',
+      TDOC_MOCK_NO_WRANGLER: '1',
+      TDOC_MOCK_NO_CF_LOGIN: '1',
+      TDOC_MOCK_NO_SUBDOMAIN: '1',
+      TDOC_MOCK_NO_R2: '1',
+    });
+    if (!r.ready_to_publish) {
+      throw new Error(`hosted must be ready without Cloudflare; steps=[${r.missing_steps.map(s => s.id).join(',')}]`);
+    }
+    for (const id of ['wrangler', 'cf_login', 'cf_subdomain', 'cf_r2', 'cf_token']) {
+      if (getStep(r, id)) throw new Error(`hosted must never ask for "${id}"`);
+    }
+  });
+
+  await t('H3: hosted still reports the deps it genuinely needs', () => {
+    for (const [mock, id] of [['TDOC_MOCK_NO_NODE', 'node'], ['TDOC_MOCK_NO_CURL', 'curl']]) {
+      const r = runDoctor({ TDOC_MOCK_NOT_PUBLISHED: '1', [mock]: '1' });
+      if (r.ready_to_publish) throw new Error(`hosted cannot be ready without ${id}`);
+      if (!getStep(r, id)) throw new Error(`expected a "${id}" step`);
+    }
+  });
+
+  await t('H4: target resolves flag > env > published.json, and the read is jq-free', () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'tdoc-doctor-target-'));
+    const cfg = path.join(dir, 'published.json');
+    try {
+      fs.writeFileSync(cfg, JSON.stringify({ platform: 'cloudflare', subdomain: 'a', worker: 'tdoc' }));
+      const fromCfg = runDoctor({ TDOC_CONFIG_FILE: cfg });
+      if (fromCfg.target !== 'cloudflare') throw new Error(`config should select cloudflare, got ${fromCfg.target}`);
+
+      // jq is what the doctor reports on, so resolving the target must not need it.
+      const noJq = runDoctor({ TDOC_CONFIG_FILE: cfg, TDOC_MOCK_NO_JQ: '1' });
+      if (noJq.target !== 'cloudflare') throw new Error(`target must resolve without jq, got ${noJq.target}`);
+
+      const fromEnv = runDoctor({ TDOC_CONFIG_FILE: cfg, TDOC_PLATFORM: 'hosted' });
+      if (fromEnv.target !== 'hosted') throw new Error(`env should beat config, got ${fromEnv.target}`);
+
+      const out = execFileSync(DOCTOR, ['--platform', 'vercel'], {
+        env: { ...process.env, TDOC_CONFIG_FILE: cfg, TDOC_PLATFORM: 'hosted' }, encoding: 'utf8',
+      });
+      const fromFlag = JSON.parse(out);
+      if (fromFlag.target !== 'vercel') throw new Error(`flag should beat env, got ${fromFlag.target}`);
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  await t('H5: an unknown platform falls back to hosted rather than guessing', () => {
+    const r = runDoctor({ TDOC_MOCK_NOT_PUBLISHED: '1', TDOC_PLATFORM: 'nonsense' });
+    if (r.target !== 'hosted') throw new Error(`expected fallback to hosted, got ${r.target}`);
   });
 
   console.log('\n--- Help text on tdoc-update ---');


### PR DESCRIPTION
## What & why

Refs #236. Slice **S1 + S2** of the approved onboarding redesign: https://tdoc.dev/d/tdoc-onboarding-redesign/v/2

A user who only wants to publish to `tdoc.dev` — the CLI's own default — was reported not-ready and walked through installing wrangler, `wrangler login`, claiming a workers.dev subdomain, and enabling R2. Hosted publishing touches none of those.

`bin/tdoc-doctor:147` had no notion of a target, so it answered the Cloudflare question for everyone:

```bash
if $node_ok && $wrangler_ok && $jq_ok && $cf_logged_in \
   && $cf_publish_token_ok && $cf_subdomain_ok && $cf_r2_enabled; then
```

`ONBOARDING.md` gates its publish step on that flag, so an agent following the file could not reach a hosted publish at all. Same root cause as #226: a surface that predates the hosted default and never learned about it.

## The change

The doctor resolves a target the way the rest of the CLI does — `--platform` > `$TDOC_PLATFORM` > `.platform` in `published.json` > `hosted` — and assesses readiness against it.

| target | ready when |
|---|---|
| `hosted` (default) | Node 18+, curl, jq |
| `vercel` | + the `vercel` CLI |
| `cloudflare` | + wrangler, CF login, readable OAuth token, subdomain, R2 |

Measured behaviour on a machine with no Cloudflare tooling at all:

```
                                              before                     after
hosted, no wrangler/no CF     ready=false steps=[wrangler,cf_login…]   ready=true  steps=[]
cloudflare, no wrangler       ready=false steps=[wrangler]             ready=false steps=[wrangler]
```

Also in this change:
- Cloudflare is **only probed when it is the target**, so the common path stops making two Cloudflare API round-trips it never needed.
- `.target` is reported so a consumer can see what was assessed. The `cloudflare` block stays in the JSON, so existing readers keep working.
- `curl` is now reported as the dependency it always was; `vercel` gets the same treatment as `wrangler`.
- The target is read from `published.json` **without jq**, because jq is itself a dependency the doctor reports on.
- An unrecognised platform falls back to `hosted` rather than guessing.

**Docs (S2)** follow the same inversion. `ONBOARDING.md` makes hosted the spine and moves the Cloudflare click-steps into a self-hosting appendix; `FIRST-DOC.md` collapses its self-host branch into a `<details>`; `SKILL.md`'s `/tdoc onboard` stops describing Cloudflare as the path and gains an explicit "never walk a hosted user through Cloudflare setup" rule. **Self-hosting is kept everywhere — demoted, not removed.**

## Tests

Five hosted scenarios added to `onboarding.test.js`; **all five fail on the pre-fix doctor** (`10 passed, 5 failed`) and pass after. The eight existing Cloudflare scenarios now name the cloudflare target explicitly and still pass under both, so BYOK behaviour is unchanged.

Two test-harness problems surfaced and are fixed here because the change could not otherwise be verified:

1. `onboarding.test.js` resolved `SKILL_DIR` to `~/.claude/skills/tdoc` — it probed **whatever build happened to be installed**, not the checkout, so a broken working tree could still go green. Now resolves from `__dirname/..`.
2. `cli.test.js`'s "every curl call carries `--max-time`" filter matched the *substring* `curl`, so it flagged `command -v curl` and the literal `brew install curl` in a `missing_steps` label. Narrowed to actual invocations. **Verified it is not weakened**: injecting `curl -sS "https://example.com/probe"` into the doctor still fails the test.

## Checklist

- [x] `npm test` passes locally — `PASS — all 43 suite(s) green`.
- [x] `onboarding.test.js` (the doctor's own suite, gated in `run.js` only for its integration half) run directly: `15 passed, 0 failed`.
- [x] Nothing browser-facing or worker-side touched, so the Playwright suites do not apply.
- [x] `SKILL.md` edited → copied to `skills/tdoc/SKILL.md`; verified identical.
- [x] No version change.

## Security note

`bin/tdoc-doctor` is a read-only probe and stays one — it still creates and deletes nothing. The change *reduces* what leaves the machine: the Cloudflare OAuth token is now read and sent to `api.cloudflare.com` only when Cloudflare is the chosen target, instead of on every run. Argument parsing accepts only `--platform`, and the value is validated against a three-item allowlist before use, falling back to `hosted` — it is never interpolated into a URL or a shell command. The `published.json` read is a `sed` extraction of `[a-z]*` that goes through the same allowlist.

## Not merging

Opened for manual testing first, per request. Not to be merged until that passes.