### PR TITLE
Ask the telemetry question after the work, not before it

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -1146,6 +1146,16 @@ if [ -n "${SKILL_TELEMETRY:-}" ]; then
   TEL_EFFECTIVE="$SKILL_TELEMETRY"
 elif [ -n "$TEL_MODE_PERSISTED" ]; then
   TEL_EFFECTIVE="$TEL_MODE_PERSISTED"
+elif [ "$TEL_PROMPTED" = "no" ]; then
+  # First ever run. The consent question used to be asked here, before any
+  # work — so the very first thing someone got after asking for a document
+  # was a question about analytics. It moves to the Final Step, after the
+  # link is in their hands.
+  #
+  # Nothing is recorded for this run. Defaulting to "on" and asking
+  # afterwards would be recording before consent; losing one event is the
+  # cheaper mistake.
+  TEL_EFFECTIVE="deferred"
 else
   TEL_EFFECTIVE="on"
 fi
@@ -1156,7 +1166,10 @@ fi
 TEL_SESSION_ID="${CLAUDE_SESSION_ID:-shell-$$-$(date +%s)}"
 
 # Write per-session sentinel (not one global file)
-if [ "$TEL_EFFECTIVE" != "off" ]; then
+# Only "on" writes. "deferred" (a first run, consent not yet asked) records
+# nothing at all — no sentinel, no pending marker — so there is nothing to
+# reap and nothing logged before the user agreed to it.
+if [ "$TEL_EFFECTIVE" = "on" ]; then
   mkdir -p "$TEL_HOME/sentinels"
   date +%s > "$TEL_HOME/sentinels/$TEL_SESSION_ID"
   find "$TEL_HOME/sentinels" -type f -mtime +1 -delete 2>/dev/null || true
@@ -1232,7 +1245,7 @@ if [ -x "$TDOC_DIR/bin/tdoc-update-nag" ]; then
   NAG_LINE="$("$TDOC_DIR/bin/tdoc-update-nag" 2>/dev/null || true)"
   if printf '%s' "$NAG_LINE" | grep -q '^TDOC_UPDATE_AVAILABLE:'; then
     echo "$NAG_LINE"
-    if [ "$TEL_EFFECTIVE" != "off" ]; then
+    if [ "$TEL_EFFECTIVE" = "on" ]; then
       "$TDOC_DIR/telemetry/bin/telemetry-log" \
         --skill tdoc \
         --event-type upgrade_prompted \
@@ -1254,8 +1267,14 @@ echo "TDOC_VERSION: $INSTALLED_VERSION"
 
 ### Instructions for the agent
 
-**If `TEL_PROMPTED` is `no`** (first time the user runs tdoc with
-telemetry), ask the user ONCE with this text and two options:
+**If `TEL_PROMPTED` is `no`, ask nothing now.** The preamble set
+`TEL_EFFECTIVE=deferred`, which records nothing for this run. Do the work
+the user actually asked for, hand over the link, and only then ask — the
+question lives in the Final Step. A person who asked for a document should
+not have their first interaction with tdoc be an analytics prompt.
+
+The question itself, when the Final Step reaches it, is this text with two
+options:
 
 > tdoc can record when it runs, how it went (success/error/abandoned),
 > how long it took, and a random ID for your machine, and send it to
@@ -1275,13 +1294,8 @@ or any other host without that tool), present the same text as plain
 prose and wait for the user's typed reply (A/B). Either way, record
 their choice the same.
 
-After they pick, record the choice:
-
-```bash
-echo "MODE_FROM_USER" > "$TEL_CONFIG_FILE"  # "on" or "off"
-touch "$TEL_PROMPTED_FLAG"
-TEL_EFFECTIVE="$(cat "$TEL_CONFIG_FILE")"
-```
+Recording their answer is the Final Step's job — see there. Do not ask
+here, and do not ask twice.
 
 **If `TEL_PROMPTED` is `yes`**, do NOT ask again. Proceed silently.
 
@@ -1334,8 +1348,33 @@ rm -f "$TEL_HOME/sentinels/$TEL_SESSION_ID"
 # event, so the self-healing reaper must not later treat it as orphaned.
 rm -f "$TEL_HOME/telemetry/pending/.pending-$TEL_SESSION_ID" 2>/dev/null
 
