### PR TITLE
fix: drop the stale "do not publish without asking" line

### DIFF
--- a/FIRST-DOC.md
+++ b/FIRST-DOC.md
@@ -557,6 +557,7 @@ first doc something a static tutorial never has — a reason to come back.
 - Do not open, quote, or summarise the contents of any conversation.
 - Do not comment on the person's life, mood, or circumstances. The subject is
   the work, not them.
-- Do not publish without asking.
+- Do not end on a `localhost` URL, and do not ask for permission before the
+  page exists. Publish it privately and let them open it up from there.
 - Do not build a fixture, a template, or a starter repo. This page is written
   fresh each time, by you, from this file.

--- a/test/tdoc-start.test.js
+++ b/test/tdoc-start.test.js
@@ -199,6 +199,8 @@ t('the first doc is the reader\'s own portrait, and the recipe carries it', () =
     'the recipe must not hand back a localhost URL — see the localhost rule in SKILL.md');
   assert(/--visibility private/.test(recipe),
     'the recipe must publish the first doc privately rather than withholding it');
+  assert(!/Do not publish without asking/.test(recipe),
+    'a stale do-not-publish line contradicts the localhost rule the recipe now follows');
   // It has to work for someone who does not write code, and for an empty machine.
   assert(/the reader may not write code/i.test(recipe),
     'the recipe must handle readers with no coding projects');


### PR DESCRIPTION
Refs #161.

#266 rewrote Step 7 so the first doc publishes privately rather than ending on a `localhost` URL. The summary list at the bottom of the same file still said:

> - Do not publish without asking.

An agent reading the file end to end got the new instruction in the step and the old one in the checklist. A contradiction is worse than either rule alone, because it resolves in whichever direction the reader happens to weigh more — and the checklist is the part that gets skimmed last, so it tends to win.

Replaced with what Step 7 actually says: never hand back localhost, and do not ask for permission before the page exists. A private publish exposes nothing, so there is nothing to ask about yet — opening it up is the decision, made while looking at the page.

The test now asserts the old line is **absent**, so it cannot come back.

`npm test` — 43 suites green.