### PR TITLE
Small screens: collapse the primary CTA (Share/Publish) to an icon

### DIFF
--- a/server/overlay.js
+++ b/server/overlay.js
@@ -791,7 +791,10 @@
     .tdoc-bar { padding: 0 8px; gap: 4px; }
     .tdoc-version-wrap { display: none; }
     .tdoc-bar .doc-title { font-size: 13px; }
-    .tdoc-bar #tdoc-publish-btn span, .tdoc-bar #tdoc-share-btn span { display: inline; }
+    /* Small screens: the primary CTA collapses to just its icon (label is kept
+       in title/aria-label). Keeps the phone bar to a compact icon + ⋯. */
+    .tdoc-bar #tdoc-publish-btn span, .tdoc-bar #tdoc-share-btn span { display: none; }
+    .tdoc-bar #tdoc-publish-btn, .tdoc-bar #tdoc-share-btn { padding: 7px 9px; }
   }
 
   /* Narrow mode (drawer + FAB) — still driven by the layout evaluator so


### PR DESCRIPTION
On phones (`<700px`) the primary CTA showed icon **+ "Share"** text. Next to the ⋯ overflow the label is just noise, so this hides it below 700px — the button becomes a compact icon (name preserved in `title` / `aria-label`), and the phone bar tightens to **icon + ⋯**. Desktop is unchanged (full icon + label).

Pure CSS, one `@media (max-width: 700px)` rule (`display: inline` → `display: none` + squarer padding). Applies to Publish too (same slot on the BYOK/local view).

Verified at 375px (icon-only, `aria-label="Share"`) and 1440px (label shown) via a standalone Playwright check; full offline suite + ui/responsive green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)