### PR TITLE
The site stops teaching the pre-hosted flow

### DIFF
--- a/landing/tdoc-start/v1/index.html
+++ b/landing/tdoc-start/v1/index.html
@@ -449,15 +449,16 @@
     <div class="steps">
 
       <article class="step-card">
-        <div class="step-hd"><span class="step-num">1</span><div><h3>Get set up.</h3><p>One line. Your AI installs tdoc and builds you a first doc to practise on.</p></div></div>
+        <div class="step-hd"><span class="step-num">1</span><div><h3>Get set up.</h3><p>One line. Your AI installs tdoc, builds you a first doc to practise on, and hands back a link you can send to anyone.</p></div></div>
         <div class="step-bd">
           <div class="term"><div class="term-bar"><span class="term-dot r"></span><span class="term-dot y"></span><span class="term-dot g"></span><span class="term-title">claude &mdash; tdoc</span></div><div class="term-bd"><span class="p">&rsaquo; </span>Set up tdoc and make my first doc: https://github.com/tornado-doc/tdoc/blob/main/FIRST-DOC.md</div></div>
           <p class="hint">You get a Game of Life page with a live board, published to a link you can share.</p>
           <p style="margin:14px 0 0"><a class="btn btn-primary" href="/start" style="width:auto;display:inline-flex;padding:0 22px">Copy the line</a></p>
           <p style="margin:8px 0 0;font-size:14px;color:#767c8b">or <a href="/templates" style="color:inherit">browse the looks</a> and start from a template.</p>
           <details class="more"><summary>Where does it get published?</summary><div class="inner">
-            <p class="hint" style="margin:0 0 10px">To a free Cloudflare account you own. The first time, your agent walks you through it: you click <em>create account</em> and <em>enable R2</em> in your own browser. No card. About five minutes, once.</p>
-            <p class="hint" style="margin:0">Only want it on your machine? Say <b>keep it local</b> and skip the account entirely.</p>
+            <p class="hint" style="margin:0 0 10px">To <b>tdoc.dev</b>, free. Nothing to sign up for and nothing to click: the first publish signs you in with GitHub once, on this machine, and every doc after that goes straight out.</p>
+            <p class="hint" style="margin:0 0 10px">Anyone with the link can read it, and can look back through earlier versions. It is never listed anywhere, so only the people you send it to will find it.</p>
+            <p class="hint" style="margin:0">Want it somewhere else? Say <b>publish it to my own Cloudflare</b> to host it yourself, or <b>keep it local</b> to skip publishing entirely.</p>
           </div></details>
         </div>
       </article>

--- a/test/tdoc-start.test.js
+++ b/test/tdoc-start.test.js
@@ -286,5 +286,32 @@ t('/start serves the doc and fails safe', () => {
     '/start must route through landingResponse so it inherits the neutral-page fallback');
 });
 
+// ---- the site must not teach the pre-publish-first flow (#236 S6) ----
+
+t('/start names tdoc.dev, not a Cloudflare account, as the destination', () => {
+  const html = fs.readFileSync(path.join(__dirname, '..', 'landing', 'tdoc-start', 'v1', 'index.html'), 'utf8');
+  const from = html.indexOf('Where does it get published');
+  const fold = html.slice(from, html.indexOf('</details>', from));
+  assert(!/free Cloudflare account you own/.test(fold),
+    '/start still names a Cloudflare account as the default destination');
+  assert(!/enable R2|About five minutes/.test(fold),
+    '/start still walks people through Cloudflare setup for the default path');
+  assert(/tdoc\.dev/.test(fold), '/start should name tdoc.dev');
+  // Self-hosting and local-only are demoted, not deleted.
+  assert(/my own Cloudflare/.test(fold), 'self-hosting should still be reachable');
+  assert(/keep it local/.test(fold), 'local-only should still be reachable');
+});
+
+t('the /me create-doc modal does not teach a manual Publish step', () => {
+  // /tdoc new publishes on its own since #239; telling people to hit Publish
+  // sends them looking for a button that is not part of the flow any more.
+  const src = fs.readFileSync(path.join(__dirname, '..', 'worker', 'worker.js'), 'utf8');
+  const from = src.indexOf('class="mk-bd"');
+  const modal = src.slice(from, src.indexOf('</ol>', from));
+  assert(!/Hit <b>Publish<\/b>/.test(modal), '/me modal still says to hit Publish');
+  assert(/publishes it, and hands you the link/.test(modal),
+    '/me modal should say the link comes back on its own');
+});
+
 console.log(`\n${pass} passed, ${fail} failed.`);
 process.exit(fail ? 1 : 0);

