### PR TITLE
feat: offer the CLAUDE.md routing line during onboarding, once

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ file and `.claude-plugin/plugin.json`.
 
 ### Added
 
+- **Onboarding offers the `CLAUDE.md` routing line, once.** The skill
+  description already routes doc requests to tdoc and reaches every session,
+  but a line in the user's own instructions reads as a rule rather than a
+  catalogue entry. Onboarding now offers to add one, names the file it would
+  edit, and takes no for an answer permanently
+  (`~/.tdoc/.routing-declined`). It asks at most once ever
+  (`~/.tdoc/.routing-prompted`) and a marker comment keeps a reinstall from
+  appending a second copy. Installing a tool never edits the config of the
+  thing that installed it without being asked. `#263`.
 - **Five house styles, a visual-first floor, and a new default.** The default
   is now the stark-sans / OpenAI-index aesthetic (white, black, Inter, an
   oversized tight-tracked headline) with a full technical-diagram vocabulary —

--- a/ONBOARDING.md
+++ b/ONBOARDING.md
@@ -149,7 +149,64 @@ echo '[]' > ~/tdocs/$SLUG/comments.json
 
 The script prints the live URL. Show it to the user, and say what it is: the doc is **unlisted** — anyone with the link can read it, and it is never listed anywhere. Don't assume they already know that; they may never have seen a tdoc page before.
 
-## Step 6 — Wrap up
+## Step 6 — Offer the routing line (ask once, never write silently)
+
+`SKILL.md`'s description is what routes doc requests to tdoc, and it reaches
+every session. A line in the user's `CLAUDE.md` is a stronger signal, because
+project instructions read as rules rather than as a catalogue entry. Offer it;
+do not take it.
+
+**Skip this step entirely if either is true:**
+
+```bash
+# already asked, at any point in the past — never ask twice
+[ -f "$HOME/.tdoc/.routing-prompted" ] && echo SKIP_ASKED
+# already present — a reinstall must not append a second copy
+grep -rq "<!-- tdoc:routing -->" CLAUDE.md "$HOME/.claude/CLAUDE.md" 2>/dev/null && echo SKIP_PRESENT
+```
+
+**Pick the target file** and name it in the question, because the user is
+agreeing to an edit of a specific path:
+
+- a `CLAUDE.md` in the current project that already has a `## Skill routing`
+  section → add the line to that section
+- otherwise `~/.claude/CLAUDE.md` — tdoc is not project-scoped, so global is
+  the honest default. Create it if it does not exist.
+
+**Ask, with the path in the question.** Use `AskUserQuestion` where the host
+offers it; on a host without that tool, ask in prose and wait for a typed
+answer:
+
+> Add a routing line for tdoc to `<path>`? It tells your agent to use tdoc for
+> document requests instead of writing a file by hand. The skill already
+> describes itself this way — this makes it a rule rather than a suggestion.
+>
+> A) Add it
+> B) No thanks
+
+**On A**, append (or add to the existing `## Skill routing` list):
+
+```markdown
+<!-- tdoc:routing -->
+- Write, draft, publish, or share any doc, write-up, explainer, or page → invoke tdoc
+```
+
+**On B**, record it and never raise it again:
+
+```bash
+touch "$HOME/.tdoc/.routing-declined"
+```
+
+**Either way**, mark it asked:
+
+```bash
+mkdir -p "$HOME/.tdoc" && touch "$HOME/.tdoc/.routing-prompted"
+```
+
+Do not commit the change, do not edit any other part of the file, and do not
+re-ask on a later run. A declined offer is a decision, not a pending task.
+
+## Step 7 — Wrap up
 
 Tell the user:
 
@@ -160,6 +217,11 @@ Tell the user:
 
 ## Idempotency
 
