### PR TITLE
fix: hand the server's own node down to the CLIs it spawns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -96,6 +96,15 @@ file and `.claude-plugin/plugin.json`.
 
 ### Fixed
 
+- **Publishing from the modal works when node is version-managed.** The local
+  server passed its own `PATH` straight to the CLIs it spawns. A server started
+  by absolute path — launchd, an editor, `nohup` from a shell that only loads
+  nvm interactively — has the bare system `PATH`, so `tdoc-publish` could not
+  find a node installed by nvm, fnm, asdf or volta and reported `node 18+ is
+  not installed` on a machine running Node 22. The server now puts its own
+  interpreter's directory in front of the child's `PATH`, and the CLI names the
+  `PATH` it searched when the check does fail, so the message stops pointing at
+  the wrong problem. `#259`.
 - **The project mark keeps a white field in both themes, and its hover
   highlight is centred.** The SVG that replaced the raster was fully
   transparent, so the dinosaur read as a see-through outline. The mark is now

--- a/bin/tdoc-publish
+++ b/bin/tdoc-publish
@@ -454,7 +454,10 @@ require_jq_for_selfhost() {
     "Self-hosting needs jq to build its Cloudflare/Vercel payloads. On macOS: 'brew install jq'. On Debian/Ubuntu: 'sudo apt-get install -y jq'. Publishing to hosted tdoc.dev does not need it — '/tdoc publish $SLUG' without --platform works as-is."
 }
 if ! command -v node >/dev/null 2>&1; then
-  fail_with_agent_prompt "node 18+ is not installed" \
+  # Name the PATH that was searched. When this fires from the local server the
+  # user does have node — it is simply not on the PATH the child inherited —
+  # and "install node" sends them to fix the wrong thing. See #259.
+  fail_with_agent_prompt "node 18+ not found on PATH ($PATH)" \
     "Install Node.js 18 or newer (https://nodejs.org). On macOS: 'brew install node'. Verify with 'node --version'. Then run '/tdoc publish $SLUG' again."
 fi
 

--- a/server/server.js
+++ b/server/server.js
@@ -10,6 +10,20 @@ const os = require('os');
 const crypto = require('crypto');
 const { spawn } = require('child_process');
 
+
+// The server knows which Node is running it; a spawned child may not. When the
+// server was started by absolute path — a launchd job, an editor, a desktop
+// launcher, nohup from a shell that only loads nvm interactively — PATH can be
+// the bare system default, and a version-managed node is not on it. The child
+// then reports "node 18+ is not installed" on a machine that has Node 22. Put
+// the running interpreter's directory in front of the child's PATH. See #259.
+function childEnv() {
+  const nodeDir = path.dirname(process.execPath);
+  const current = process.env.PATH || '';
+  const already = current.split(path.delimiter).includes(nodeDir);
+  return already ? process.env : { ...process.env, PATH: `${nodeDir}${path.delimiter}${current}` };
+}
+
 const PORT = process.env.TDOC_PORT ? Number(process.env.TDOC_PORT) : 7878;
 const ROOT = process.env.TDOC_DIR || path.join(os.homedir(), 'tdocs');
 const OVERLAY_PATH = path.join(__dirname, 'overlay.js');
