### PR TITLE
Publishing to hosted tdoc.dev no longer requires jq

### DIFF
--- a/bin/tdoc-publish
+++ b/bin/tdoc-publish
@@ -52,6 +52,49 @@ EOF
 }
 
 SLUG=""
+# ── JSON helpers, Node-backed ────────────────────────────────────────────
+# Publishing to hosted tdoc.dev used to hard-fail without jq. Node 18+ is
+# already a requirement on every path, so the hosted path has no reason to
+# need a second JSON tool that macOS does not ship. Self-hosting still uses
+# jq: those paths are wrangler/vercel territory and their own dependency
+# checks already assume a developer machine.
+#
+# json_get  <dotted.path>   JSON on stdin  → the value, or empty
+# json_str  <string>                       → a JSON-encoded string
+json_get() {
+  node -e '
+    let s = "";
+    process.stdin.on("data", (d) => { s += d; });
+    process.stdin.on("end", () => {
+      let o;
+      try { o = JSON.parse(s); } catch { process.exit(0); }
+      const v = process.argv[1].split(".").reduce((a, k) => (a == null ? a : a[k]), o);
+      if (v !== undefined && v !== null) process.stdout.write(String(v));
+    });
+  ' "$1"
+}
+json_str() { node -e 'process.stdout.write(JSON.stringify(process.argv[1]))' "$1"; }
+
+# build_payload <slug> <version> <html-file> <meta-file> <widgets-json> [comments-file]
+# Node reads the files itself: an entire HTML document, images and all, never
+# has to survive a shell round trip.
+build_payload() {
+  node -e '
+    const fs = require("fs");
+    const [slug, version, htmlPath, metaPath, widgetsJson, commentsPath] = process.argv.slice(1);
+    const out = {
+      slug,
+      version: Number(version),
+      html: fs.readFileSync(htmlPath, "utf8"),
+      meta: JSON.parse(fs.readFileSync(metaPath, "utf8")),
+    };
+    if (commentsPath) out.comments = JSON.parse(fs.readFileSync(commentsPath, "utf8"));
+    const widgets = JSON.parse(widgetsJson || "{}");
+    if (Object.keys(widgets).length) out.widgets = widgets;
+    process.stdout.write(JSON.stringify(out));
+  ' "$1" "$2" "$3" "$4" "$5" "${6:-}"
+}
+
 PLATFORM_FLAG="${TDOC_PLATFORM:-}"
 SIGNIN_ONLY=0
 VISIBILITY_FLAG=""
@@ -240,11 +283,12 @@ hosted_github_signin() {
     exit 1
   fi
   local user_code device_code uri interval expires
-  user_code="$(printf '%s' "$payload" | jq -r '.user_code // empty')"
-  device_code="$(printf '%s' "$payload" | jq -r '.device_code // empty')"
-  uri="$(printf '%s' "$payload" | jq -r '.verification_uri_complete // .verification_uri // empty')"
-  interval="$(printf '%s' "$payload" | jq -r '.interval // 5')"
-  expires="$(printf '%s' "$payload" | jq -r '.expires_in // 900')"
+  user_code="$(printf '%s' "$payload" | json_get user_code)"
+  device_code="$(printf '%s' "$payload" | json_get device_code)"
+  uri="$(printf '%s' "$payload" | json_get verification_uri_complete)"
+  [ -z "$uri" ] && uri="$(printf '%s' "$payload" | json_get verification_uri)"
+  interval="$(printf '%s' "$payload" | json_get interval)"; interval="${interval:-5}"
+  expires="$(printf '%s' "$payload" | json_get expires_in)"; expires="${expires:-900}"
   if [ -z "$user_code" ] || [ -z "$device_code" ] || [ -z "$uri" ]; then
     echo "[tdoc] GitHub device-flow start was missing user_code/device_code." >&2
     printf '%s\n' "$payload" | head -c 400 >&2; echo >&2
@@ -319,11 +363,12 @@ hosted_github_signin() {
       -d "{\"device_code\":\"$(printf '%s' "$device_code" | sed 's/"/\\"/g')\"}")" || continue
     http="${resp##*$'\n'}"
     payload="${resp%$'\n'*}"
-    if printf '%s' "$payload" | jq -e '.ok == true' >/dev/null 2>&1; then
-      echo "[tdoc] Signed in as $(printf '%s' "$payload" | jq -r '.identity.login // "github user"')" >&2
+    if [ "$(printf '%s' "$payload" | json_get ok)" = "true" ]; then
+      _who="$(printf '%s' "$payload" | json_get identity.login)"
+      echo "[tdoc] Signed in as ${_who:-github user}" >&2
       return 0
     fi
-    err="$(printf '%s' "$payload" | jq -r '.error // empty')"
+    err="$(printf '%s' "$payload" | json_get error)"
     case "$err" in
       authorization_pending|'') ;;
       slow_down) interval=$((interval + 5)) ;;
