### PR TITLE
fix: resolve the skill directory at runtime so the self-update can run

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -123,6 +123,15 @@ file and `.claude-plugin/plugin.json`.
 
 ### Fixed
 
+- **The skill actually keeps itself current now.** `#248` added an automatic
+  fast-forward to `origin/main` on every tdoc invocation, guarded on a
+  `TDOC_DIR` that a placeholder token was supposed to fill in at install time.
+  Nothing ever filled it in — the install script it named does not exist — so
+  every install carried the literal token, the guard `[ -x "$TDOC_DIR/bin/tdoc-update" ]`
+  was false, and the update silently never ran on any machine. The skill
+  directory is now resolved at runtime the same way the setup check resolves
+  it, `~/.agents/skills/tdoc` is included in the candidates, and the two
+  meanings of `TDOC_DIR` in one file are no longer the same variable.
 - **The first doc goes to tdoc.dev, privately, instead of ending at
   localhost.** The recipe told the agent to build the page, open it locally and
   ask before publishing — which recreated exactly the failure the localhost

--- a/SKILL.md
+++ b/SKILL.md
@@ -1196,8 +1196,8 @@ if [ "$TEL_EFFECTIVE" = "on" ]; then
     _P_SKILL="$(echo "$_PDATA" | grep -o '"skill":"[^"]*"' | head -1 | cut -d'"' -f4)"
     _P_SID="$(echo "$_PDATA" | grep -o '"session_id":"[^"]*"' | head -1 | cut -d'"' -f4)"
     [ -z "$_P_SKILL" ] && continue
-    if [ -x "__TDOC_DIR__/telemetry/bin/telemetry-log" ]; then
-      "__TDOC_DIR__/telemetry/bin/telemetry-log" \
+    if [ -x "$TDOC_SKILL_ROOT/telemetry/bin/telemetry-log" ]; then
+      "$TDOC_SKILL_ROOT/telemetry/bin/telemetry-log" \
         --skill "$_P_SKILL" --outcome unknown \
         --step "reaped-incomplete-run" --session-id "$_P_SID" 2>/dev/null || true
     fi
@@ -1207,15 +1207,27 @@ fi
 # ─── Upgrade check (BYOK: origin/main, every run) ───────────
 # GitHub releases lag (v0.9.0 sat while overlay kept shipping on main).
 # Compare this skill checkout to origin/main the same way tdoc-update does.
-# TDOC_DIR is substituted at install time by postinstall-telemetry.sh.
-TDOC_DIR="__TDOC_DIR__"
+#
+# Resolve the skill directory at RUNTIME. This used to be a placeholder token
+# substituted at install time, and the substitution never happened:
+# every install carried the literal string, so `[ -x "$TDOC_SKILL_ROOT/bin/tdoc-update" ]`
+# was false and the automatic update silently never ran, on any machine, ever.
+# A self-update that depends on an install step is a self-update that does not
+# exist. Note this is a different directory from the TDOC_DIR above, which is
+# the docs root (~/tdocs) — hence the distinct name.
+TDOC_SKILL_ROOT="${TDOC_SKILL_DIR:-}"
+if [ -z "$TDOC_SKILL_ROOT" ]; then
+  for _d in "$HOME/.claude/skills/tdoc" "$HOME/.codex/skills/tdoc" "$HOME/.agents/skills/tdoc"; do
+    [ -f "$_d/SKILL.md" ] && TDOC_SKILL_ROOT="$_d" && break
+  done
+fi
 
 # Resolve installed version, trying multiple sources in order:
 #   1. VERSION file (if maintained, like gstack)
 #   2. git describe --tags (most recent reachable tag)
 #   3. fallback "0.0.0" (skip the check)
-INSTALLED_VERSION="$(cat "$TDOC_DIR/VERSION" 2>/dev/null)"
-if [ -z "$INSTALLED_VERSION" ] && [ -d "$TDOC_DIR/.git" ]; then
+INSTALLED_VERSION="$(cat "$TDOC_SKILL_ROOT/VERSION" 2>/dev/null)"
+if [ -z "$INSTALLED_VERSION" ] && [ -d "$TDOC_SKILL_ROOT/.git" ]; then
   INSTALLED_VERSION="$(cd "$TDOC_DIR" && git describe --tags --abbrev=0 2>/dev/null | sed 's/^v//')"
 fi
 [ -z "$INSTALLED_VERSION" ] && INSTALLED_VERSION="0.0.0"
@@ -1236,17 +1248,17 @@ fi
 # and run the full interactive update instead — auto-stashing local edits and
 # offering a redeploy, on every single run. Only invoke it when it is a flag
 # the installed script actually knows.
-if [ -z "${TDOC_SKIP_UPDATE_CHECK:-}" ] && [ -x "$TDOC_DIR/bin/tdoc-update" ] \
-   && grep -q -- '--auto)' "$TDOC_DIR/bin/tdoc-update" 2>/dev/null; then
-  "$TDOC_DIR/bin/tdoc-update" --auto 2>&1 || true
+if [ -z "${TDOC_SKIP_UPDATE_CHECK:-}" ] && [ -x "$TDOC_SKILL_ROOT/bin/tdoc-update" ] \
+   && grep -q -- '--auto)' "$TDOC_SKILL_ROOT/bin/tdoc-update" 2>/dev/null; then
+  "$TDOC_SKILL_ROOT/bin/tdoc-update" --auto 2>&1 || true
 fi
 
-if [ -x "$TDOC_DIR/bin/tdoc-update-nag" ]; then
-  NAG_LINE="$("$TDOC_DIR/bin/tdoc-update-nag" 2>/dev/null || true)"
+if [ -x "$TDOC_SKILL_ROOT/bin/tdoc-update-nag" ]; then
+  NAG_LINE="$("$TDOC_SKILL_ROOT/bin/tdoc-update-nag" 2>/dev/null || true)"
   if printf '%s' "$NAG_LINE" | grep -q '^TDOC_UPDATE_AVAILABLE:'; then
     echo "$NAG_LINE"
     if [ "$TEL_EFFECTIVE" = "on" ]; then
-      "$TDOC_DIR/telemetry/bin/telemetry-log" \
+      "$TDOC_SKILL_ROOT/telemetry/bin/telemetry-log" \
         --skill tdoc \
         --event-type upgrade_prompted \
         --outcome unknown \
@@ -1388,7 +1400,7 @@ mention (not a /tdoc command), use `chat` or `freeform`.
 **On success**:
 
 ```bash
-"__TDOC_DIR__/telemetry/bin/telemetry-log" \
+"$TDOC_SKILL_ROOT/telemetry/bin/telemetry-log" \
   --skill tdoc \
   --outcome success \
   --duration "$DURATION" \
@@ -1400,7 +1412,7 @@ mention (not a /tdoc command), use `chat` or `freeform`.
 **On error**:
 
 ```bash
-"__TDOC_DIR__/telemetry/bin/telemetry-log" \
+"$TDOC_SKILL_ROOT/telemetry/bin/telemetry-log" \
   --skill tdoc \
   --outcome error \
   --duration "$DURATION" \
@@ -1414,7 +1426,7 @@ mention (not a /tdoc command), use `chat` or `freeform`.
 **On abandoned** (user asked to stop):
 
 ```bash
-"__TDOC_DIR__/telemetry/bin/telemetry-log" \
+"$TDOC_SKILL_ROOT/telemetry/bin/telemetry-log" \
   --skill tdoc \
   --outcome abandoned \
   --duration "$DURATION" \

--- a/skills/tdoc/SKILL.md
+++ b/skills/tdoc/SKILL.md
@@ -1196,8 +1196,8 @@ if [ "$TEL_EFFECTIVE" = "on" ]; then
     _P_SKILL="$(echo "$_PDATA" | grep -o '"skill":"[^"]*"' | head -1 | cut -d'"' -f4)"
     _P_SID="$(echo "$_PDATA" | grep -o '"session_id":"[^"]*"' | head -1 | cut -d'"' -f4)"
     [ -z "$_P_SKILL" ] && continue
-    if [ -x "__TDOC_DIR__/telemetry/bin/telemetry-log" ]; then
-      "__TDOC_DIR__/telemetry/bin/telemetry-log" \
+    if [ -x "$TDOC_SKILL_ROOT/telemetry/bin/telemetry-log" ]; then
+      "$TDOC_SKILL_ROOT/telemetry/bin/telemetry-log" \
         --skill "$_P_SKILL" --outcome unknown \
         --step "reaped-incomplete-run" --session-id "$_P_SID" 2>/dev/null || true
     fi
@@ -1207,15 +1207,27 @@ fi
 # ─── Upgrade check (BYOK: origin/main, every run) ───────────
 # GitHub releases lag (v0.9.0 sat while overlay kept shipping on main).
 # Compare this skill checkout to origin/main the same way tdoc-update does.
-# TDOC_DIR is substituted at install time by postinstall-telemetry.sh.
-TDOC_DIR="__TDOC_DIR__"
+#
+# Resolve the skill directory at RUNTIME. This used to be a placeholder token
+# substituted at install time, and the substitution never happened:
+# every install carried the literal string, so `[ -x "$TDOC_SKILL_ROOT/bin/tdoc-update" ]`
+# was false and the automatic update silently never ran, on any machine, ever.
+# A self-update that depends on an install step is a self-update that does not
+# exist. Note this is a different directory from the TDOC_DIR above, which is
+# the docs root (~/tdocs) — hence the distinct name.
+TDOC_SKILL_ROOT="${TDOC_SKILL_DIR:-}"
+if [ -z "$TDOC_SKILL_ROOT" ]; then
+  for _d in "$HOME/.claude/skills/tdoc" "$HOME/.codex/skills/tdoc" "$HOME/.agents/skills/tdoc"; do
+    [ -f "$_d/SKILL.md" ] && TDOC_SKILL_ROOT="$_d" && break
+  done
+fi
 
 # Resolve installed version, trying multiple sources in order:
 #   1. VERSION file (if maintained, like gstack)
 #   2. git describe --tags (most recent reachable tag)
 #   3. fallback "0.0.0" (skip the check)
-INSTALLED_VERSION="$(cat "$TDOC_DIR/VERSION" 2>/dev/null)"
-if [ -z "$INSTALLED_VERSION" ] && [ -d "$TDOC_DIR/.git" ]; then
+INSTALLED_VERSION="$(cat "$TDOC_SKILL_ROOT/VERSION" 2>/dev/null)"
+if [ -z "$INSTALLED_VERSION" ] && [ -d "$TDOC_SKILL_ROOT/.git" ]; then
   INSTALLED_VERSION="$(cd "$TDOC_DIR" && git describe --tags --abbrev=0 2>/dev/null | sed 's/^v//')"
 fi
 [ -z "$INSTALLED_VERSION" ] && INSTALLED_VERSION="0.0.0"
@@ -1236,17 +1248,17 @@ fi
 # and run the full interactive update instead — auto-stashing local edits and
 # offering a redeploy, on every single run. Only invoke it when it is a flag
 # the installed script actually knows.
-if [ -z "${TDOC_SKIP_UPDATE_CHECK:-}" ] && [ -x "$TDOC_DIR/bin/tdoc-update" ] \
-   && grep -q -- '--auto)' "$TDOC_DIR/bin/tdoc-update" 2>/dev/null; then
-  "$TDOC_DIR/bin/tdoc-update" --auto 2>&1 || true
+if [ -z "${TDOC_SKIP_UPDATE_CHECK:-}" ] && [ -x "$TDOC_SKILL_ROOT/bin/tdoc-update" ] \
+   && grep -q -- '--auto)' "$TDOC_SKILL_ROOT/bin/tdoc-update" 2>/dev/null; then
+  "$TDOC_SKILL_ROOT/bin/tdoc-update" --auto 2>&1 || true
 fi
 
-if [ -x "$TDOC_DIR/bin/tdoc-update-nag" ]; then
-  NAG_LINE="$("$TDOC_DIR/bin/tdoc-update-nag" 2>/dev/null || true)"
+if [ -x "$TDOC_SKILL_ROOT/bin/tdoc-update-nag" ]; then
+  NAG_LINE="$("$TDOC_SKILL_ROOT/bin/tdoc-update-nag" 2>/dev/null || true)"
   if printf '%s' "$NAG_LINE" | grep -q '^TDOC_UPDATE_AVAILABLE:'; then
     echo "$NAG_LINE"
     if [ "$TEL_EFFECTIVE" = "on" ]; then
-      "$TDOC_DIR/telemetry/bin/telemetry-log" \
+      "$TDOC_SKILL_ROOT/telemetry/bin/telemetry-log" \
         --skill tdoc \
         --event-type upgrade_prompted \
         --outcome unknown \
@@ -1388,7 +1400,7 @@ mention (not a /tdoc command), use `chat` or `freeform`.
 **On success**:
 
 ```bash
-"__TDOC_DIR__/telemetry/bin/telemetry-log" \
+"$TDOC_SKILL_ROOT/telemetry/bin/telemetry-log" \
   --skill tdoc \
   --outcome success \
   --duration "$DURATION" \
@@ -1400,7 +1412,7 @@ mention (not a /tdoc command), use `chat` or `freeform`.
 **On error**:
 
 ```bash
-"__TDOC_DIR__/telemetry/bin/telemetry-log" \
+"$TDOC_SKILL_ROOT/telemetry/bin/telemetry-log" \
   --skill tdoc \
   --outcome error \
   --duration "$DURATION" \
@@ -1414,7 +1426,7 @@ mention (not a /tdoc command), use `chat` or `freeform`.
 **On abandoned** (user asked to stop):
 
 ```bash
-"__TDOC_DIR__/telemetry/bin/telemetry-log" \
+"$TDOC_SKILL_ROOT/telemetry/bin/telemetry-log" \
   --skill tdoc \
   --outcome abandoned \
   --duration "$DURATION" \

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -911,5 +911,29 @@ t('onboarding offers the CLAUDE.md routing line and never writes it silently', (
   }
 });
 
+// ---- the skill's self-update must be able to run at all ----
+
+t('SKILL.md resolves its own directory at runtime, not at install time', () => {
+  const skill = fs.readFileSync(path.join(__dirname, '..', 'SKILL.md'), 'utf8');
+  // The failure this guards: TDOC_DIR was a __TDOC_DIR__ placeholder meant to be
+  // substituted by an install script that does not exist, so every install
+  // carried the literal string, `[ -x "$TDOC_DIR/bin/tdoc-update" ]` was false,
+  // and the automatic update silently never ran on any machine.
+  assert(!/__TDOC_DIR__/.test(skill),
+    'SKILL.md still contains an install-time placeholder — it will never be substituted');
+  assert(/TDOC_SKILL_ROOT=/.test(skill), 'no runtime resolution of the skill directory');
+  assert(/tdoc-update" --auto/.test(skill) || /tdoc-update" --auto/.test(skill.replace(/\n\s*/g, ' ')),
+    'the automatic update call is gone');
+
+  // And the guard must actually pass against a real checkout.
+  const root = path.join(__dirname, '..');
+  const probe = spawnSync('sh', ['-c',
+    `TDOC_SKILL_ROOT="${root}"; [ -x "$TDOC_SKILL_ROOT/bin/tdoc-update" ] && ` +
+    `grep -q -- '--auto)' "$TDOC_SKILL_ROOT/bin/tdoc-update" && echo ok`],
+    { encoding: 'utf8', timeout: 10000 });
+  assert(probe.stdout.trim() === 'ok',
+    'the resolved directory does not satisfy the update guard');
+});
+
 console.log(`\n${pass} passed, ${fail} failed`);
 process.exit(fail ? 1 : 0);


### PR DESCRIPTION
Refs #248.

## The self-update has never run

#248 made every tdoc invocation fast-forward its checkout to `origin/main` instead of nagging. The guard:

```bash
# TDOC_DIR is substituted at install time by postinstall-telemetry.sh.
TDOC_DIR="__TDOC_DIR__"
if [ -z "${TDOC_SKIP_UPDATE_CHECK:-}" ] && [ -x "$TDOC_DIR/bin/tdoc-update" ] ...
```

**That script does not exist in the repo.** Nothing ever substituted the token:

```
/Users/…/.claude/skills/tdoc   unreplaced placeholders: 6
/Users/…/.agents/skills/tdoc   unreplaced placeholders: 6
```

So `[ -x "__TDOC_DIR__/bin/tdoc-update" ]` is false, the block is skipped, and the automatic update **has never run on any machine since the feature shipped**. It fails silently and looks identical to "already up to date".

The same token gated `telemetry-log`, so those calls were dead too.

## The fix

Resolve at runtime, the way the setup check at the top of the same file already does:

```bash
TDOC_SKILL_ROOT="${TDOC_SKILL_DIR:-}"
if [ -z "$TDOC_SKILL_ROOT" ]; then
  for _d in "$HOME/.claude/skills/tdoc" "$HOME/.codex/skills/tdoc" "$HOME/.agents/skills/tdoc"; do
    [ -f "$_d/SKILL.md" ] && TDOC_SKILL_ROOT="$_d" && break
  done
fi
```

`~/.agents/skills/tdoc` is added because it is a real install location when Claude Code and Codex are both present — and on this machine it is the checkout that was serving the port.

Renamed too: `TDOC_DIR` meant two different things in one file — the docs root (`~/tdocs`) near the top, reassigned to the skill checkout further down.

## Tests

Fails if a placeholder token returns, if the runtime resolution disappears, or if the resolved directory does not satisfy the guard — and it runs the guard against the real checkout rather than only reading the source.

**Negative control:** restoring `TDOC_DIR="__TDOC_DIR__"` makes it fail (`48 passed, 3 failed`).

`npm test` — 43 suites green, including the plugin-mode `SKILL.md` drift check.