### PR TITLE
Keep the skill current automatically instead of nagging

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -1207,6 +1207,27 @@ if [ -z "$INSTALLED_VERSION" ] && [ -d "$TDOC_DIR/.git" ]; then
 fi
 [ -z "$INSTALLED_VERSION" ] && INSTALLED_VERSION="0.0.0"
 
+# ─── Keep the skill current, automatically ───
+# Every run fast-forwards this checkout to origin/main. No prompt: a user who
+# asked for a doc did not ask to be interviewed about versions.
+#
+# It declines to act, quietly, in the two cases where acting could destroy
+# work: a dirty tree (auto-stashing is the one path here that can lose edits)
+# and a diverged checkout (someone developing tdoc itself). It never redeploys
+# a Worker — pushing to the user's own Cloudflare/Vercel account is a separate
+# action, not a side effect of asking for a doc.
+#
+# TDOC_SKIP_UPDATE_CHECK=1 turns the whole thing off.
+# The capability probe is not optional. tdoc-update's argument loop has no
+# catch-all, so a version that predates --auto would SILENTLY IGNORE the flag
+# and run the full interactive update instead — auto-stashing local edits and
+# offering a redeploy, on every single run. Only invoke it when it is a flag
+# the installed script actually knows.
+if [ -z "${TDOC_SKIP_UPDATE_CHECK:-}" ] && [ -x "$TDOC_DIR/bin/tdoc-update" ] \
+   && grep -q -- '--auto)' "$TDOC_DIR/bin/tdoc-update" 2>/dev/null; then
+  "$TDOC_DIR/bin/tdoc-update" --auto 2>&1 || true
+fi
+
 if [ -x "$TDOC_DIR/bin/tdoc-update-nag" ]; then
   NAG_LINE="$("$TDOC_DIR/bin/tdoc-update-nag" 2>/dev/null || true)"
   if printf '%s' "$NAG_LINE" | grep -q '^TDOC_UPDATE_AVAILABLE:'; then
@@ -1264,7 +1285,16 @@ TEL_EFFECTIVE="$(cat "$TEL_CONFIG_FILE")"
 
 **If `TEL_PROMPTED` is `yes`**, do NOT ask again. Proceed silently.
 
-**If the preamble printed `TDOC_UPDATE_AVAILABLE`**, tell the user
+**If the preamble printed `[tdoc] updated tdoc to <sha>`**, the skill just
+fast-forwarded itself. Mention it in one short line and carry on — do not stop
+to ask about it, and do not offer to redeploy anything.
+
+**If it printed `skipping the automatic update`**, the checkout is dirty or has
+diverged, which means someone is working on tdoc itself. Say nothing about it
+unless the user asks; it is not their problem.
+
+**If the preamble printed `TDOC_UPDATE_AVAILABLE`**, the automatic update could
+not apply (see above). Tell the user
 immediately (before the rest of the tdoc work). Do not wait until the
 end, and do not swallow it. Example:
 

--- a/bin/tdoc-update
+++ b/bin/tdoc-update
@@ -13,6 +13,10 @@
 #   tdoc-update            # interactive (asks before redeploy)
 #   tdoc-update --yes      # non-interactive (auto-redeploy if published)
 #   tdoc-update --check    # report-only: print what WOULD change, no changes
+#   tdoc-update --auto     # silent keep-current, run on every skill invocation:
+#                          #   fast-forward only, never stashes, never
+#                          #   redeploys, and prints nothing when there is
+#                          #   nothing to do.
 
 set -uo pipefail
 
@@ -21,10 +25,12 @@ cd "$SKILL_DIR" || { echo "tdoc-update: cannot cd into $SKILL_DIR" >&2; exit 1; 
 
 YES=0
 CHECK=0
+AUTO=0
 for arg in "$@"; do
   case "$arg" in
     --yes|-y) YES=1 ;;
     --check) CHECK=1 ;;
+    --auto)  AUTO=1 ;;
     -h|--help) echo "usage: tdoc-update [--yes] [--check]"; exit 0 ;;
   esac
 done
@@ -36,7 +42,7 @@ if [ ! -d .git ]; then
   exit 1
 fi
 
-echo "[tdoc-update] fetching origin/main..."
+[ "$AUTO" = "1" ] || echo "[tdoc-update] fetching origin/main..."
 if ! git fetch origin main --quiet; then
   echo "[tdoc-update] fetch failed (check network / GitHub access)." >&2
   exit 1