@@ -375,9 +420,9 @@ first_time_setup_hosted() {
     printf '%s\n' "$payload" | head -c 400 >&2; echo >&2
     exit 1
   fi
-  token="$(printf '%s' "$payload" | jq -r '.token // empty')"
-  account_id="$(printf '%s' "$payload" | jq -r '.account_id // empty')"
-  github_login="$(printf '%s' "$payload" | jq -r '.github_login // empty')"
+  token="$(printf '%s' "$payload" | json_get token)"
+  account_id="$(printf '%s' "$payload" | json_get account_id)"
+  github_login="$(printf '%s' "$payload" | json_get github_login)"
   if [ -z "$token" ] || [ -z "$account_id" ]; then
     echo "[tdoc] hosted token response was missing token/account_id." >&2
     printf '%s\n' "$payload" | head -c 400 >&2; echo >&2
@@ -387,22 +432,27 @@ first_time_setup_hosted() {
   public_host="${public_host#https://}"
   (
     umask 077
-    jq -n \
-      --arg tok "$token" \
-      --arg base "$base" \
-      --arg host "$public_host" \
-      --arg acct "$account_id" \
-      --arg gh "$github_login" \
-      '{platform:"hosted", upload_token:$tok, base:$base, public_host:$host, account_id:$acct, github_login:$gh, created: now | todate}' \
-      > "$CONFIG_FILE"
+    node -e '
+      const [tok, base, host, acct, gh] = process.argv.slice(1);
+      process.stdout.write(JSON.stringify({
+        platform: "hosted", upload_token: tok, base, public_host: host,
+        account_id: acct, github_login: gh,
+        created: new Date().toISOString().replace(/\.\d{3}Z$/, "Z"),
+      }));
+    ' "$token" "$base" "$public_host" "$account_id" "$github_login" > "$CONFIG_FILE"
   )
   chmod 600 "$CONFIG_FILE"
   echo "[tdoc] hosted publish configured: $base"
 }
-if ! command -v jq >/dev/null 2>&1; then
+# jq is NOT required to publish to hosted tdoc.dev. Node 18+ is already a
+# requirement everywhere and macOS ships no jq, so demanding it turned a
+# zero-setup path into an install step. The self-host branches still use it
+# and check for it where they need it.
+require_jq_for_selfhost() {
+  command -v jq >/dev/null 2>&1 && return 0
   fail_with_agent_prompt "jq is not installed" \
-    "Install jq so tdoc can build its publish payload. On macOS: 'brew install jq'. On Debian/Ubuntu: 'sudo apt-get install -y jq'. Then run '/tdoc publish $SLUG' again."
-fi
+    "Self-hosting needs jq to build its Cloudflare/Vercel payloads. On macOS: 'brew install jq'. On Debian/Ubuntu: 'sudo apt-get install -y jq'. Publishing to hosted tdoc.dev does not need it — '/tdoc publish $SLUG' without --platform works as-is."
+}
 if ! command -v node >/dev/null 2>&1; then
   fail_with_agent_prompt "node 18+ is not installed" \
     "Install Node.js 18 or newer (https://nodejs.org). On macOS: 'brew install node'. Verify with 'node --version'. Then run '/tdoc publish $SLUG' again."
@@ -486,6 +536,7 @@ vercel_bundle_sha() {
 }
 
 first_time_setup() {
+  require_jq_for_selfhost
   echo "[tdoc] first-time publish setup (cloudflare)"
   require_wrangler
 
@@ -673,6 +724,7 @@ vercel_deploy_prod() {
 }
 
 first_time_setup_vercel() {
+  require_jq_for_selfhost
   echo "[tdoc] first-time publish setup (vercel)"
   require_vercel
 
@@ -781,7 +833,7 @@ if [ ! -f "$CONFIG_FILE" ]; then
 else
   # Existing config is the default. An explicit --platform that differs
   # rewrites published.json via full re-setup (not a half-migrate).
-  PLATFORM="$(jq -r '.platform // "cloudflare"' "$CONFIG_FILE")"
+  PLATFORM="$(json_get platform < "$CONFIG_FILE")"; PLATFORM="${PLATFORM:-cloudflare}"
   if [ -n "$PLATFORM_FLAG" ] && [ "$PLATFORM_FLAG" != "$PLATFORM" ]; then
     echo "[tdoc] switching publish platform from '$PLATFORM' to '$PLATFORM_FLAG' (rewriting $CONFIG_FILE)."
     CONFIG_BACKUP="${CONFIG_FILE}.bak.switch"
@@ -802,13 +854,13 @@ else
   fi
 fi
 
-PLATFORM="$(jq -r '.platform // "cloudflare"' "$CONFIG_FILE")"
+PLATFORM="$(json_get platform < "$CONFIG_FILE")"; PLATFORM="${PLATFORM:-cloudflare}"
 
-TOKEN="$(jq -r .upload_token "$CONFIG_FILE")"
+TOKEN="$(json_get upload_token < "$CONFIG_FILE")"
 
 if [ "$PLATFORM" = "hosted" ]; then
-  BASE="$(jq -r '.base // empty' "$CONFIG_FILE")"
-  PUBLIC_HOST="$(jq -r '.public_host // empty' "$CONFIG_FILE")"
+  BASE="$(json_get base < "$CONFIG_FILE")"
+  PUBLIC_HOST="$(json_get public_host < "$CONFIG_FILE")"
   for _f in TOKEN:upload_token BASE:base PUBLIC_HOST:public_host; do
     _var="${_f%%:*}"; _key="${_f##*:}"; _val="$(eval "printf '%s' \"\$$_var\"")"
     if [ -z "$_val" ] || [ "$_val" = "null" ]; then
@@ -975,10 +1027,14 @@ if [ -n "$VISIBILITY_FLAG" ] || [ -n "$HISTORY_FLAG" ] || [ -n "$COMMENTING_FLAG
         )
     ' "$META_FILE" > "$tmp_meta"
   mv "$tmp_meta" "$META_FILE"
-  echo "[tdoc] access → $(jq -c .access "$META_FILE")"
+  echo "[tdoc] access → $(node -e 'const m=JSON.parse(require("fs").readFileSync(process.argv[1],"utf8"));process.stdout.write(JSON.stringify(m.access===undefined?null:m.access))' "$META_FILE")"
 fi
 
-VERSION="$(jq -r '.versions | sort_by(.n) | last | .n' "$META_FILE")"
+VERSION="$(node -e '
+  const m = JSON.parse(require("fs").readFileSync(process.argv[1], "utf8"));
+  const vs = (m.versions || []).map((x) => Number(x.n)).filter(Number.isFinite);
+  process.stdout.write(vs.length ? String(Math.max(...vs)) : "");
+' "$META_FILE")"
 HTML_FILE="$DOC_DIR/v${VERSION}/index.html"
 if [ ! -f "$HTML_FILE" ]; then
   echo "no html at $HTML_FILE" >&2
@@ -1003,26 +1059,18 @@ upload_version() {
     for wf in "$wdir"/*.html; do
       [ -f "$wf" ] || continue
       wname="$(basename "$wf" .html)"
-      widgets_json="$(jq -n --argjson acc "$widgets_json" --arg name "$wname" --rawfile html "$wf" '$acc + {($name): $html}')" || return 1
+      widgets_json="$(node -e '
+        const fs = require("fs");
+        const acc = JSON.parse(process.argv[1]);
+        acc[process.argv[2]] = fs.readFileSync(process.argv[3], "utf8");
+        process.stdout.write(JSON.stringify(acc));
+      ' "$widgets_json" "$wname" "$wf")" || return 1
     done
   fi
-  if [ -f "$comments_file" ] && jq -e 'type == "array" and length > 0' "$comments_file" >/dev/null 2>&1; then
-    payload="$(jq -n \
-      --arg slug "$SLUG" \
-      --argjson version "$v" \
-      --rawfile html "$html_path" \
-      --slurpfile meta "$META_FILE" \
-      --slurpfile comments "$comments_file" \
-      --argjson widgets "$widgets_json" \
-      '{slug:$slug, version:$version, html:$html, meta: $meta[0], comments: $comments[0]} + (if $widgets == {} then {} else {widgets:$widgets} end)')"
+  if [ -f "$comments_file" ] && node -e 'const a=JSON.parse(require("fs").readFileSync(process.argv[1],"utf8"));process.exit(Array.isArray(a)&&a.length?0:1)' "$comments_file" >/dev/null 2>&1; then
+    payload="$(build_payload "$SLUG" "$v" "$html_path" "$META_FILE" "$widgets_json" "$comments_file")" || return 1
   else
-    payload="$(jq -n \
-      --arg slug "$SLUG" \
-      --argjson version "$v" \
-      --rawfile html "$html_path" \
-      --slurpfile meta "$META_FILE" \
-      --argjson widgets "$widgets_json" \
-      '{slug:$slug, version:$version, html:$html, meta: $meta[0]} + (if $widgets == {} then {} else {widgets:$widgets} end)')"
+    payload="$(build_payload "$SLUG" "$v" "$html_path" "$META_FILE" "$widgets_json")" || return 1
   fi
   # Pass the payload via a temp file, not an argument — docs with embedded
   # images exceed ARG_MAX as a curl argument (curl: Argument list too long).
@@ -1036,14 +1084,15 @@ upload_version() {
     --data-binary @"$payload_file")" || { rm -f "$payload_file"; echo "[tdoc] v$v upload: network error/timeout" >&2; return 1; }
   rm -f "$payload_file"
   local ok
-  ok="$(echo "$resp" | jq -r '.ok // false')"
+  ok="$(printf '%s' "$resp" | json_get ok)"; ok="${ok:-false}"
+  _sz="$(printf '%s' "$resp" | json_get size)"
   if [ "$ok" = "true" ]; then
     local merged
-    merged="$(echo "$resp" | jq -r '.mergedComments // 0')"
+    merged="$(printf '%s' "$resp" | json_get mergedComments)"; merged="${merged:-0}"
     if [ "$merged" != "0" ] && [ "$merged" != "null" ]; then
-      echo "[tdoc] v$v uploaded ($(echo "$resp" | jq -r '.size // "?"') bytes, +$merged local comment(s) merged)"
+      echo "[tdoc] v$v uploaded (${_sz:-?} bytes, +$merged local comment(s) merged)"
     else
-      echo "[tdoc] v$v uploaded ($(echo "$resp" | jq -r '.size // "?"') bytes)"
+      echo "[tdoc] v$v uploaded (${_sz:-?} bytes)"
     fi
   else
     echo "[tdoc] v$v upload FAILED: $resp" >&2
@@ -1055,7 +1104,12 @@ upload_version() {
 # picker in the doc UI needs older versions to be reachable too — we don't
 # rely on past publishes having uploaded them. Latest goes last so the
 # meta KV ends up pointing at the actual newest version.
-LOCAL_VERSIONS="$(jq -r '.versions | sort_by(.n) | .[].n' "$META_FILE")"
+LOCAL_VERSIONS="$(node -e '
+  const m = JSON.parse(require("fs").readFileSync(process.argv[1], "utf8"));
+  const vs = (m.versions || []).map((x) => Number(x.n)).filter(Number.isFinite);
+  vs.sort((a, b) => a - b);
+  process.stdout.write(vs.join("\n"));
+' "$META_FILE")"
 echo "[tdoc] uploading $SLUG versions: $(echo "$LOCAL_VERSIONS" | tr '\n' ' ')"
 # Older versions are best-effort: a transient failure on an OLD version must NOT
 # abort the publish before the LATEST version + meta land (otherwise meta

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -70,9 +70,9 @@ t('tdoc-publish defaults to hosted and treats Cloudflare/Vercel as self-host fla
   assert(/sign_in_required/.test(src), 'hosted setup must handle a missing GitHub session');
   assert(!/TDOC_HOSTED_UPLOAD_TOKEN/.test(src), 'hosted setup must not require an out-of-band upload token');
   assert(/TDOC_HOSTED_BASE:-https:\/\/tdoc\.dev/.test(src), 'hosted setup does not default to tdoc.dev');
-  assert(/platform:"hosted"/.test(src), 'hosted setup does not persist hosted platform');
-  assert(/github_login:\$gh/.test(src), 'hosted setup does not persist github_login');
-  assert(/account_id:\$acct/.test(src), 'hosted setup does not persist account_id');
+  assert(/platform: "hosted"/.test(src), 'hosted setup does not persist hosted platform');
+  assert(/github_login: gh/.test(src), 'hosted setup does not persist github_login');
+  assert(/account_id: acct/.test(src), 'hosted setup does not persist account_id');
   assert(/if \[ "\$PLATFORM" = "hosted" \]/.test(src), 'hosted platform branch missing');
   assert(/UPLOAD_BASE="\$BASE"/.test(src), 'hosted branch should upload to configured base');
   assert(/PUBLIC_BASE="\$BASE"/.test(src), 'hosted branch should emit configured hosted base links');
@@ -762,6 +762,50 @@ t('tdoc-update arg loop still has no catch-all (why the probe exists)', () => {
   const src = readBin('tdoc-update');
   const loop = src.slice(src.indexOf('for arg in "$@"'), src.indexOf('done', src.indexOf('for arg in "$@"')));
   assert(!/\*\)/.test(loop), 'arg loop gained a catch-all — revisit the SKILL.md probe');
+});
+
+
+// ---- hosted publish must not need jq (#256) ----
+
+t('the hosted path uses no jq at all', () => {
+  const src = readBin('tdoc-publish');
+  // Everything hosted-reachable: the device flow, the token mint, the config
+  // write and read, the upload payload, and the response parse.
+  const hostedFns = [
+    src.slice(src.indexOf('hosted_github_signin()'), src.indexOf('first_time_setup_hosted()')),
+    src.slice(src.indexOf('first_time_setup_hosted()'), src.indexOf('require_jq_for_selfhost')),
+    src.slice(src.indexOf('build_payload()'), src.indexOf('PLATFORM_FLAG=')),
+  ].join('\n');
+  const calls = hostedFns.split('\n').filter((l) => /\bjq\s+(-|["'$])/.test(l) && !l.trim().startsWith('#'));
+  assert(calls.length === 0, `hosted path still shells out to jq:\n      ${calls.join('\n      ')}`);
+});
+
+t('jq is required for self-hosting, and only there', () => {
+  const src = readBin('tdoc-publish');
+  // No top-level hard fail any more — that turned a zero-setup path into an
+  // install step on a machine that ships no jq.
+  assert(!/^if ! command -v jq >\/dev\/null 2>&1; then$/m.test(src),
+    'the global jq gate is back');
+  assert(/require_jq_for_selfhost\(\)/.test(src), 'the self-host jq gate is missing');
+  for (const fn of ['first_time_setup()', 'first_time_setup_vercel()']) {
+    const i = src.indexOf(fn);
+    assert(i !== -1, `${fn} not found`);
+    const head = src.slice(i, i + 200);
+    assert(/require_jq_for_selfhost/.test(head), `${fn} does not check for jq`);
+  }
+  // And the message must not send a hosted user to install anything.
+  const msg = src.slice(src.indexOf('Self-hosting needs jq'), src.indexOf('Self-hosting needs jq') + 320);
+  assert(/does not need it/.test(msg), 'the jq message should say hosted publishing is unaffected');
+});
+
+t('build_payload embeds the document without a shell round trip', () => {
+  const src = readBin('tdoc-publish');
+  const fn = src.slice(src.indexOf('build_payload()'), src.indexOf('PLATFORM_FLAG='));
+  assert(/readFileSync\(htmlPath/.test(fn), 'the HTML must be read by node, not passed as an argument');
+  assert(/JSON\.stringify\(out\)/.test(fn), 'the payload must be JSON-encoded by node');
+  // Widgets and comments stay optional, the way the jq version had them.
+  assert(/if \(commentsPath\)/.test(fn), 'comments must stay optional');
+  assert(/Object\.keys\(widgets\)\.length/.test(fn), 'widgets must stay optional');
 });
 
 console.log(`\n${pass} passed, ${fail} failed`);

--- a/test/tornado-doc-landing.test.js
+++ b/test/tornado-doc-landing.test.js
@@ -392,7 +392,10 @@ t('bin/tdoc-landing-release writes a clean v1 with no review thread', () => {
 
   // tdoc-publish only attaches comments.json when it is a non-empty array.
   const publish = fs.readFileSync(path.join(root, 'bin', 'tdoc-publish'), 'utf8');
-  assert(/type == "array" and length > 0/.test(publish),
+  // The check moved from jq to node when the hosted path dropped its jq
+  // dependency (#256); the invariant is the same — attach comments.json only
+  // when it is a non-empty array.
+  assert(/Array\.isArray\(a\) *&& *a\.length/.test(publish),
     'tdoc-publish must skip empty comments.json so the release payload does not send a dummy list');
 });
 
@@ -420,7 +423,8 @@ t('release payload carries the homepage access policy', () => {
 
   const publish = fs.readFileSync(path.join(root, 'bin', 'tdoc-publish'), 'utf8');
   // The access block only matters if it is in the upload body.
-  assert(/meta: \$meta\[0\]/.test(publish),
+  // Built by build_payload in node now (#256) rather than jq --slurpfile.
+  assert(/meta: JSON\.parse\(fs\.readFileSync\(metaPath/.test(publish),
     'tdoc-publish no longer sends local meta.json, so payload access never reaches /api/upload');
   // --visibility public must merge, not replace. Otherwise the documented
   // publish line would wipe history_visibility / commenting back to defaults.


### PR DESCRIPTION
## What & why

Fixes #256. Slice **S8** of https://tdoc.dev/d/tdoc-onboarding-redesign/v/3

A publish stopped before doing anything when `jq` was missing. macOS ships no jq, while Node 18+ is already a hard requirement on every tdoc path — and anyone running Claude Code has it. So the hosted path demanded a *second* JSON tool for work Node can do, turning a zero-setup path into an install step for someone who has never opened a package manager.

## Scope: hosted only, deliberately

Self-hosting keeps jq. Those branches are wrangler/Vercel territory, already assume a developer machine, and converting the ~80 remaining call sites would be a large change reaching nobody on the out-of-the-box path.

The top-level `command -v jq` hard fail becomes `require_jq_for_selfhost`, called from `first_time_setup` and `first_time_setup_vercel`. Its message says plainly that hosted publishing is unaffected, rather than implying tdoc needs jq at all.

Two small node helpers cover the reads. The one that mattered is `build_payload`: jq built the upload body with `--rawfile`, embedding an entire HTML document into JSON through the shell. Node reads the files itself, so the document never makes that trip.

## Verified against a genuinely jq-free PATH

Not a mock — every executable symlinked into a temp dir **except** `jq`:

```
jq: 没有 ✓        bash:ok node:ok curl:ok grep:ok sed:ok

hosted    → [tdoc] hosted publish configured
            Published: http://127.0.0.1:8899/d/d/v/1
self-host → Self-hosting needs jq to build its Cloudflare/Vercel payloads...
```

The document carried `café`, embedded quotes and a backslash, plus a widget and a non-empty comments file — the characters most likely to break shell-mediated JSON.

**Method note worth reading.** My first attempt masked jq by putting a *failing* `jq` earlier on PATH. That turned out to be a harsher test for the hosted path — it passed with jq present-but-broken, meaning nothing hosted-reachable even invokes it — but it does **not** exercise the self-host gate, because `command -v jq` succeeds on a file that exists whether or not it runs. I only noticed because the self-host gate stayed silent when it should have fired.

## Tests

Three added, verified red when a single `jq` call is put back on the hosted path (`44 passed, 1 failed`):

- no jq anywhere hosted-reachable (device flow, token mint, config, payload, response)
- jq required in exactly the two self-host entrypoints, and the message does not tell a hosted user to install anything
- `build_payload` reads the document rather than taking it as an argument

Four existing assertions matched the old jq syntax (`platform:"hosted"`, `meta: $meta[0]`, `type == "array" and length > 0`, `account_id:$acct`) and are updated to the same invariants in the new form — the checks are preserved, only the spelling changed.

`npm test` — `PASS — all 43 suite(s) green`.

## Checklist

- [x] `npm test` passes.
- [x] `bin/` only; nothing browser-facing or worker-side, so the Playwright suites do not apply.
- [x] `SKILL.md` not edited.
- [x] No version change.

## Security note

`bin/tdoc-publish` handles the upload token, and this touches how its payloads are built. The replacement is strictly safer on the injection axis: values now reach node as `process.argv` entries and are serialised by `JSON.stringify`, instead of being interpolated into a jq filter string. The HTML document is read from disk by node rather than passed through the shell, which removes an ARG_MAX-sized value from the command line entirely. `json_get` parses stdin with `JSON.parse` inside a try/catch and emits nothing on malformed input, so a hostile response cannot execute or inject — the previous `jq -r` behaviour on bad input was the same. No change to where the token is stored (`chmod 600` on `~/.tdoc/published.json` is untouched), which host it is sent to, or what is sent.