@@ -831,7 +845,7 @@ const server = http.createServer(async (req, res) => {
     // Same spawn hardening as /api/publish: error listener, hard timeout,
     // bounded output. Deleting is quick; 60s covers a slow unpublish curl.
     const args = body.published === false ? [slug, '--local-only'] : [slug];
-    const proc = spawn(bin, args, { env: process.env });
+    const proc = spawn(bin, args, { env: childEnv() });
     let out = '', err = '', settled = false, killed = false;
     const CAP = 64 * 1024;
     const append = (buf, d) => (buf.length < CAP ? buf + d : buf);
@@ -869,7 +883,7 @@ const server = http.createServer(async (req, res) => {
     // a bounded output buffer so runaway child output can't OOM us. wrangler
     // legitimately needs the inherited env (CLOUDFLARE_* creds), so we keep it
     // but this endpoint is now origin/CSRF-gated above.
-    const proc = spawn(bin, [slug], { env: process.env });
+    const proc = spawn(bin, [slug], { env: childEnv() });
     let out = '', err = '', settled = false, killed = false;
     const CAP = 256 * 1024; // 256 KiB of captured output is plenty
     const append = (buf, d) => (buf.length < CAP ? buf + d : buf);

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -848,5 +848,41 @@ t('the Final Step owns the consent question and logs nothing for that run', () =
     'the deferred run must not be logged — that would be recording before consent');
 });
 
+// ---- the local server must hand its own node down to spawned CLIs (#259) ----
+
+t('server spawns CLIs with the running interpreter on PATH', () => {
+  const src = fs.readFileSync(path.join(__dirname, '..', 'server', 'server.js'), 'utf8');
+  assert(/function childEnv\(\)/.test(src), 'childEnv helper missing');
+  assert(/path\.dirname\(process\.execPath\)/.test(src),
+    'childEnv does not derive the node directory from process.execPath');
+  const spawns = src.split('\n').filter(l => /\bspawn\(bin\b/.test(l));
+  assert(spawns.length >= 2, `expected at least 2 spawn sites, found ${spawns.length}`);
+  for (const s of spawns) {
+    assert(/env:\s*childEnv\(\)/.test(s),
+      `spawn site does not pass childEnv(): ${s.trim()}`);
+  }
+});
+
+t('a stripped PATH hides node from a child, and childEnv restores it', () => {
+  // The failure this guards: the server is started by absolute path (launchd,
+  // an editor, nohup from a non-interactive shell) so nvm/fnm/asdf shims are
+  // not on PATH. The child then reports "node is not installed" on a machine
+  // that has node. Prove both halves rather than trusting the code read.
+  const bare = '/usr/bin:/bin:/usr/sbin:/sbin';
+  const nodeDir = path.dirname(process.execPath);
+  const look = (p) => spawnSync('sh', ['-c', 'command -v node || true'],
+    { env: { PATH: p }, encoding: 'utf8', timeout: 10000 }).stdout.trim();
+
+  if (look(bare)) {
+    // node lives in /usr/bin on this machine; the bug cannot occur here.
+    return;
+  }
+  assert(look(bare) === '', 'expected node to be invisible on a bare PATH');
+  const restored = look(`${nodeDir}${path.delimiter}${bare}`);
+  assert(restored !== '', 'prepending the interpreter directory did not expose node');
+  assert(restored.startsWith(nodeDir),
+    `child resolved a different node: ${restored} (wanted one under ${nodeDir})`);
+});
+
 console.log(`\n${pass} passed, ${fail} failed`);
 process.exit(fail ? 1 : 0);


### PR DESCRIPTION
Refs #259.

## The report

Publish from the modal always failed with `publish_failed`. The underlying stderr was **`node 18+ is not installed`** — on a machine running **Node v22.22.1**. The same doc published from a shell on the first try.

## The cause

```
server process : ~/.nvm/versions/node/v22.22.1/bin/node …/server/server.js
server PATH    : /usr/bin:/bin:/usr/sbin:/sbin
```

The server is started by **absolute path** in most real setups — launchd, an editor, a desktop launcher, `nohup` from a shell that sources nvm only when interactive. It runs fine; its `PATH` does not contain the version manager's bin directory. Both spawn sites passed `env: process.env`, so the child inherited that `PATH`, and `bin/tdoc-publish:456` does `command -v node`.

Reproduced exactly:

```bash
$ env -i HOME="$HOME" PATH=/usr/bin:/bin:/usr/sbin:/sbin sh -c "command -v node"
(nothing)
$ command -v node
/Users/…/.nvm/versions/node/v22.22.1/bin/node
```

**This reaches every machine where node is managed by nvm, fnm, asdf, volta, or Homebrew on Apple Silicon** — and `bin/tdoc-doctor` reports `ready_to_publish: true` at the same moment, because the doctor runs with the user's own PATH.

## The fix

The server already knows which node is running it. `childEnv()` puts `path.dirname(process.execPath)` in front of the child's `PATH`, and returns `process.env` unchanged when it is already there. Applied at both spawn sites — publish and delete.

The CLI's failure text now names the `PATH` it searched. `node 18+ is not installed` sent the user to install node they already had; the next report of this will be one line instead of an investigation.

## Tests

| Test | Covers |
|---|---|
| `server spawns CLIs with the running interpreter on PATH` | `childEnv()` exists, derives the directory from `process.execPath`, and **every** `spawn(bin…)` site uses it |
| `a stripped PATH hides node from a child, and childEnv restores it` | the premise itself — node really is invisible on a bare PATH, and prepending the interpreter directory really exposes it. Skips on machines where node lives in `/usr/bin`, where the bug cannot occur |

**Negative control:** reverting `childEnv()` to `process.env` makes the first test fail (`48 passed, 1 failed`), so it is testing the fix rather than passing vacuously.

`npm test` — 43 suites green. `shellcheck --severity=warning` clean on the changed script.

## Not doing

- Changing how the server is started, or documenting a PATH requirement for users. The server holds the answer already; it should pass it down.
- The related install-split problem (#260), where the server answering the port can be a different checkout than the CLI. Separate change.