@@ -47,7 +53,15 @@ REMOTE="$(git rev-parse origin/main)"
 BASE="$(git merge-base HEAD origin/main)"
 
 if [ "$LOCAL" = "$REMOTE" ]; then
-  echo "[tdoc-update] already up-to-date (no remote changes)."
+  # --auto runs on every skill invocation; "nothing to do" must be silent.
+  [ "$AUTO" = "1" ] || echo "[tdoc-update] already up-to-date (no remote changes)."
+  exit 0
+fi
+
+if [ "$LOCAL" != "$BASE" ] && [ "$AUTO" = "1" ]; then
+  # A diverged checkout belongs to someone working on tdoc itself. Fast-forward
+  # is impossible and anything else would rewrite their branch.
+  echo "[tdoc-update] checkout has diverged — skipping the automatic update." >&2
   exit 0
 fi
 
@@ -57,11 +71,14 @@ if [ "$LOCAL" != "$BASE" ]; then
   exit 1
 fi
 
-# Show the incoming changelog
-echo
-echo "[tdoc-update] incoming changes:"
-git --no-pager log --oneline "$LOCAL..$REMOTE" | sed 's/^/  /'
-echo
+# Show the incoming changelog. --auto keeps this quiet: it runs on every skill
+# invocation, so a changelog every time would be noise, not information.
+if [ "$AUTO" != "1" ]; then
+  echo
+  echo "[tdoc-update] incoming changes:"
+  git --no-pager log --oneline "$LOCAL..$REMOTE" | sed 's/^/  /'
+  echo
+fi
 
 if [ "$CHECK" = "1" ]; then
   # ${#} would be the CLI arg count (1 for `--check`), not the commit count.
@@ -72,19 +89,31 @@ fi
 # Stash local edits, if any
 STASH_REF=""
 if ! git diff --quiet || ! git diff --cached --quiet; then
+  if [ "$AUTO" = "1" ]; then
+    # Keeping the skill current must never touch work in progress. Auto-stashing
+    # is the one path here that can lose someone's edits, so --auto declines.
+    echo "[tdoc-update] local edits present — skipping the automatic update." >&2
+    exit 0
+  fi
   echo "[tdoc-update] local edits detected — stashing..."
   git stash push -u -m "tdoc-update auto-stash $(date -Iseconds)" >/dev/null
   STASH_REF="$(git stash list | head -1 | awk -F: '{print $1}')"
 fi
 
 # Pull (fast-forward)
-echo "[tdoc-update] fast-forwarding..."
+[ "$AUTO" = "1" ] || echo "[tdoc-update] fast-forwarding..."
 if ! git merge --ff-only origin/main --quiet; then
   echo "[tdoc-update] fast-forward failed. Aborting."
   [ -n "$STASH_REF" ] && git stash pop "$STASH_REF" >/dev/null
   exit 1
 fi
-echo "[tdoc-update] updated to: $(git rev-parse --short HEAD)"
+if [ "$AUTO" = "1" ]; then
+  # One line, not silence: the user's tooling just changed under them and they
+  # should be able to see why behaviour differs from a minute ago.
+  echo "[tdoc] updated tdoc to $(git rev-parse --short HEAD)" >&2
+else
+  echo "[tdoc-update] updated to: $(git rev-parse --short HEAD)"
+fi
 
 # Restart the local server if it's running — otherwise the user keeps hitting
 # stale routes (e.g. a 404 on /api/publish after we added the endpoint).
@@ -115,6 +144,12 @@ if [ -n "$STASH_REF" ]; then
 fi
 
 # Offer to redeploy
+# --auto stops here. Updating the local skill is one thing; pushing a new Worker
+# bundle to the user's own Cloudflare/Vercel account is another, and is not a
+# side effect of asking for a doc.
+if [ "$AUTO" = "1" ]; then
+  exit 0
+fi
 CONFIG_FILE="$HOME/.tdoc/published.json"
 if [ -f "$CONFIG_FILE" ]; then
   PUBLISHED_SLUG=""

--- a/skills/tdoc/SKILL.md
+++ b/skills/tdoc/SKILL.md
@@ -1207,6 +1207,27 @@ if [ -z "$INSTALLED_VERSION" ] && [ -d "$TDOC_DIR/.git" ]; then
 fi
 [ -z "$INSTALLED_VERSION" ] && INSTALLED_VERSION="0.0.0"
 
