### PR TITLE
A first publish gets the modern access defaults, not the legacy ones

### DIFF
--- a/test/hosted-oob-behavior.test.js
+++ b/test/hosted-oob-behavior.test.js
@@ -721,6 +721,79 @@ async function issue(worker, env, login = 'alice', label = login) {
     assert(!body.includes('id="tdoc-duplicate-btn"'), 'export must not include published chrome');
   });
 
+  // ---- a first publish gets the modern access defaults, not the legacy ones ----
+  // PR #101 set out: new policy defaults to unlisted + history owner, while
+  // "docs without access stay public + full history" is back-compat for docs
+  // that predate the policy. But tdoc-publish sends no access block on a plain
+  // publish, so a brand-new doc was indistinguishable from a legacy one and
+  // got the legacy treatment — world-visible version history on every doc
+  // published without flags.
+
+  await t('a brand-new doc is stamped unlisted + owner history', async () => {
+    const mod = await loadWorker();
+    const worker = mod.default;
+    const env = makeEnv(mod.CommentsStore);
+    const a = await issue(worker, env, 'alice');
+    const r = await worker.fetch(req('/api/upload', {
+      method: 'POST', token: a.token,
+      body: { slug: 'fresh-doc', version: 1, html: '<h1>A</h1>',
+              meta: { title: 'A', slug: 'fresh-doc', versions: [{ n: 1, created: '2026-01-01T00:00:00Z' }] } },
+    }), env, {});
+    assert(r.status === 200, `upload ${r.status}`);
+    const meta = JSON.parse(await env.META.get('meta:fresh-doc'));
+    assert(meta.access, 'a first publish must persist an access block');
+    assert(meta.access.visibility === 'unlisted',
+      `expected unlisted, got ${meta.access.visibility}`);
+    assert(meta.access.history_visibility === 'owner',
+      `expected owner history, got ${meta.access.history_visibility}`);
+  });
+
+  await t('a genuinely legacy doc keeps its back-compat treatment', async () => {
+    const mod = await loadWorker();
+    const worker = mod.default;
+    const env = makeEnv(mod.CommentsStore);
+    const a = await issue(worker, env, 'alice');
+    // Build a genuine legacy doc: publish it for real so ownership is claimed
+    // in the Durable Object, then strip the access block the way a doc from
+    // before the policy would look. Writing meta straight into KV is not
+    // enough — the write gate checks the owner claim, not just meta, and the
+    // republish below is denied 403 without it.
+    await worker.fetch(req('/api/upload', {
+      method: 'POST', token: a.token,
+      body: { slug: 'legacy-doc', version: 1, html: '<h1>L</h1>',
+              meta: { title: 'L', slug: 'legacy-doc', versions: [{ n: 1, created: '2026-01-01T00:00:00Z' }] } },
+    }), env, {});
+    const seeded = JSON.parse(await env.META.get('meta:legacy-doc'));
+    delete seeded.access;
+    await env.META.put('meta:legacy-doc', JSON.stringify(seeded));
+    const r = await worker.fetch(req('/api/upload', {
+      method: 'POST', token: a.token,
+      body: { slug: 'legacy-doc', version: 2, html: '<h1>L2</h1>',
+              meta: { title: 'L', slug: 'legacy-doc', versions: [{ n: 1, created: '2026-01-01T00:00:00Z' }, { n: 2, created: '2026-01-02T00:00:00Z' }] } },
+    }), env, {});
+    assert(r.status === 200, `upload ${r.status}`);
+    const meta = JSON.parse(await env.META.get('meta:legacy-doc'));
+    assert(!meta.access,
+      `republishing a legacy doc must not silently change its policy, got ${JSON.stringify(meta.access)}`);
+  });
+
+  await t('an explicit --visibility still wins over the default', async () => {
+    const mod = await loadWorker();
+    const worker = mod.default;
+    const env = makeEnv(mod.CommentsStore);
+    const a = await issue(worker, env, 'alice');
+    const r = await worker.fetch(req('/api/upload', {
+      method: 'POST', token: a.token,
+      body: { slug: 'explicit-doc', version: 1, html: '<h1>E</h1>',
+              meta: { title: 'E', slug: 'explicit-doc', versions: [{ n: 1, created: '2026-01-01T00:00:00Z' }],
+                      access: { visibility: 'private' } } },
+    }), env, {});
+    assert(r.status === 200, `upload ${r.status}`);
+    const meta = JSON.parse(await env.META.get('meta:explicit-doc'));
+    assert(meta.access.visibility === 'private',
+      `explicit visibility must win, got ${meta.access.visibility}`);
+  });
+
   console.log(`\n${pass} passed, ${fail} failed`);
   process.exit(fail ? 1 : 0);
 })();

