### PR TITLE
fix: build the first doc's slug from the person, not the document

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -123,6 +123,13 @@ file and `.claude-plugin/plugin.json`.
 
 ### Fixed
 
+- **The first doc's slug is per-person, so onboarding stops colliding.** Hosted
+  slugs are one flat global namespace and the recipe derived the slug from the
+  document title, which handed every user the same one. The second person to
+  run onboarding was rejected — `slug_taken` (409) or `not_doc_owner` (403) —
+  on the first publish they ever attempted. The slug now carries the reader's
+  name, falls back to their GitHub login, and a collision is retried with a
+  suffix rather than surfaced as a failure. `#244`.
 - **The skill actually keeps itself current now.** `#248` added an automatic
   fast-forward to `origin/main` on every tdoc invocation, guarded on a
   `TDOC_DIR` that a placeholder token was supposed to fill in at install time.

--- a/FIRST-DOC.md
+++ b/FIRST-DOC.md
@@ -506,6 +506,30 @@ own, `/me` is the operator catalog — which is them — but it is reached at th
 own domain, not at tdoc.dev. Naming tdoc.dev there
 walks them into a sign-in wall on somebody else's site.
 
+## Step 6d — the slug must be theirs, not the document's
+
+Hosted slugs are one flat global namespace. A first doc whose slug comes from
+its title gives every user on earth the same one, and the second person to run
+onboarding is rejected — `slug_taken` (409) or `not_doc_owner` (403) — on the
+very first publish they ever attempt. This is not an edge case: it happens to
+everyone after the first.
+
+**Build the slug from the person, not from the page.** Use the same name you
+resolved for the title, lowercased and kebab-cased:
+
+```
+what-ai-knows-<name>        →  what-ai-knows-serena
+```
+
+If no name resolved, fall back to their GitHub login from the hosted account.
+If neither exists, append a short random suffix rather than shipping a bare
+title — a slug nobody can claim twice is worth more than a tidy one.
+
+**If the publish still returns 409 or 403, do not stop and do not report a
+failure to the user.** Append a numeric suffix and retry once
+(`what-ai-knows-serena-2`). They are watching their first doc appear; a
+collision is your problem to solve, not a message for them to read.
+
 ## Step 7 — publish it privately, then hand over the link
 
 **Publish it. Do not end at localhost.** The rest of tdoc has a hard rule
@@ -518,7 +542,7 @@ and their working hours, and the default visibility makes the link the
 credential. Resolve it with access, not with localhost:
 
 ```bash
-"$SKILL_DIR/bin/tdoc-publish" --visibility private --history owner <slug>
+"$SKILL_DIR/bin/tdoc-publish" --visibility private --history owner what-ai-knows-<name>
 ```
 
 `private` means the doc is readable by them and by accounts they explicitly

--- a/test/tdoc-start.test.js
+++ b/test/tdoc-start.test.js
@@ -199,6 +199,12 @@ t('the first doc is the reader\'s own portrait, and the recipe carries it', () =
     'the recipe must not hand back a localhost URL — see the localhost rule in SKILL.md');
   assert(/--visibility private/.test(recipe),
     'the recipe must publish the first doc privately rather than withholding it');
+  // Hosted slugs are one global namespace, so a slug derived from the title
+  // hands everyone the same one and rejects every user after the first (#244).
+  assert(/what-ai-knows-<name>/.test(recipe),
+    'the recipe must build the slug from the person, not from the document title');
+  assert(/409|slug_taken/.test(recipe),
+    'the recipe must handle a slug collision instead of surfacing it to the user');
   assert(!/Do not publish without asking/.test(recipe),
     'a stale do-not-publish line contradicts the localhost rule the recipe now follows');
   // It has to work for someone who does not write code, and for an empty machine.


### PR DESCRIPTION
Refs #244.

## The bug #244 actually reported

Replacing the Conway doc was the visible half. The half that breaks people is the namespace:

> `conways-game-of-life` was already claimed by another account… a brand-new user hitting a 403 on their very first publish is a broken first run.

Hosted slugs are **one flat global namespace**. A slug derived from the document title is the same string for every user on earth, so everyone after the first is rejected with `slug_taken` (409) or `not_doc_owner` (403) — on the first publish they ever attempt.

## Replacing the doc did not fix it

`SKILL.md:318` picks a slug "from the prompt (kebab-case, ≤4 words)". For the new first doc that resolves to `what-ai-knows` for everyone — and **the development copy has already claimed it globally**:

```
tdoc.dev/d/what-ai-knows/v/1 → 200
```

So the next person to run onboarding would have hit #244 immediately, against a different slug. New subject, same bug.

## The fix

The slug comes from the person, not the page:

```
what-ai-knows-<name>   →  what-ai-knows-serena
```

Falling back to the GitHub login on the hosted account, and to a random suffix when neither resolves — a slug nobody can claim twice is worth more than a tidy one.

And a collision is handled rather than reported: on 409 or 403 the agent appends a numeric suffix and retries once. The user is watching their first doc appear; a namespace collision is not a message for them to read.

## Tests

The recipe must contain the per-person slug form and must handle `409` / `slug_taken`, so a future edit cannot walk it back to a title-derived slug.

`npm test` — 43 suites green.