-TEL_EFFECTIVE="${SKILL_TELEMETRY:-$(cat "$TEL_HOME/.telemetry-mode" 2>/dev/null || echo on)}"
+TEL_PROMPTED="no"; [ -f "$TEL_HOME/.telemetry-prompted" ] && TEL_PROMPTED="yes"
+TEL_MODE_PERSISTED="$(cat "$TEL_HOME/.telemetry-mode" 2>/dev/null | tr -d ' \n\r')"
+if [ -n "${SKILL_TELEMETRY:-}" ]; then
+  TEL_EFFECTIVE="$SKILL_TELEMETRY"
+elif [ -n "$TEL_MODE_PERSISTED" ]; then
+  TEL_EFFECTIVE="$TEL_MODE_PERSISTED"
+elif [ "$TEL_PROMPTED" = "no" ]; then
+  TEL_EFFECTIVE="deferred"
+else
+  TEL_EFFECTIVE="on"
+fi
+echo "TEL_EFFECTIVE: $TEL_EFFECTIVE"
 ```
+
+**If `TEL_EFFECTIVE` is `deferred`** — this was the user's first ever run.
+Hand over the finished work FIRST. Then, once the link is in their hands,
+ask the consent question above, exactly once, and record their answer:
+
+```bash
+echo "MODE_FROM_USER" > "$TEL_HOME/.telemetry-mode"   # "on" or "off"
+touch "$TEL_HOME/.telemetry-prompted"
+```
+
+Then **stop** — log nothing for this run. There is no sentinel and no
+pending marker to clean up, because the preamble wrote neither. The next
+run honours whatever they chose. One lost event is the correct price for
+not recording before someone agreed to it.
 
 If `TEL_EFFECTIVE` is `off`, **stop here** — do not call telemetry-log.
 

--- a/skills/tdoc/SKILL.md
+++ b/skills/tdoc/SKILL.md
@@ -1146,6 +1146,16 @@ if [ -n "${SKILL_TELEMETRY:-}" ]; then
   TEL_EFFECTIVE="$SKILL_TELEMETRY"
 elif [ -n "$TEL_MODE_PERSISTED" ]; then
   TEL_EFFECTIVE="$TEL_MODE_PERSISTED"
+elif [ "$TEL_PROMPTED" = "no" ]; then
+  # First ever run. The consent question used to be asked here, before any
+  # work — so the very first thing someone got after asking for a document
+  # was a question about analytics. It moves to the Final Step, after the
+  # link is in their hands.
+  #
+  # Nothing is recorded for this run. Defaulting to "on" and asking
+  # afterwards would be recording before consent; losing one event is the
+  # cheaper mistake.
+  TEL_EFFECTIVE="deferred"
 else
   TEL_EFFECTIVE="on"
 fi
@@ -1156,7 +1166,10 @@ fi
 TEL_SESSION_ID="${CLAUDE_SESSION_ID:-shell-$$-$(date +%s)}"
 
 # Write per-session sentinel (not one global file)
-if [ "$TEL_EFFECTIVE" != "off" ]; then
+# Only "on" writes. "deferred" (a first run, consent not yet asked) records
+# nothing at all — no sentinel, no pending marker — so there is nothing to
+# reap and nothing logged before the user agreed to it.
+if [ "$TEL_EFFECTIVE" = "on" ]; then
   mkdir -p "$TEL_HOME/sentinels"
   date +%s > "$TEL_HOME/sentinels/$TEL_SESSION_ID"
   find "$TEL_HOME/sentinels" -type f -mtime +1 -delete 2>/dev/null || true
@@ -1232,7 +1245,7 @@ if [ -x "$TDOC_DIR/bin/tdoc-update-nag" ]; then
   NAG_LINE="$("$TDOC_DIR/bin/tdoc-update-nag" 2>/dev/null || true)"
   if printf '%s' "$NAG_LINE" | grep -q '^TDOC_UPDATE_AVAILABLE:'; then
     echo "$NAG_LINE"
-    if [ "$TEL_EFFECTIVE" != "off" ]; then
+    if [ "$TEL_EFFECTIVE" = "on" ]; then
       "$TDOC_DIR/telemetry/bin/telemetry-log" \
         --skill tdoc \
         --event-type upgrade_prompted \
@@ -1254,8 +1267,14 @@ echo "TDOC_VERSION: $INSTALLED_VERSION"
 
 ### Instructions for the agent
 
-**If `TEL_PROMPTED` is `no`** (first time the user runs tdoc with
-telemetry), ask the user ONCE with this text and two options:
+**If `TEL_PROMPTED` is `no`, ask nothing now.** The preamble set
+`TEL_EFFECTIVE=deferred`, which records nothing for this run. Do the work
+the user actually asked for, hand over the link, and only then ask — the
+question lives in the Final Step. A person who asked for a document should
+not have their first interaction with tdoc be an analytics prompt.
+
+The question itself, when the Final Step reaches it, is this text with two
+options:
 
 > tdoc can record when it runs, how it went (success/error/abandoned),
 > how long it took, and a random ID for your machine, and send it to
@@ -1275,13 +1294,8 @@ or any other host without that tool), present the same text as plain
 prose and wait for the user's typed reply (A/B). Either way, record
 their choice the same.
 
-After they pick, record the choice:
-
-```bash
-echo "MODE_FROM_USER" > "$TEL_CONFIG_FILE"  # "on" or "off"
-touch "$TEL_PROMPTED_FLAG"
-TEL_EFFECTIVE="$(cat "$TEL_CONFIG_FILE")"
-```
+Recording their answer is the Final Step's job — see there. Do not ask
+here, and do not ask twice.
 
 **If `TEL_PROMPTED` is `yes`**, do NOT ask again. Proceed silently.
 
@@ -1334,8 +1348,33 @@ rm -f "$TEL_HOME/sentinels/$TEL_SESSION_ID"
 # event, so the self-healing reaper must not later treat it as orphaned.
 rm -f "$TEL_HOME/telemetry/pending/.pending-$TEL_SESSION_ID" 2>/dev/null
 
-TEL_EFFECTIVE="${SKILL_TELEMETRY:-$(cat "$TEL_HOME/.telemetry-mode" 2>/dev/null || echo on)}"
+TEL_PROMPTED="no"; [ -f "$TEL_HOME/.telemetry-prompted" ] && TEL_PROMPTED="yes"
+TEL_MODE_PERSISTED="$(cat "$TEL_HOME/.telemetry-mode" 2>/dev/null | tr -d ' \n\r')"
+if [ -n "${SKILL_TELEMETRY:-}" ]; then
+  TEL_EFFECTIVE="$SKILL_TELEMETRY"
+elif [ -n "$TEL_MODE_PERSISTED" ]; then
+  TEL_EFFECTIVE="$TEL_MODE_PERSISTED"
+elif [ "$TEL_PROMPTED" = "no" ]; then
+  TEL_EFFECTIVE="deferred"
+else
+  TEL_EFFECTIVE="on"
+fi
+echo "TEL_EFFECTIVE: $TEL_EFFECTIVE"
 ```