--- a/worker/worker.js
+++ b/worker/worker.js
@@ -1550,9 +1550,8 @@ ${rows.length === 0 ? '<p class="empty">No published docs yet. Hit <b>Create a d
         <li>Open the AI you already use.
           <span class="mk-say">Use tdoc to make me a one page summary of this quarter, with a chart of weekly signups.</span>
         </li>
-        <li>It writes the page and opens it for you.</li>
-        <li>Hit <b>Publish</b>, top right, to put it online.</li>
-        <li>Send the link to anyone. They comment on the page, and your AI answers them.</li>
+        <li>It writes the page, publishes it, and hands you the link.</li>
+        <li>Send that link to anyone. They comment on the page, and your AI answers them.</li>
       </ol>
     </div>
     <div class="mk-ft">Want a specific look first? <a href="/templates">Browse templates</a>. &nbsp;·&nbsp; Not set up yet? <a href="/start">Start here</a>.</div>


### PR DESCRIPTION
## What & why

Fixes #250. Slice **S6** of https://tdoc.dev/d/tdoc-onboarding-redesign/v/3

Two surfaces described a setup that no longer happens. That is worse than saying nothing — a reader arrives expecting it.

**`/start`, section 1** told people their doc goes to "a free Cloudflare account you own", with *create account* and *enable R2* clicks and "about five minutes, once". Since #237 and #239 the default is tdoc.dev, with no Cloudflare account and nothing to click.

It now describes the real destination, and adds what the reader is actually about to wonder — who can see this:

> Anyone with the link can read it, and can look back through earlier versions. It is never listed anywhere, so only the people you send it to will find it.

That wording matches what a plain publish really does (the legacy access policy, kept as-is per #245/#246), rather than claiming "unlisted".

Self-hosting and local-only stay in the same fold — demoted, not deleted.

**The `/me` "Create a doc" modal** said *"Hit Publish, top right, to put it online."* `/tdoc new` publishes on its own since #239, so that sent people hunting for a button that is not in the flow.

## S10 is deliberately not done

The redesign also listed S10, *"three surfaces teach three different opening prompts."* I checked it before implementing and it does not hold up:

- `/start` and `server/onboard.js` show the **same** string — onboard.js builds the line /start displays.
- The `/me` line is a usage example for someone already set up, not a competing setup instruction.
- The homepage teaches no line at all; it links to `/start`.

There is nothing to unify. That finding was wrong when I wrote it, and #250 records why, so it does not get re-opened on the strength of it.

## Tests

Two cases added to `tdoc-start.test.js`, verified red against the old copy (`26 passed, 2 failed`):

- `/start` names tdoc.dev, does not name a Cloudflare account or R2, and still offers self-host and local-only.
- The `/me` modal no longer says to hit Publish.

`npm test` — `PASS — all 43 suite(s) green`.

## Checklist

- [x] `npm test` passes.
- [x] `worker.js` touched, but only a static copy string inside the `/me` modal — no route, auth, or CSP surface. Playwright suites are not installed here and skip; they reproduce that way on clean `main`.
- [x] `SKILL.md` not edited.
- [x] No version change.

## Security note

Copy only. The `/start` change edits a published landing document's HTML text; the `worker.js` change edits three list items in the `/me` modal's static markup. No route, handler, auth check, CSP directive, or user input path is touched, and no new text is interpolated from a request.