--- a/worker/worker.js
+++ b/worker/worker.js
@@ -3966,6 +3966,15 @@ export default {
         if (!incoming.access && prev && prev.access) {
           incoming.access = prev.access;
         }
+        // A brand-new doc with no access block falls through to
+        // accessFromMeta's legacy branch, which answers `public` — so every
+        // doc published without explicit flags was world-readable, while the
+        // product told the user it was unlisted. Stamp the modern defaults on
+        // FIRST publish only. A doc that already exists without an access
+        // block is genuinely legacy and keeps its back-compat treatment.
+        if (!incoming.access && !prev) {
+          incoming.access = normalizeAccess(null, { legacy: false });
+        }
         if (incoming.access) {
           const validatedAccess = validateAccessWrite(incoming.access);
           if (validatedAccess.error) {


### PR DESCRIPTION
## What & why

Fixes #245. Found by manual testing of the onboarding work — a freshly published doc showed as **public** when the product had just told the user it was unlisted.

`bin/tdoc-publish` writes an `access` block only when the user passes `--visibility` / `--history` / `--commenting` / `--allow-user`. A plain `tdoc-publish <slug>` therefore stores no access at all, which sends the doc down `accessFromMeta`'s legacy branch:

```js
const visibility = ACCESS_VISIBILITIES.has(a.visibility)
  ? a.visibility
  : (legacy ? 'public' : 'unlisted');
```

Reproduced against the real worker with fake KV/R2/DO bindings — a plain upload stores `meta.access: null`.

## The consequence is version history, not readability

Worth being precise, because "public" sounds worse than it is here. `public` and `unlisted` are identical for reading (worker.js:256 returns true for both), and tdoc.dev has no public catalog at all — the landing page and `/me` are both explicitly not one. So this is **not** a doc leak.

The line that matters is the next one:

```js
if (access.history_visibility === 'public') return true;   // worker.js:261
```

**Anyone holding the link could page back through every earlier version.** Someone who revised a doc five times before sharing it shared all five.

## This restores #101's intent rather than changing it

#101 wrote it out:

> - **Legacy**: docs without `access` stay public + full history (no break)
> - default for **new** policy: owner

New docs were always meant to get the modern defaults; the legacy branch is back-compat for docs that predate the policy. The gap is that the CLI never sends an access block, so a new doc is indistinguishable from a legacy one.

The fix stamps the modern defaults **only when there is no prior meta for the slug** — a first publish. A doc that already exists without an access block is genuinely legacy and keeps its treatment, so nothing changes policy under existing users.

## Tests

Three cases in `hosted-oob-behavior.test.js`:

| case | before this change |
|---|---|
| a first publish is unlisted + owner history | **fails** |
| republishing a legacy doc does NOT acquire a policy | passes — guard |
| an explicit visibility still wins | passes — guard |

Verified by reverting the worker change: `30 passed, 1 failed`.

One note on the fixture: building the "legacy doc" case needs a real first upload so ownership is claimed in the Durable Object. Writing meta straight into KV is not enough — the write gate checks the owner claim, and the republish comes back 403. My first attempt did exactly that and failed for that reason.

## Checklist

- [x] `npm test` — `PASS — all 43 suite(s) green`.
- [x] Worker touched; the Playwright suites skip here (not installed) and `publish.test.js` errors on `require('playwright')` at module top — both reproduce on clean `main`, unrelated to this change.
- [x] `SKILL.md` not edited.
- [x] No version change.
- [x] `worker/_worker.bundled.js` is not committed; CI rebuilds it on deploy.

## Security note

This narrows what an unauthenticated visitor can reach: a new doc's version history goes from world-visible to owner-only. It grants nothing new. The change is confined to defaulting a policy object on first publish and runs inside the existing upload path, after `requireUploadAuth` and `requireDocWriteAccess`; it reads no request input beyond the meta already being validated, and an explicitly supplied `access` still goes through `validateAccessWrite` unchanged. Existing docs are deliberately untouched, so no one's shared link changes behaviour under them.

## Not merging

Held for manual testing, per request.