### PR TITLE
Collapse the top bar to Share + ⋯, fold Copy into the overflow menu

### DIFF
--- a/server/overlay.js
+++ b/server/overlay.js
@@ -471,8 +471,11 @@
   .tdoc-secondary-menu .tdoc-sec-sep { border-top: 1px solid #eee; margin: 4px 6px; }
 
   .tdoc-menu-wrap { position: relative; display: inline-block; }
-  /* Overflow ⋯ button shows on narrow viewports. */
-  .tdoc-bar .tdoc-secondary-toggle { display: none; padding: 6px 10px; }
+  /* ⋯ overflow is the single home for secondary actions (Copy / Duplicate /
+     Download) at every width. Their inline bar buttons stay in the DOM for the
+     #146 chrome contract but never render — the ⋯ menu drives them. */
+  .tdoc-bar .tdoc-secondary-toggle { display: inline-flex; padding: 6px 10px; }
+  .tdoc-bar #tdoc-duplicate-btn, .tdoc-bar #tdoc-download-wrap, .tdoc-bar #tdoc-saveas-btn { display: none; }
   /* Identity chip — avatar + name (name hides on narrow). */
   .tdoc-chip { display: inline-flex; align-items: center; gap: 8px; padding: 3px 12px 3px 3px; background: #f0f1f4; border-radius: 999px; cursor: pointer; color: #1a1a1a; font: inherit; border: none; position: relative; }
   .tdoc-chip:hover { background: #e5e6ea; }
@@ -783,21 +786,16 @@
   @media (max-width: 900px) {
     .tdoc-chip .name { display: none; }
     .tdoc-chip { padding: 3px; }
-    .tdoc-bar #tdoc-duplicate-btn, .tdoc-bar #tdoc-download-wrap, .tdoc-bar #tdoc-saveas-btn { display: none; }
-    .tdoc-bar .tdoc-secondary-toggle { display: inline-flex; }
   }
   @media (max-width: 700px) {
     .tdoc-bar { padding: 0 8px; gap: 4px; }
     .tdoc-version-wrap { display: none; }
     .tdoc-bar .doc-title { font-size: 13px; }
-    .tdoc-bar #tdoc-copy-md-btn span { display: none; }
     .tdoc-bar #tdoc-publish-btn span, .tdoc-bar #tdoc-share-btn span { display: inline; }
   }
 
   /* Narrow mode (drawer + FAB) — still driven by the layout evaluator so
      it can also kick in when the comment column would crowd the article. */
-  body.tdoc-narrow .tdoc-bar #tdoc-duplicate-btn, body.tdoc-narrow .tdoc-bar #tdoc-download-wrap, body.tdoc-narrow .tdoc-bar #tdoc-saveas-btn { display: none; }
-  body.tdoc-narrow .tdoc-bar .tdoc-secondary-toggle { display: inline-flex; }
   body.tdoc-narrow #tdoc-comment-layer { position: fixed; top: auto; left: 0; right: 0; bottom: 0; max-height: 70vh; width: 100%; pointer-events: auto; background: #fff; border-top: 1px solid #e5e5e5; box-shadow: 0 -4px 24px rgba(0,0,0,0.08); transform: translateY(100%); transition: transform .2s; overflow-y: auto; padding: 12px 12px 24px; box-sizing: border-box; z-index: 999998; }
   body.tdoc-narrow #tdoc-comment-layer.open { transform: translateY(0); }
   /* Backdrop scrim behind the mobile drawer. A dedicated element is what makes
@@ -961,19 +959,8 @@
     </div>
     <span class="doc-title" id="tdoc-title">tdoc</span>`}`;
 
-  // Right: copy menu + primary CTA (Share or Publish) + ⋯ overflow + identity.
-  const copyMenuHtml = `
-    <div class="tdoc-menu-wrap">
-      <button id="tdoc-copy-md-btn" title="Copy as Markdown" aria-label="Copy as Markdown">
-        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="9" y="9" width="13" height="13" rx="2"/><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/></svg>
-        <span>Copy</span>
-      </button>
-      <div class="tdoc-menu" id="tdoc-copy-md-menu">
-        <button data-mode="doc">Doc only</button>
-        <button data-mode="doc-comments">Doc + comments</button>
-      </div>
-    </div>`;
-
+  // Right: primary CTA (Share or Publish) + ⋯ overflow + identity. Copy /
+  // Duplicate / Download all live inside the ⋯ menu now — see rightHtml.
   const primaryCtaHtml = isFork ? '' : (isPublished
     ? `<button id="tdoc-share-btn" class="primary" title="Share" aria-label="Share">
          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71"/><path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71"/></svg>
@@ -1013,10 +1000,9 @@
   const rightHtml = `
     ${cfg.isLanding ? githubBtnHtml : ''}
     ${themeBtnHtml}
-    ${isSiteBar ? '' : copyMenuHtml}
     ${isSiteBar ? '' : forkBtnHtml}
     ${isSiteBar ? '' : primaryCtaHtml}
-    ${!isSiteBar && (isPublished || isFork) ? `<div class="tdoc-menu-wrap">
+    ${!isSiteBar ? `<div class="tdoc-menu-wrap">
       <button class="tdoc-secondary-toggle" id="tdoc-more-btn" aria-label="More" title="More">⋯</button>
       <div class="tdoc-secondary-menu" id="tdoc-secondary-menu">
         ${versions.length > 1 ? `<div class="tdoc-sec-versions" role="group" aria-label="Version">
@@ -1024,6 +1010,7 @@
           ${versions.map(v => `<button role="option" data-version="${v.n}" class="tdoc-sec-version${v.n === version ? ' current' : ''}">v${v.n}${v.n === version ? ' · current' : ''}</button>`).join('')}
           <div class="tdoc-sec-sep"></div>
         </div>` : ''}
+        <button data-action="copy">Copy as Markdown</button>
         ${isPublished ? '<button data-action="duplicate">Duplicate</button><button data-action="download">Download HTML</button><button data-action="download-pdf">Download PDF</button>' : ''}
         ${isFork ? '<button data-action="saveas">Download HTML</button><button data-action="download-pdf">Download PDF</button>' : ''}
       </div>
@@ -1229,7 +1216,6 @@
       e.stopPropagation();
       const open = dlMenu.classList.toggle('open');
       dlBtn.setAttribute('aria-expanded', open ? 'true' : 'false');
-      if (copyMenu) copyMenu.classList.remove('open');
     };
     dlMenu.querySelectorAll('button').forEach((b) => {
       b.onclick = (e) => {
@@ -1263,24 +1249,6 @@
     });
   }
 
-  const copyBtn = document.getElementById('tdoc-copy-md-btn');
-  const copyMenu = document.getElementById('tdoc-copy-md-menu');
-  if (copyBtn && copyMenu) {
-    copyBtn.onclick = (e) => {
-      e.stopPropagation();
-      copyMenu.classList.toggle('open');
-      if (dlMenu) dlMenu.classList.remove('open');
-      if (dlBtn) dlBtn.setAttribute('aria-expanded', 'false');
-    };
-    copyMenu.querySelectorAll('button').forEach(b => {
-      b.onclick = async (e) => {
-        e.stopPropagation();
-        copyMenu.classList.remove('open');
-        await window.__tdocCopyDocMd(b.dataset.mode === 'doc-comments');
-      };
-    });
-  }
-
   const moreBtn = document.getElementById('tdoc-more-btn');
   const secMenu = document.getElementById('tdoc-secondary-menu');
   if (moreBtn && secMenu) {
@@ -1295,6 +1263,7 @@
           if (Number.isFinite(vn) && vn !== version) location.href = `/d/${encodeURIComponent(slug)}/v/${vn}`;
           return;
         }
+        if (b.dataset.action === 'copy') window.__tdocCopyDocMd(false);
         if (b.dataset.action === 'duplicate') duplicateDoc();
         if (b.dataset.action === 'download' || b.dataset.action === 'saveas') downloadExport();
         if (b.dataset.action === 'download-pdf') startDownload('pdf');
@@ -4175,7 +4144,6 @@
     // Close menus that aren't under the cursor
     if (secMenu && !t.closest('#tdoc-more-btn') && !t.closest('#tdoc-secondary-menu')) secMenu.classList.remove('open');
     if (!t.closest('.tdoc-menu-wrap')) {
-      copyMenu.classList.remove('open');
       if (dlMenu) dlMenu.classList.remove('open');
       if (dlBtn) dlBtn.setAttribute('aria-expanded', 'false');
     }
@@ -4308,18 +4276,6 @@
       return ok;
     }
   }
-  function flashCopied(btn) {
-    if (!btn || btn.dataset.flashing === '1') return;
-    btn.dataset.flashing = '1';
-    const orig = btn.innerHTML;
-    const oc = btn.style.color, ob = btn.style.borderColor;
-    btn.innerHTML = `<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12"/></svg><span>Copied</span>`;
-    btn.style.color = '#3ecf8e'; btn.style.borderColor = '#3ecf8e';
-    setTimeout(() => {
-      btn.innerHTML = orig; btn.style.color = oc; btn.style.borderColor = ob;
-      btn.dataset.flashing = '0';
-    }, 1200);
-  }
   function flashToast(msg) {
     const t = document.createElement('div');
     t.textContent = msg;
@@ -4360,8 +4316,9 @@
       md += '\n\n---\n\n## Comments\n\n' + state.activeComments.map(commentToMd).join('\n---\n\n');
     }
     const ok = await copyText(md);
-    if (ok) flashCopied(document.getElementById('tdoc-copy-md-btn'));
-    else flashToast('Copy failed');
+    // Copy now lives in the ⋯ menu, which closes on click, so there's no bar
+    // button to flash — confirm with a toast instead.
+    flashToast(ok ? 'Copied as Markdown' : 'Copy failed');
   };
   window.__tdocCopyCommentMd = async function (commentId, srcBtn) {
     const c = state.activeComments.find(x => x.id === commentId);

--- a/test/me-management.test.js
+++ b/test/me-management.test.js
@@ -150,7 +150,10 @@ t('/me reuses the overlay top bar and hides Share / Duplicate / Copy', () => {
   assert(!index.includes('class="who"'), 'identity belongs in the overlay chip');
   assert(index.includes('nonce="${nonce}"'), '/me catalog script must carry the CSP nonce');
   assert(overlay.includes('const isCatalog = !!cfg.isCatalog'), 'overlay must read isCatalog');
-  assert(overlay.includes("${isSiteBar ? '' : copyMenuHtml}"), 'catalog must hide Copy');
+  // Copy now lives in the ⋯ overflow, and the whole overflow is !isSiteBar-gated,
+  // so the catalog bar drops Copy/Duplicate/Download together.
+  assert(overlay.includes('<button data-action="copy">Copy as Markdown</button>'), 'Copy lives in the ⋯ overflow menu');
+  assert(overlay.includes('${!isSiteBar ? `<div class="tdoc-menu-wrap">'), 'catalog must hide Copy (⋯ overflow is !isSiteBar-gated)');
   assert(overlay.includes("${isSiteBar ? '' : primaryCtaHtml}"), 'catalog must hide Share');
   assert(overlay.includes("${isSiteBar ? '' : forkBtnHtml}"), 'catalog must hide Duplicate/Download');
   assert(overlay.includes('id="tdoc-title"'),

--- a/test/overlay-pure.test.js
+++ b/test/overlay-pure.test.js
@@ -231,11 +231,12 @@ t('overlay exposes a data-tdoc-copy click-to-copy primitive', () => {
   assert(/writeText/.test(body), 'copy uses navigator.clipboard.writeText');
   assert(/,\s*true\s*\)/.test(body), 'listener is capture-phase (beats artifact/comment handlers)');
 });
-t('copy primitive uses a UNIQUELY named flash helper (no flashCopied collision)', () => {
+t('copy primitives use distinctly named flash helpers (no flashCopied collision)', () => {
   assert(/function flashCopyTrigger\(/.test(src), 'flashCopyTrigger must exist');
-  // there must still be exactly one flashCopied (the copy-as-markdown one)
+  // Copy-as-Markdown moved into the ⋯ menu and now confirms with a toast, so the
+  // old bar-button flashCopied helper is gone — there must be none left to collide.
   const n = (src.match(/function flashCopied\(/g) || []).length;
-  assert(n === 1, `expected exactly one function flashCopied(, found ${n}`);
+  assert(n === 0, `flashCopied should be gone (toast now), found ${n}`);
 });
 
 console.log(`\n${pass} passed, ${fail} failed`);

--- a/test/responsive.test.js
+++ b/test/responsive.test.js
@@ -179,12 +179,12 @@ async function tPub(name, fn) {
       if (m.right > m.ww + 1) throw new Error(`footer right=${m.right} > viewport ${m.ww}`);
     });
 
-    await t('Copy button opens its dropdown', async () => {
-      await page.evaluate(() => document.querySelector('#tdoc-copy-md-btn').click());
+    await t('⋯ menu carries a Copy as Markdown action', async () => {
+      await page.evaluate(() => document.querySelector('#tdoc-more-btn').click());
       await page.waitForTimeout(120);
-      const open = await page.evaluate(() => document.querySelector('#tdoc-copy-md-menu.open') !== null);
-      await page.evaluate(() => { const m = document.querySelector('#tdoc-copy-md-menu'); if (m) m.classList.remove('open'); });
-      if (!open) throw new Error('copy dropdown did not open');
+      const hasCopy = await page.evaluate(() => !!document.querySelector('#tdoc-secondary-menu.open [data-action="copy"]'));
+      await page.evaluate(() => { const m = document.querySelector('#tdoc-secondary-menu'); if (m) m.classList.remove('open'); });
+      if (!hasCopy) throw new Error('no Copy action in the ⋯ menu');
     });
 
     // Published-only: identity chip present.

--- a/test/tornado-doc-landing.test.js
+++ b/test/tornado-doc-landing.test.js
@@ -336,8 +336,11 @@ t('homepage bar is site chrome, not a document toolbar', () => {
     'title must sit in the left cluster, not a fake-centered slot');
   assert(overlay.includes("${cfg.isLanding ? githubBtnHtml : ''}"),
     'homepage bar must expose a GitHub icon');
-  assert(overlay.includes("${isSiteBar ? '' : copyMenuHtml}"),
-    'homepage bar must drop Copy');
+  // Copy now sits in the ⋯ overflow, which is only rendered when !isSiteBar,
+  // so the homepage (site bar) drops it along with Duplicate/Download.
+  assert(overlay.includes('<button data-action="copy">Copy as Markdown</button>') &&
+         overlay.includes('${!isSiteBar ? `<div class="tdoc-menu-wrap">'),
+    'homepage bar must drop Copy (it lives in the !isSiteBar ⋯ overflow)');
   assert(overlay.includes("${isSiteBar ? '' : primaryCtaHtml}"),
     'homepage bar must drop Share');
 

--- a/test/ui.test.js
+++ b/test/ui.test.js
@@ -197,74 +197,52 @@ async function tPub(name, fn) {
     }
   });
 
-  await t('Copy button exists with icon + label', async () => {
-    const btn = await page.$('#tdoc-copy-md-btn');
-    if (!btn) throw new Error('no #tdoc-copy-md-btn');
-    const label = await btn.textContent();
-    if (!label.includes('Copy')) throw new Error(`label was "${label}"`);
-    const svg = await btn.$('svg');
-    if (!svg) throw new Error('no svg icon inside Copy button');
+  // Copy moved into the ⋯ overflow menu as a single action (the old two-option
+  // doc-only/doc+comments submenu is gone — Copy is always doc-only markdown).
+  await t('⋯ menu carries a single "Copy as Markdown" action', async () => {
+    await page.click('#tdoc-more-btn');
+    await page.waitForSelector('#tdoc-secondary-menu.open', { timeout: 1000 });
+    const items = await page.$$eval('#tdoc-secondary-menu.open [data-action="copy"]', els => els.map(e => e.textContent.trim()));
+    if (items.length !== 1) throw new Error(`expected one Copy action, got ${items.length}`);
+    if (items[0] !== 'Copy as Markdown') throw new Error(`label was "${items[0]}"`);
+    await page.click('h1', { position: { x: 5, y: 5 } });
+    await page.waitForTimeout(120);
   });
 
-  await t('Copy menu hidden by default', async () => {
-    const open = await page.$('.tdoc-menu.open');
-    if (open) throw new Error('menu is open before click');
+  await t('⋯ menu hidden by default', async () => {
+    const open = await page.$('#tdoc-secondary-menu.open');
+    if (open) throw new Error('secondary menu open before click');
   });
 
-  await t('Click Copy opens menu with two options', async () => {
-    await page.click('#tdoc-copy-md-btn');
-    await page.waitForSelector('.tdoc-menu.open', { timeout: 1000 });
-    const items = await page.$$eval('.tdoc-menu.open button', els => els.map(e => e.textContent.trim()));
-    if (items.length !== 2) throw new Error(`expected 2 menu items, got ${items.length}: ${items.join(', ')}`);
-    if (!items.includes('Doc only')) throw new Error(`no "Doc only": ${items.join(', ')}`);
-    if (!items.includes('Doc + comments')) throw new Error(`no "Doc + comments": ${items.join(', ')}`);
-  });
-
-  await t('Click outside closes menu', async () => {
+  await t('Click outside closes the ⋯ menu', async () => {
+    await page.click('#tdoc-more-btn');
+    await page.waitForSelector('#tdoc-secondary-menu.open');
     await page.click('h1', { position: { x: 5, y: 5 } });
     await page.waitForTimeout(150);
-    const open = await page.$('.tdoc-menu.open');
+    const open = await page.$('#tdoc-secondary-menu.open');
     if (open) throw new Error('menu stayed open after outside click');
   });
 
-  await t('Doc only copy → clipboard has markdown', async () => {
-    await page.click('#tdoc-copy-md-btn');
-    await page.waitForSelector('.tdoc-menu.open');
-    await page.click('.tdoc-menu.open button[data-mode="doc"]');
+  await t('Copy as Markdown → clipboard has markdown, no Comments section', async () => {
+    await page.click('#tdoc-more-btn');
+    await page.waitForSelector('#tdoc-secondary-menu.open');
+    await page.click('#tdoc-secondary-menu.open [data-action="copy"]');
     await page.waitForTimeout(300);
     const clip = await page.evaluate(() => navigator.clipboard.readText());
     if (!clip || clip.length < 20) throw new Error(`clipboard too short: "${clip}"`);
     if (!clip.includes('#')) throw new Error('no markdown headings in clipboard');
-    if (clip.includes('## Comments')) throw new Error('doc-only should not include Comments section');
+    if (clip.includes('## Comments')) throw new Error('Copy as Markdown must not include a Comments section');
   });
 
-  await t('Copy button briefly shows "Copied" after copy', async () => {
-    await page.click('#tdoc-copy-md-btn');
-    await page.waitForSelector('.tdoc-menu.open');
-    await page.click('.tdoc-menu.open button[data-mode="doc"]');
-    // Within the 1200ms flash window, the button should read "Copied"
+  await t('Copy confirms with a "Copied as Markdown" toast', async () => {
+    await page.click('#tdoc-more-btn');
+    await page.waitForSelector('#tdoc-secondary-menu.open');
+    await page.click('#tdoc-secondary-menu.open [data-action="copy"]');
     await page.waitForFunction(
-      () => document.querySelector('#tdoc-copy-md-btn')?.textContent?.includes('Copied'),
+      () => [...document.querySelectorAll('div')].some(d => d.textContent === 'Copied as Markdown'),
       null,
-      { timeout: 800 }
+      { timeout: 1200 }
     );
-    // And revert afterward
-    await page.waitForFunction(
-      () => document.querySelector('#tdoc-copy-md-btn')?.textContent?.trim() === 'Copy',
-      null,
-      { timeout: 2000 }
-    );
-  });
-
-  await t('Doc + comments copy → markdown includes Comments section if comments exist', async () => {
-    await page.click('#tdoc-copy-md-btn');
-    await page.waitForSelector('.tdoc-menu.open');
-    await page.click('.tdoc-menu.open button[data-mode="doc-comments"]');
-    await page.waitForTimeout(300);
-    const clip = await page.evaluate(() => navigator.clipboard.readText());
-    const hasComments = await page.evaluate(() => document.querySelectorAll('.tdoc-margin-comment').length > 0);
-    if (hasComments && !clip.includes('## Comments')) throw new Error('expected ## Comments section');
-    if (!hasComments && clip.includes('## Comments')) throw new Error('no comments but section appeared');
   });
 
   await t('Anchor highlight is clickable (pointer cursor)', async () => {
@@ -736,7 +714,7 @@ async function tPub(name, fn) {
   });
 
   // ----- Feature: Share button on published view -----
-  await tPub('Share button visible on published view (left of Copy)', async () => {
+  await tPub('Share button visible on published view', async () => {
     const share = await page.$('#tdoc-share-btn');
     if (!share) throw new Error('no #tdoc-share-btn on published doc');
     const text = await share.textContent();


### PR DESCRIPTION
## What

The top bar is now just the primary CTA (**Share** / **Publish**) + a **⋯** overflow at every width. All secondary actions live in the ⋯ menu:

> ⋯ → **Copy as Markdown · Duplicate · Download HTML · Download PDF** _(+ a version group on phones)_

Before, Copy / Duplicate / Download each sat in the bar and only progressively collapsed as the viewport tightened, and Copy had its own two-option `Doc only / Doc + comments` submenu.

## Decisions (from discussion)

- **Copy is one action** now — copy the doc as Markdown to the clipboard. The `Doc + comments` option is dropped (we don't need it). It confirms with a **"Copied as Markdown" toast** (the menu closes on click, so the old in-button "Copied" flash had nothing to flash).
- **Flat, single-level menu** — not a Google-style nested submenu. Four short items don't need nesting.
- **"Duplicate" keeps its name.** #146 deliberately removed the word *Fork* from published chrome, and "Duplicate" doesn't collide with "Copy". Renaming to Fork would reverse that contract.
- **Local docs** now get the ⋯ too (previously published/fork only), so they keep a Copy affordance.

## Contract safety

The inline `#tdoc-duplicate-btn` / Download menu stay in the DOM (the **#146** chrome contract greps the source for them) but are CSS-hidden at all widths — the ⋯ items drive them. Same mechanism as the mobile-overflow work.

## Tests

- Reworked the Copy chrome cases in `ui.test.js` + `responsive.test.js` to drive the ⋯ path (label, clipboard, toast, outside-click close).
- Updated `me-management` / `tornado-doc-landing` / `overlay-pure` assertions that pinned the old `copyMenuHtml` / `flashCopied` shape — intent preserved (site bar still drops Copy; no helper-name collision).
- **Full offline suite green: 48/48** (`node test/run.js --all`).
- Also verified published-mode desktop behaviour with a standalone Playwright check: bar = Share + ⋯; ⋯ = Copy·Duplicate·Download HTML·Download PDF + version group; Copy lands markdown on the clipboard + toast.

> Relationship to #231 (cici's bar-overflow CSS): this subsumes it — Duplicate/Download are collapsed here too, plus Copy. If this merges, #231 becomes redundant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)