+# ─── Keep the skill current, automatically ───
+# Every run fast-forwards this checkout to origin/main. No prompt: a user who
+# asked for a doc did not ask to be interviewed about versions.
+#
+# It declines to act, quietly, in the two cases where acting could destroy
+# work: a dirty tree (auto-stashing is the one path here that can lose edits)
+# and a diverged checkout (someone developing tdoc itself). It never redeploys
+# a Worker — pushing to the user's own Cloudflare/Vercel account is a separate
+# action, not a side effect of asking for a doc.
+#
+# TDOC_SKIP_UPDATE_CHECK=1 turns the whole thing off.
+# The capability probe is not optional. tdoc-update's argument loop has no
+# catch-all, so a version that predates --auto would SILENTLY IGNORE the flag
+# and run the full interactive update instead — auto-stashing local edits and
+# offering a redeploy, on every single run. Only invoke it when it is a flag
+# the installed script actually knows.
+if [ -z "${TDOC_SKIP_UPDATE_CHECK:-}" ] && [ -x "$TDOC_DIR/bin/tdoc-update" ] \
+   && grep -q -- '--auto)' "$TDOC_DIR/bin/tdoc-update" 2>/dev/null; then
+  "$TDOC_DIR/bin/tdoc-update" --auto 2>&1 || true
+fi
+
 if [ -x "$TDOC_DIR/bin/tdoc-update-nag" ]; then
   NAG_LINE="$("$TDOC_DIR/bin/tdoc-update-nag" 2>/dev/null || true)"
   if printf '%s' "$NAG_LINE" | grep -q '^TDOC_UPDATE_AVAILABLE:'; then
@@ -1264,7 +1285,16 @@ TEL_EFFECTIVE="$(cat "$TEL_CONFIG_FILE")"
 
 **If `TEL_PROMPTED` is `yes`**, do NOT ask again. Proceed silently.
 
-**If the preamble printed `TDOC_UPDATE_AVAILABLE`**, tell the user
+**If the preamble printed `[tdoc] updated tdoc to <sha>`**, the skill just
+fast-forwarded itself. Mention it in one short line and carry on — do not stop
+to ask about it, and do not offer to redeploy anything.
+
+**If it printed `skipping the automatic update`**, the checkout is dirty or has
+diverged, which means someone is working on tdoc itself. Say nothing about it
+unless the user asks; it is not their problem.
+
+**If the preamble printed `TDOC_UPDATE_AVAILABLE`**, the automatic update could
+not apply (see above). Tell the user
 immediately (before the rest of the tdoc work). Do not wait until the
 end, and do not swallow it. Example:
 

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -719,5 +719,50 @@ t('SKILL.md and skills/tdoc/SKILL.md stay identical', () => {
   assert(a === b, 'SKILL.md and its plugin-mode copy have drifted');
 });
 
+
+// ---- tdoc-update --auto: keep current without ever destroying work ----
+
+t('tdoc-update --auto never stashes and never redeploys', () => {
+  const src = readBin('tdoc-update');
+  assert(/--auto\)\s*AUTO=1/.test(src), '--auto flag missing');
+  // The stash path is the one that can lose someone's edits.
+  const stashIdx = src.indexOf('git stash push');
+  const guardIdx = src.lastIndexOf('AUTO" = "1"', stashIdx);
+  assert(guardIdx !== -1 && guardIdx < stashIdx,
+    '--auto must bail out before the stash push');
+  // Redeploy pushes to the user's own infrastructure.
+  const redeployIdx = src.indexOf('bin/tdoc-publish');
+  const exitIdx = src.lastIndexOf('AUTO" = "1"', redeployIdx);
+  assert(exitIdx !== -1 && exitIdx < redeployIdx,
+    '--auto must exit before the redeploy offer');
+});
+
+t('tdoc-update --auto declines on a diverged checkout', () => {
+  const src = readBin('tdoc-update');
+  assert(/LOCAL" != "\$BASE" \] && \[ "\$AUTO" = "1"/.test(src),
+    '--auto must skip rather than fail on a diverged checkout');
+});
+
+t('SKILL.md probes for --auto before calling it', () => {
+  // tdoc-update's arg loop has no catch-all: a version predating --auto would
+  // ignore the flag and run the FULL interactive update, stashing local edits
+  // on every skill run. The probe is what stops that.
+  const skill = fs.readFileSync(path.join(__dirname, '..', 'SKILL.md'), 'utf8');
+  const call = skill.indexOf('bin/tdoc-update" --auto');
+  assert(call !== -1, 'Step 0 should keep the skill current');
+  const probe = skill.lastIndexOf("grep -q -- '--auto)'", call);
+  assert(probe !== -1 && probe < call, 'the --auto call must be capability-probed');
+  assert(skill.lastIndexOf('TDOC_SKIP_UPDATE_CHECK', call) !== -1,
+    'there must be an off switch');
+});
+
+t('tdoc-update arg loop still has no catch-all (why the probe exists)', () => {
+  // If this ever gains a `*)` that errors on unknown flags, the probe in
+  // SKILL.md can be simplified — but until then it is load-bearing.
+  const src = readBin('tdoc-update');
+  const loop = src.slice(src.indexOf('for arg in "$@"'), src.indexOf('done', src.indexOf('for arg in "$@"')));
+  assert(!/\*\)/.test(loop), 'arg loop gained a catch-all — revisit the SKILL.md probe');
+});
+
 console.log(`\n${pass} passed, ${fail} failed`);
 process.exit(fail ? 1 : 0);


