### PR TITLE
fix: the first doc publishes privately instead of ending at localhost

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -123,6 +123,14 @@ file and `.claude-plugin/plugin.json`.
 
 ### Fixed
 
+- **The first doc goes to tdoc.dev, privately, instead of ending at
+  localhost.** The recipe told the agent to build the page, open it locally and
+  ask before publishing — which recreated exactly the failure the localhost
+  rule exists to prevent, one commit after that rule landed. A first doc that
+  lives only on the machine has not shown anyone what tdoc is. It now publishes
+  with `--visibility private`, so the reader gets a real link on their own
+  account that nobody else can open, and opening it up is a decision they make
+  while looking at the page rather than before it exists. `#161`.
 - **Publishing from the modal works when node is version-managed.** The local
   server passed its own `PATH` straight to the CLIs it spawns. A server started
   by absolute path — launchd, an editor, `nohup` from a shell that only loads

--- a/FIRST-DOC.md
+++ b/FIRST-DOC.md
@@ -506,15 +506,40 @@ own, `/me` is the operator catalog — which is them — but it is reached at th
 own domain, not at tdoc.dev. Naming tdoc.dev there
 walks them into a sign-in wall on somebody else's site.
 
-## Step 7 — show it before you publish
+## Step 7 — publish it privately, then hand over the link
 
-**Do not publish this one automatically.** Every other tdoc is published as a
-matter of course; this one is about them, and the default visibility means the
-link is the credential.
+**Publish it. Do not end at localhost.** The rest of tdoc has a hard rule
+against handing back a `http://localhost` URL when the human did not ask for
+one, and it applies here: a first doc that lives only on their machine has not
+shown them what tdoc is. The shareable link *is* the product working.
 
-Build it, open it locally, and ask. If they say yes, publish and give them the
-URL on its own line. If they say no, leave it on their machine and tell them
-the command to publish it later.
+The tension is real — this page is about them, it carries their project names
+and their working hours, and the default visibility makes the link the
+credential. Resolve it with access, not with localhost:
+
+```bash
+"$SKILL_DIR/bin/tdoc-publish" --visibility private --history owner <slug>
+```
+
+`private` means the doc is readable by them and by accounts they explicitly
+allow, and by nobody holding the link. They get a real `https://tdoc.dev/d/...`
+URL, on their account, listed at their hub — and none of it is exposed.
+
+Then say, in one line each:
+
+- the URL, on its own line
+- that it is private to them right now, and nobody with the link can open it
+- how to open it up when they want to:
+  `tdoc-publish --visibility unlisted <slug>` for link-readable, or
+  `--allow-user <github-login>` to add one person
+
+**Do not ask first and publish second.** Asking "shall I publish this?" before
+they have seen anything asks them to consent to a page that does not exist yet.
+Publish privately — which exposes nothing — show them the page at its real URL,
+and let opening it up be their decision, made while looking at it.
+
+The only case that ends locally is the one the human asked for: they said keep
+it local, or they are self-hosting and their own worker is not ready.
 
 ## If there is no history
 

--- a/ONBOARDING.md
+++ b/ONBOARDING.md
@@ -138,8 +138,10 @@ Two things from that file are easy to skip and must not be:
 
 - **Say the scan line before scanning.** Enumerating someone's assistant
   folders unannounced, on first run, is the fastest way to lose them.
-- **Do not publish it automatically.** Every other tdoc is published as a
-  matter of course; this one is about them. Build it, open it locally, and ask.
+- **Publish it privately, and hand over the real URL.** This one is about them,
+  so it goes up as `--visibility private` — a real `tdoc.dev` link, on their
+  account, that nobody else can open. Do not end on a `localhost` URL; that is
+  the failure the localhost rule in SKILL.md exists to prevent.
 
 If the machine has no history to read, FIRST-DOC.md says what to do instead —
 follow that rather than falling back to a placeholder document.

--- a/test/tdoc-start.test.js
+++ b/test/tdoc-start.test.js
@@ -195,8 +195,10 @@ t('the first doc is the reader\'s own portrait, and the recipe carries it', () =
   // It is a portrait, not an activity log, and it is not published unasked.
   assert(/Name a trait, then prove it/.test(recipe),
     'the recipe must ask for traits rather than activity readings');
-  assert(/Do not publish this one automatically/.test(recipe),
-    'the recipe must withhold publication until the human says yes');
+  assert(/Do not end at localhost/.test(recipe),
+    'the recipe must not hand back a localhost URL — see the localhost rule in SKILL.md');
+  assert(/--visibility private/.test(recipe),
+    'the recipe must publish the first doc privately rather than withholding it');
   // It has to work for someone who does not write code, and for an empty machine.
   assert(/the reader may not write code/i.test(recipe),
     'the recipe must handle readers with no coding projects');


### PR DESCRIPTION
Refs #161.

## The contradiction

`FIRST-DOC.md` said:

> Do not publish this one automatically… Build it, open it locally, and ask.

`SKILL.md:289` says:

> **The localhost rule: never hand over a `localhost` URL unless the user asked to keep the doc local.** Not as a fallback, not when a sign-in did not finish, not as "here it is locally in the meantime".

And `4db5e04` — three commits back on `main` — is titled **"/tdoc new publishes to tdoc.dev and never hands back localhost (#239)"**. The recipe reintroduced the exact failure that commit had just fixed, for the one doc every new user sees first.

Someone receiving a first doc never asked for a local one. Ending there means onboarding completes without ever showing them what tdoc is — the link is the product working.

## Why the original wording existed, and the better answer

The privacy concern is real: this page carries the reader's project names and working hours, and the default visibility makes the link the credential. But that is an **access** problem, not a hosting one.

```bash
tdoc-publish --visibility private --history owner <slug>
```

A real `tdoc.dev` URL, on their account, listed at their hub, that **nobody holding the link can open**. Nothing is exposed, and the page exists somewhere real.

The recipe now also says *not* to ask first: asking "shall I publish this?" before they have seen anything asks for consent to a page that does not exist yet. Publish privately — which exposes nothing — show them the page at its real URL, and let opening it up be a decision made while looking at it, with the two commands to do so.

The only run that still ends locally is the one the human asked for.

## Tests

`tdoc-start.test.js` asserted the old rule. It now asserts the new one — the recipe must contain `Do not end at localhost` and `--visibility private`, so a future edit cannot quietly walk it back.

`npm test` — 43 suites green.