+
+**If `TEL_EFFECTIVE` is `deferred`** — this was the user's first ever run.
+Hand over the finished work FIRST. Then, once the link is in their hands,
+ask the consent question above, exactly once, and record their answer:
+
+```bash
+echo "MODE_FROM_USER" > "$TEL_HOME/.telemetry-mode"   # "on" or "off"
+touch "$TEL_HOME/.telemetry-prompted"
+```
+
+Then **stop** — log nothing for this run. There is no sentinel and no
+pending marker to clean up, because the preamble wrote neither. The next
+run honours whatever they chose. One lost event is the correct price for
+not recording before someone agreed to it.
 
 If `TEL_EFFECTIVE` is `off`, **stop here** — do not call telemetry-log.
 

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -772,8 +772,15 @@ t('a first run defers the telemetry question and records nothing', () => {
   const step0 = skill.slice(skill.indexOf('## Step 0'), skill.indexOf('## Final Step'));
 
   // First run resolves to "deferred", not "on".
-  assert(/TEL_PROMPTED" = "no" \]; then\s*\n(?:#[^\n]*\n|\s*#[^\n]*\n)*\s*TEL_EFFECTIVE="deferred"/.test(step0),
-    'a first run should resolve TEL_EFFECTIVE to deferred');
+  // Checked as a line sequence rather than one regex. The regex version had
+  // two alternatives matching the same input inside a star — exponential
+  // backtracking, which CodeQL flagged as js/redos.
+  const lines = step0.split('\n').map((l) => l.trim());
+  const branch = lines.findIndex((l) => l.includes('TEL_PROMPTED" = "no" ]; then'));
+  assert(branch !== -1, 'no first-run branch in the mode resolution');
+  const body = lines.slice(branch + 1).filter((l) => l && !l.startsWith('#'));
+  assert(body[0] === 'TEL_EFFECTIVE="deferred"',
+    `a first run should resolve TEL_EFFECTIVE to deferred, got: ${body[0]}`);
 
   // And "deferred" must not slip through a `!= off` gate and write a sentinel.
   assert(!/TEL_EFFECTIVE" != "off" \]; then\s*\n\s*mkdir -p "\$TEL_HOME\/sentinels"/.test(step0),

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -764,5 +764,39 @@ t('tdoc-update arg loop still has no catch-all (why the probe exists)', () => {
   assert(!/\*\)/.test(loop), 'arg loop gained a catch-all — revisit the SKILL.md probe');
 });
 
+
+// ---- consent is asked after the work, not before it (#236 S9) ----
+
+t('a first run defers the telemetry question and records nothing', () => {
+  const skill = fs.readFileSync(path.join(__dirname, '..', 'SKILL.md'), 'utf8');
+  const step0 = skill.slice(skill.indexOf('## Step 0'), skill.indexOf('## Final Step'));
+
+  // First run resolves to "deferred", not "on".
+  assert(/TEL_PROMPTED" = "no" \]; then\s*\n(?:#[^\n]*\n|\s*#[^\n]*\n)*\s*TEL_EFFECTIVE="deferred"/.test(step0),
+    'a first run should resolve TEL_EFFECTIVE to deferred');
+
+  // And "deferred" must not slip through a `!= off` gate and write a sentinel.
+  assert(!/TEL_EFFECTIVE" != "off" \]; then\s*\n\s*mkdir -p "\$TEL_HOME\/sentinels"/.test(step0),
+    'the sentinel gate must require "on", not merely "not off" — deferred would pass');
+  assert(/TEL_EFFECTIVE" = "on" \]; then\s*\n\s*mkdir -p "\$TEL_HOME\/sentinels"/.test(step0),
+    'the sentinel should only be written when telemetry is on');
+
+  // Step 0 must not contain the question any more.
+  assert(!/ask the user ONCE with this text/.test(step0),
+    'Step 0 still asks the consent question before doing the work');
+});
+
+t('the Final Step owns the consent question and logs nothing for that run', () => {
+  const skill = fs.readFileSync(path.join(__dirname, '..', 'SKILL.md'), 'utf8');
+  const final = skill.slice(skill.indexOf('## Final Step'));
+  assert(/is `deferred`/.test(final), 'the Final Step should handle the deferred first run');
+  assert(/Hand over the finished work FIRST/.test(final),
+    'the Final Step should deliver before asking');
+  assert(/\.telemetry-prompted/.test(final) && /\.telemetry-mode/.test(final),
+    'the Final Step should persist the answer');
+  assert(/log nothing for this run/.test(final),
+    'the deferred run must not be logged — that would be recording before consent');
+});
+
 console.log(`\n${pass} passed, ${fail} failed`);
 process.exit(fail ? 1 : 0);


### PR DESCRIPTION
## What & why

Fixes #252. Slice **S9** of https://tdoc.dev/d/tdoc-onboarding-redesign/v/3

On a first run the consent question was the first thing that happened. Someone typed *"write me a one-pager"* and got a multiple-choice question about analytics before any document existed. Asking is fine; asking **first** is what made the out-of-the-box path feel like paperwork.

It moves to the Final Step: do the work, hand over the link, then ask.

## The consent wrinkle this exposes

Deferring the question forces an answer the old ordering never needed: **what does the first run record while consent is still unknown?**

`TEL_EFFECTIVE` defaulted to `on`, which was only safe because the user had already been asked before anything was written. Ask later and that same default means recording before consent.

So a first run resolves to a third mode, `deferred` — no sentinel, no pending marker, no event. The next run honours whatever they chose. One lost event is the right price for not recording before someone agreed to it.

## The part that was easy to get wrong

`deferred` passes a `!= "off"` test. Both gates in Step 0 used exactly that, so the sentinel and pending marker would have been written anyway and the whole thing would have looked fine while quietly recording an unconsented run.

I hit this in testing — the simulation showed `模式: deferred | 写了 sentinel: 会`. Both gates are now `= "on"`, and there is a test asserting specifically that the sentinel gate is not a not-off test.

## Lifecycle, measured

```
first run              mode=deferred  sentinel written: no ✓  question asked: no ✓
user answers "on",
second run             mode=on        sentinel written: yes ✓ question asked: no ✓
user answers "off"     mode=off       records: no ✓
```

## Tests

Two cases in `cli.test.js`, verified red when the deferred branch is removed (`41 passed, 3 failed`):

- a first run resolves to `deferred`, the sentinel gate requires `on` rather than not-off, and Step 0 no longer contains the question
- the Final Step delivers first, owns the question, persists the answer, and logs nothing for that run

`npm test` — `PASS — all 43 suite(s) green`.

## Checklist

- [x] `npm test` passes.
- [x] Nothing browser-facing or worker-side; Playwright suites do not apply.
- [x] `SKILL.md` edited → copied to `skills/tdoc/SKILL.md` (a test pins them identical).
- [x] No version change.

## Security note

This strictly reduces what is collected: a first run now records nothing at all, where previously it recorded under a default-on mode. No new data, destination, or credential is involved. The consent text, the three opt-out paths, and the fields recorded are unchanged; only the ordering and the first-run default move.