### PR DESCRIPTION
## What & why

Fixes #247.

Every run already compared the checkout to `origin/main` and printed `TDOC_UPDATE_AVAILABLE`, but applying it was something the user had to know to do. People ran old code for a long time. Someone who asked for a document did not ask to be interviewed about versions.

`tdoc-update --auto` now runs in Step 0 on every invocation and just applies the update.

| state | what `--auto` does |
|---|---|
| behind, clean | fast-forwards; **one** line: `[tdoc] updated tdoc to <sha>` |
| already current | nothing at all — no output |
| dirty tree | skips; does **not** stash |
| diverged | skips; does **not** rewrite the branch |
| any | never redeploys a Worker |

Measured, all five:

```
① clean + behind   → [[tdoc] updated tdoc to 4db5e04]   HEAD advanced ✓
② already current  → []
③ tracked file modified → "local edits present — skipping"
                        stash count 0 ✓ · my edit intact ✓ · HEAD unmoved ✓
④ diverged         → "checkout has diverged — skipping"   my commit intact ✓
⑤ without --auto   → unchanged interactive behaviour
```

## Where I drew the line, and why

The instruction was "fully automatic, stop asking". Two behaviours are deliberately **not** automatic, and neither is a prompt:

- **It will not auto-stash.** That is the one path in `tdoc-update` that can lose someone's uncommitted work. Skipping is silent; it does not ask, it just leaves the tree alone.
- **It will not redeploy a Worker.** Updating the local skill is one thing; pushing a bundle to the user's own Cloudflare/Vercel account is another, and should not happen because someone asked for a doc.

`TDOC_SKIP_UPDATE_CHECK=1` disables all of it.

## The probe in Step 0 is load-bearing

`tdoc-update`'s argument loop has **no catch-all**:

```bash
for arg in "$@"; do
  case "$arg" in
    --yes|-y) YES=1 ;;
    --check) CHECK=1 ;;
    -h|--help) ... ;;
  esac
done
```

So a checkout predating `--auto` would **silently ignore the flag and run the full interactive update** — auto-stashing local edits and offering a redeploy, on every skill run. That is exactly the behaviour this PR exists to prevent, and I hit it live while testing against the installed copy.

Step 0 therefore checks the flag exists before using it, and a test pins the loop's permissiveness, so if it ever gains a `*)` the probe gets simplified deliberately rather than by accident.

## Tests

Four cases in `cli.test.js`; verified they fail when the guards are removed (`39 passed, 3 failed` with the probe stripped).

`npm test` — `PASS — all 43 suite(s) green`.

## Security note

This makes the skill fetch and execute new code from `origin/main` on every run without asking, which is a real change in posture and worth naming: a compromised `main` reaches users on their next invocation rather than whenever they choose to update. That is inherent to the request for automatic updates, and is mitigated only by it being fast-forward-only from the project's own remote over HTTPS, never a different ref or remote, and by `TDOC_SKIP_UPDATE_CHECK=1`. It narrows two things versus the existing `tdoc-update`: no stashing, so it cannot touch uncommitted work, and no Worker deploy, so it cannot push anything to the user's cloud account. No new credential, network destination, or user input is involved.

## Not merging

Held for your call, given the posture change above.