+- `~/.tdoc/.routing-prompted` — the CLAUDE.md routing offer was already
+  made. Never ask a second time, whichever way it was answered.
+- `~/.tdoc/.routing-declined` — the user said no. Treat it as settled.
+- `<!-- tdoc:routing -->` in a `CLAUDE.md` — the line is already there; a
+  reinstall must not append another.
 Every step is safe to re-run. The doctor reads state; the publish script checks for existing resources before creating. The user can interrupt and resume at any point.
 
 ## Appendix — self-hosting on your own Cloudflare or Vercel

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -884,5 +884,32 @@ t('a stripped PATH hides node from a child, and childEnv restores it', () => {
     `child resolved a different node: ${restored} (wanted one under ${nodeDir})`);
 });
 
+// ---- the onboarding routing offer must stay an offer (#263) ----
+
+t('onboarding offers the CLAUDE.md routing line and never writes it silently', () => {
+  const ob = fs.readFileSync(path.join(__dirname, '..', 'ONBOARDING.md'), 'utf8');
+  const step = ob.slice(ob.indexOf('## Step 6 — Offer the routing line'),
+                        ob.indexOf('## Step 7'));
+  assert(step.length > 200, 'routing step missing or truncated');
+
+  // Asked at most once, ever.
+  assert(/\.routing-prompted/.test(step), 'no .routing-prompted guard — would re-ask every install');
+  // A no is remembered.
+  assert(/\.routing-declined/.test(step), 'no .routing-declined marker — a decline would not stick');
+  // A reinstall cannot append a second copy.
+  assert(/<!-- tdoc:routing -->/.test(step), 'no idempotency marker for the appended line');
+  // It is an offer: the user is asked, and the path is named in the question.
+  assert(/AskUserQuestion/.test(step), 'step does not ask — writing CLAUDE.md unasked is the failure this guards');
+  assert(/`<path>`/.test(step), 'the question does not name the file being edited');
+  // And it must not quietly commit on the user's behalf.
+  assert(/Do not commit/i.test(step), 'step does not forbid committing the edit');
+
+  // The markers are registered where a future reader looks for them.
+  const idem = ob.slice(ob.indexOf('## Idempotency'));
+  for (const m of ['.routing-prompted', '.routing-declined', 'tdoc:routing']) {
+    assert(idem.includes(m), `${m} not listed under Idempotency`);
+  }
+});
+
 console.log(`\n${pass} passed, ${fail} failed`);
 process.exit(fail ? 1 : 0);


### PR DESCRIPTION
Refs #263.

## Why

`SKILL.md`'s description is what routes doc requests to tdoc, and it works — it reaches every session's skill listing. It is still a *description*, so an agent that hand-rolls an HTML file instead of invoking the skill has broken nothing mechanical. That happened in a real session: the doc came out of a Python script, and tdoc was only used after the user asked for it by name.

A line in the user's own `CLAUDE.md` reads as a rule instead of a catalogue entry.

## What this refuses to do

**Write to `CLAUDE.md` as a side effect of installing.** It is the user's file, it enters every session's context permanently, and the line duplicates what the description already declares. Installing a tool must not silently edit the config of the thing that installed it.

## So it is an offer, with gstack's guards

The same pattern gstack already uses on these machines:

| Guard | Mechanism |
|---|---|
| Asked at most once, ever | `~/.tdoc/.routing-prompted`, matching the existing `.telemetry-prompted` convention |
| A no is permanent | `~/.tdoc/.routing-declined` — never revisited |
| A reinstall cannot duplicate | `<!-- tdoc:routing -->` marker in the file |
| The user knows what they agreed to | the question names the path |
| No surprise commits | the step forbids committing the edit |

Target file prefers a project `CLAUDE.md` that already has a `## Skill routing` section; otherwise `~/.claude/CLAUDE.md`, since tdoc is not project-scoped.

## Tests

`onboarding offers the CLAUDE.md routing line and never writes it silently` asserts the step still asks, still names the path, keeps both state markers and the idempotency marker, forbids committing, and registers all three markers under `## Idempotency` where the next reader will look.

**Negative control:** removing the `AskUserQuestion` line — i.e. turning the offer into a silent write — makes the test fail (`49 passed, 1 failed`). It is testing the property, not the wording.

`npm test` — 43 suites green.

## Not doing

- Changing the `SKILL.md` description. It stays the primary mechanism; this is a belt for users who want one.
- Any write without an explicit yes.