### PR TITLE
Clamp the comment popup to the viewport (fix cutoff below the fold)

### DIFF
--- a/server/overlay.js
+++ b/server/overlay.js
@@ -3569,11 +3569,22 @@
     document.body.appendChild(popup);   // append first so offsetHeight is known
     const popupH = popup.offsetHeight || 140;
     const popupW = popup.offsetWidth || 320;
-    if (anchor._placeAbove && rect.top - 8 - popupH >= 8) {
-      popup.style.top = (window.scrollY + rect.top - popupH - 8) + 'px';
-    } else {
-      popup.style.top = (window.scrollY + rect.bottom + 8) + 'px';
-    }
+    const above = window.scrollY + rect.top - popupH - 8;
+    const below = window.scrollY + rect.bottom + 8;
+    // Prefer above when the element pill asked for it and there is room; else
+    // open below the selection so the sheet follows the cursor.
+    let top = (anchor._placeAbove && rect.top - 8 - popupH >= 8) ? above : below;
+    // Clamp vertically to the viewport — the horizontal clamp below always
+    // kept the sheet on screen sideways, but `top` used to be set blind, so a
+    // comment on a selection (or artifact) low in the viewport opened below
+    // the fold and the textarea + Comment button were cut off. Mirror the
+    // emoji-picker / margin-card behavior: if the sheet would spill past the
+    // bottom, flip it above the anchor; if it still doesn't fit (tall sheet /
+    // short viewport), pin it to the bottom edge so its controls stay reachable.
+    const vpTop = window.scrollY + 8;
+    const vpBottom = window.scrollY + window.innerHeight - 8;
+    if (top + popupH > vpBottom) top = (above >= vpTop) ? above : Math.max(vpTop, vpBottom - popupH);
+    popup.style.top = top + 'px';
     // `rect.left` is the caret / mouse-up X for text selections (not the
     // line-box origin). Clamp in document coords so a caret near the right
     // edge still keeps the 320px sheet on screen.

--- a/test/ui.test.js
+++ b/test/ui.test.js
@@ -414,6 +414,44 @@ async function tPub(name, fn) {
     await page.click('.tdoc-popup .head .x').catch(() => {});
   });
 
+  await t('Comment popup on a LOW selection is not cut off below the fold', async () => {
+    // The popup clamps horizontally but used to set `top` blind — a comment on
+    // a selection low in the viewport opened below the fold and the textarea +
+    // Comment button were cut off. It must flip above when there's no room.
+    const info = await page.evaluate(() => {
+      const vh = window.innerHeight;
+      const ps = [...document.querySelectorAll('.wrap p, .wrap li, .wrap td')]
+        .filter(p => p.firstChild && p.firstChild.nodeType === 3 && p.textContent.trim().length > 20);
+      if (!ps.length) return null;
+      const target = ps[Math.min(3, ps.length - 1)];
+      // scroll the paragraph to ~90px above the viewport bottom (popup needs ~140)
+      const y = target.getBoundingClientRect().top + window.scrollY;
+      window.scrollTo(0, y - (vh - 90));
+      const tn = target.firstChild;
+      const r = document.createRange();
+      r.setStart(tn, 0); r.setEnd(tn, Math.min(28, tn.textContent.length));
+      const sel = window.getSelection(); sel.removeAllRanges(); sel.addRange(r);
+      const sr = r.getBoundingClientRect();
+      return { vh, x: sr.left + 5, y: sr.bottom, roomBelow: vh - sr.bottom };
+    });
+    if (!info) { console.log('  (no low selectable paragraph, skipping)'); return; }
+    if (info.roomBelow > 150) { console.log('  (viewport too tall to force the clamp, skipping)'); return; }
+    await page.evaluate(({ x, y }) => {
+      document.dispatchEvent(new MouseEvent('mouseup', {
+        clientX: x, clientY: y, bubbles: true, cancelable: true, view: window, button: 0,
+      }));
+    }, { x: info.x, y: info.y });
+    await page.waitForSelector('.tdoc-popup', { timeout: 2000 });
+    const box = await page.$eval('.tdoc-popup', el => {
+      const r = el.getBoundingClientRect();
+      return { top: r.top, bottom: r.bottom };
+    });
+    if (box.bottom > info.vh + 1 || box.top < -1) {
+      throw new Error(`popup spills the viewport: top ${box.top.toFixed(1)}, bottom ${box.bottom.toFixed(1)}, viewport ${info.vh}`);
+    }
+    await page.click('.tdoc-popup .head .x').catch(() => {});
+  });
+
   await t('Drag STARTED INSIDE canvas does NOT open popup (passes through)', async () => {
     const canvas = await page.$('canvas');
     if (!canvas) { console.log('  (no canvas, skipping)'); return; }


### PR DESCRIPTION
Fixes #270.

The comment sheet (`openPopup`) clamped **horizontally** but set its `top`
blind, so a comment on a **low text selection** — or an **artifact** with no
room above — opened below the fold with the textarea + Comment button **cut
off**. The emoji picker and margin card already flip against the viewport
bottom; the popup was the one piece of overlay chrome that never got it.

**Reproduced** on the real overlay (`tdoc-sys-default`, 807px viewport): a
selection with ~69px of room below opened the popup at viewport-Y 746–898 →
**91px below the fold** (`isCutOff: true`). After the fix it flips above the
selection and sits fully on screen (559–712).

## The fix
Clamp `top` to the viewport: spill past the bottom → flip above the anchor;
still doesn't fit (tall sheet / short viewport) → pin to the bottom edge so the
controls stay reachable. One source (`server/overlay.js`) → ships to localhost
and tdoc.dev via `bin/tdoc-bundle` at deploy.

## Test
`ui.test.js` gains a regression test: select text low in the viewport, open the
popup, assert it never spills the viewport (top ≥ 0, bottom ≤ viewport).

Offline suite green; verified live in the browser (before: cut off; after:
flipped above, fully visible).

🤖 Generated with [Claude Code](https://claude.com/claude-code)