### PR TITLE
The first doc every new user publishes no longer needs jq

### DIFF
--- a/bin/tdoc-publish
+++ b/bin/tdoc-publish
@@ -1012,23 +1012,38 @@ if [ -n "$VISIBILITY_FLAG" ] || [ -n "$HISTORY_FLAG" ] || [ -n "$COMMENTING_FLAG
     ''|owner|invited|signed_in|off) ;;
     *) echo "[tdoc] invalid --commenting '$COMMENTING_FLAG' (owner|invited|signed_in|off)" >&2; exit 1 ;;
   esac
-  ALLOW_JSON='[]'
-  if [ ${#ALLOW_USERS[@]} -gt 0 ]; then
-    ALLOW_JSON="$(printf '%s
-' "${ALLOW_USERS[@]}" | jq -R . | jq -s .)"
-  fi
+  # Written with node, not jq. FIRST-DOC.md step 7 makes the very first doc a
+  # `--visibility private --history owner` publish, so this block is on the
+  # hosted path for every new user — and #256 removed jq from that path
+  # precisely because macOS does not ship it. It was missed then because the
+  # test only checked inside the functions that changed.
+  ALLOW_JSON="$(printf '%s\n' "${ALLOW_USERS[@]:-}" | node -e '
+    let s = "";
+    process.stdin.on("data", (d) => { s += d; });
+    process.stdin.on("end", () => {
+      const list = s.split("\n").map((x) => x.trim()).filter(Boolean);
+      process.stdout.write(JSON.stringify(list));
+    });
+  ')"
   tmp_meta="$(mktemp -t tdoc-meta.XXXXXX)"
-  jq     --arg vis "${VISIBILITY_FLAG}"     --arg hist "${HISTORY_FLAG}"     --arg comm "${COMMENTING_FLAG}"     --argjson allow "$ALLOW_JSON"     '
-      .access = (.access // {})
-      | .access.visibility = (if $vis != "" then $vis else (.access.visibility // "unlisted") end)
-      | .access.history_visibility = (if $hist != "" then $hist else (.access.history_visibility // "owner") end)
-      | .access.commenting = (if $comm != "" then $comm else (.access.commenting // "signed_in") end)
-      | .access.allowed_users = (
-          if ($allow|length) > 0 then
-            (((.access.allowed_users // []) + $allow) | map(ascii_downcase|sub("^github:";"")|sub("^@";"")) | unique)
-          else (.access.allowed_users // []) end
-        )
-    ' "$META_FILE" > "$tmp_meta"
+  node -e '
+    const fs = require("fs");
+    const [metaPath, vis, hist, comm, allowJson] = process.argv.slice(1);
+    const m = JSON.parse(fs.readFileSync(metaPath, "utf8"));
+    const a = (m.access && typeof m.access === "object") ? m.access : {};
+    a.visibility = vis || a.visibility || "unlisted";
+    a.history_visibility = hist || a.history_visibility || "owner";
+    a.commenting = comm || a.commenting || "signed_in";
+    const incoming = JSON.parse(allowJson || "[]");
+    if (incoming.length) {
+      const norm = (u) => String(u).toLowerCase().replace(/^github:/, "").replace(/^@/, "");
+      a.allowed_users = [...new Set([...(a.allowed_users || []), ...incoming].map(norm))];
+    } else {
+      a.allowed_users = a.allowed_users || [];
+    }
+    m.access = a;
+    fs.writeFileSync(process.argv[6], JSON.stringify(m, null, 2));
+  ' "$META_FILE" "${VISIBILITY_FLAG}" "${HISTORY_FLAG}" "${COMMENTING_FLAG}" "$ALLOW_JSON" "$tmp_meta"
   mv "$tmp_meta" "$META_FILE"
   echo "[tdoc] access → $(node -e 'const m=JSON.parse(require("fs").readFileSync(process.argv[1],"utf8"));process.stdout.write(JSON.stringify(m.access===undefined?null:m.access))' "$META_FILE")"
 fi

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -935,5 +935,104 @@ t('SKILL.md resolves its own directory at runtime, not at install time', () => {
     'the resolved directory does not satisfy the update guard');
 });
 
+
+// ---- access flags must not drag jq back onto the hosted path (#272) ----
+// FIRST-DOC.md step 7 publishes the very first doc with
+// `--visibility private --history owner`, so this is the path EVERY new user
+// takes. #256 removed jq from hosted publishing but its test only looked
+// inside the functions that had changed, and the access-block writer sits
+// outside all of them — so the first doc still died with "jq: command not
+// found" on a machine without jq. This test runs the real thing instead of
+// grepping, so scope cannot drift again.
+
+t('a hosted publish with access flags works with no jq on PATH', () => {
+  const bin = path.join(BIN, 'tdoc-publish');
+  const home = fs.mkdtempSync(path.join(os.tmpdir(), 'tdoc-nojq-'));
+  const port = 8600 + Math.floor(Math.random() * 300);
+  const binDir = path.join(home, 'bin');
+  fs.mkdirSync(binDir, { recursive: true });
+
+  // A PATH with everything the script needs EXCEPT jq. Masking jq with a
+  // failing stub would not work: `command -v jq` succeeds on a file that
+  // exists whether or not it runs.
+  for (const dir of (process.env.PATH || '').split(':')) {
+    let entries = [];
+    try { entries = fs.readdirSync(dir); } catch { continue; }
+    for (const name of entries) {
+      if (name === 'jq') continue;
+      const target = path.join(binDir, name);
+      if (fs.existsSync(target)) continue;
+      try { fs.symlinkSync(path.join(dir, name), target); } catch {}
+    }
+  }
+  assert(!fs.existsSync(path.join(binDir, 'jq')), 'the jq-free PATH still has jq');
+
+  const stub = spawn(process.execPath, ['-e',
+    `require('http').createServer((q,s)=>{let b='';q.on('data',d=>b+=d);q.on('end',()=>{` +
+    `s.setHeader('content-type','application/json');` +
+    `const u=q.url.split('?')[0];` +
+    `if(u==='/api/upload'){const j=JSON.parse(b||'{}');` +
+    `return s.end(JSON.stringify({ok:true,slug:j.slug,version:j.version,size:42,` +
+    `access:(j.meta&&j.meta.access)||null}));}` +
+    `s.statusCode=404;s.end('{}');});}).listen(${port},'127.0.0.1');`], { stdio: 'ignore' });
+
+  try {
+    const up = spawnSync('bash', ['-c',
+      `for i in $(seq 1 100); do curl -sS -o /dev/null --max-time 1 -X POST ` +
+      `http://127.0.0.1:${port}/api/upload && exit 0; sleep 0.05; done; exit 1`],
+      { encoding: 'utf8', timeout: 15000 });
+    assert(up.status === 0, 'stub server never came up');
+
+    fs.mkdirSync(path.join(home, '.tdoc'), { recursive: true });
+    fs.writeFileSync(path.join(home, '.tdoc', 'published.json'), JSON.stringify({
+      platform: 'hosted', base: `http://127.0.0.1:${port}`,
+      public_host: '127.0.0.1', upload_token: 'tok', github_login: 'tester',
+    }));
+    const docs = path.join(home, 'tdocs', 'first-doc', 'v1');
+    fs.mkdirSync(docs, { recursive: true });
+    fs.writeFileSync(path.join(docs, 'index.html'),
+      '<!doctype html><body><div class="wrap"><h1>D</h1></div></body>');
+    fs.writeFileSync(path.join(home, 'tdocs', 'first-doc', 'meta.json'), JSON.stringify({
+      title: 'D', slug: 'first-doc', versions: [{ n: 1, created: '2026-01-01T00:00:00Z' }],
+    }));
+    fs.writeFileSync(path.join(home, 'tdocs', 'first-doc', 'comments.json'), '[]');
+
+    // Exactly what FIRST-DOC.md step 7 tells the agent to run.
+    const r = spawnSync(bin, ['--visibility', 'private', '--history', 'owner', 'first-doc'], {
+      env: { ...process.env, PATH: binDir, HOME: home, TDOC_DIR: path.join(home, 'tdocs') },
+      encoding: 'utf8', timeout: 60000,
+    });
+    assert(!/jq: command not found/.test(r.stdout + r.stderr),
+      `the access path still needs jq:\n      ${(r.stdout + r.stderr).split('\n').filter((l) => /jq/.test(l)).join('\n      ')}`);
+    assert(r.status === 0, `publish exited ${r.status}: ${r.stderr}`);
+    assert(/Published:/.test(r.stdout), `no published URL: ${r.stdout}`);
+
+    // And the policy it wrote must be the one that was asked for.
+    const meta = JSON.parse(fs.readFileSync(path.join(home, 'tdocs', 'first-doc', 'meta.json'), 'utf8'));
+    assert(meta.access.visibility === 'private',
+      `expected private, got ${meta.access.visibility}`);
+    assert(meta.access.history_visibility === 'owner',
+      `expected owner history, got ${meta.access.history_visibility}`);
+    assert(Array.isArray(meta.access.allowed_users), 'allowed_users must stay an array');
+
+    // A later flag must MERGE, not replace: publishing again with only
+    // --visibility has to leave history_visibility alone. Getting this wrong
+    // would quietly re-expose the version history of a doc someone had
+    // deliberately locked down.
+    const r2 = spawnSync(bin, ['--visibility', 'unlisted', 'first-doc'], {
+      env: { ...process.env, PATH: binDir, HOME: home, TDOC_DIR: path.join(home, 'tdocs') },
+      encoding: 'utf8', timeout: 60000,
+    });
+    assert(r2.status === 0, `second publish exited ${r2.status}: ${r2.stderr}`);
+    const meta2 = JSON.parse(fs.readFileSync(path.join(home, 'tdocs', 'first-doc', 'meta.json'), 'utf8'));
+    assert(meta2.access.visibility === 'unlisted', 'the new visibility did not apply');
+    assert(meta2.access.history_visibility === 'owner',
+      `history_visibility was reset to ${meta2.access.history_visibility} instead of merging`);
+  } finally {
+    stub.kill();
+    fs.rmSync(home, { recursive: true, force: true });
+  }
+});
+
 console.log(`\n${pass} passed, ${fail} failed`);
 process.exit(fail ? 1 : 0);

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -1034,5 +1034,54 @@ t('a hosted publish with access flags works with no jq on PATH', () => {
   }
 });
 
+
+t('no jq call sits outside a self-host-only region (#272)', () => {
+  // The behavioural test above proves ONE hosted path works without jq. This
+  // one covers the whole file, because the bug it replaces was not a missing
+  // line — it was a test scoped to the code that changed instead of to the
+  // surface the claim covered. Anything added at top level, or in a new
+  // helper, is caught here even if nobody thinks to exercise it.
+  const src = readBin('tdoc-publish');
+  const lines = src.split('\n');
+
+  const fnRange = (name) => {
+    const start = lines.indexOf(`${name}() {`);
+    if (start === -1) return null;
+    for (let j = start + 1; j < lines.length; j++) if (lines[j] === '}') return [start, j];
+    return null;
+  };
+
+  // The platform dispatch is at column 0, so its closing `fi` is too;
+  // everything nested inside is indented.
+  const dispatch = lines.indexOf('if [ "$PLATFORM" = "hosted" ]; then');
+  assert(dispatch !== -1, 'the platform dispatch moved — this guard needs updating');
+  let dispatchEnd = -1;
+  for (let j = dispatch + 1; j < lines.length; j++) if (lines[j] === 'fi') { dispatchEnd = j; break; }
+  assert(dispatchEnd !== -1, 'could not find the end of the platform dispatch');
+  let firstElif = -1;
+  for (let j = dispatch + 1; j < dispatchEnd; j++) {
+    if (lines[j].startsWith('elif [ "$PLATFORM"')) { firstElif = j; break; }
+  }
+  assert(firstElif !== -1, 'the dispatch has no self-host branch');
+
+  const allowed = [['self-host dispatch', firstElif, dispatchEnd]];
+  for (const fn of ['first_time_setup', 'first_time_setup_vercel', 'cf_api',
+                    'resolve_wrangler_oauth_token', 'bundle_worker']) {
+    const r = fnRange(fn);
+    if (r) allowed.push([fn, r[0], r[1]]);
+  }
+  assert(allowed.length >= 4, 'the self-host functions moved — this guard needs updating');
+
+  const stray = [];
+  lines.forEach((l, i) => {
+    if (!/\bjq\s+(-|["'$])/.test(l)) return;
+    if (l.trim().startsWith('#')) return;
+    if (allowed.some(([, a, b]) => i >= a && i <= b)) return;
+    stray.push(`line ${i + 1}: ${l.trim().slice(0, 80)}`);
+  });
+  assert(stray.length === 0,
+    `jq is reachable from the hosted path:\n      ${stray.join('\n      ')}`);
+});
+
 console.log(`\n${pass} passed, ${fail} failed`);
 process.exit(fail ? 1 : 0);

--- a/test/tornado-doc-landing.test.js
+++ b/test/tornado-doc-landing.test.js
@@ -428,8 +428,13 @@ t('release payload carries the homepage access policy', () => {
     'tdoc-publish no longer sends local meta.json, so payload access never reaches /api/upload');
   // --visibility public must merge, not replace. Otherwise the documented
   // publish line would wipe history_visibility / commenting back to defaults.
-  assert(/\.access\.visibility = \(if \$vis != "" then \$vis else \(\.access\.visibility \/\/ "unlisted"\) end\)/.test(publish),
+  // Written in node since #272; the merge semantics are unchanged — an
+  // unspecified flag falls back to what the payload already had, and only
+  // then to the default. cli.test.js exercises this behaviourally.
+  assert(/a\.visibility = vis \|\| a\.visibility \|\| "unlisted"/.test(publish),
     'tdoc-publish access merge no longer keeps unspecified fields from the payload');
+  assert(/a\.history_visibility = hist \|\| a\.history_visibility \|\| "owner"/.test(publish),
+    'history_visibility no longer merges');
 
   const workerSrc = fs.readFileSync(path.join(root, 'worker', 'worker.js'), 'utf8');
   assert(/if \(incoming\.access\)/.test(workerSrc) && /incoming\.access = normalizeAccess\(validatedAccess\.access/.test(workerSrc),


### PR DESCRIPTION
## What & why

Fixes #272. Found by running onboarding end to end on a simulated clean machine — fresh clone, empty `~/.tdoc`, no jq, no wrangler.

```
$ tdoc-publish --visibility private --history owner what-ai-knows-serena
bin/tdoc-publish: line 1021: jq: command not found
```

`FIRST-DOC.md` step 7 **mandates** those flags — the page is about the person, so it must not be link-readable. Which means every new user's first publish takes the access path, and that path still shelled out to jq.

## Why #256 missed it, which matters more than the line

#256 removed jq from hosted publishing and I added a test asserting it. That test sliced three function bodies — `hosted_github_signin`, `first_time_setup_hosted`, `build_payload` — and grepped those.

The access-block writer is at top level, outside all three, guarded only by "did the user pass an access flag". It was never in scope. **The test was scoped to the code I had changed rather than to the surface the claim covered.**

So the replacement is not a wider grep. It publishes for real, with the exact flags from FIRST-DOC.md, against a stub, on a PATH built by symlinking every executable **except** jq.

One note on that method: masking jq with a *failing* stub does not work, because `command -v jq` succeeds on a file that exists whether or not it runs. That mistake is what let the self-host gate go untested in #257, so the PATH here is built by exclusion instead.

## Also pinned: merge, not replace

The same test republishes with only `--visibility` and asserts `history_visibility` survives. Getting that wrong would quietly re-expose the version history of a doc someone had deliberately locked down. `tornado-doc-landing.test.js` had a static assertion for this in jq syntax; it is updated to the node form and now has behaviour behind it rather than a spelling match.

## Verified end to end

```
[tdoc] access → {"visibility":"private","history_visibility":"owner","commenting":"signed_in","allowed_users":[]}
[tdoc] v1 uploaded (26029 bytes)
Published: https://tdoc.dev/d/what-ai-knows-serena/v/1

anonymous GET → HTTP 401        (an unlisted doc on the same host → 200)
```

Reverting the fix turns the new test red (`51 passed, 1 failed`). `npm test` — `PASS — all 43 suite(s) green`.

## Checklist

- [x] `npm test` passes.
- [x] `bin/` only; the Playwright suites do not apply.
- [x] `SKILL.md` not edited.
- [x] No version change.

## Security note

Confined to how the access policy is serialised. Values arrive as `process.argv` and are written with `JSON.stringify` instead of being interpolated into a jq filter, which removes a shell-quoting surface rather than adding one. The `allowed_users` normalisation keeps the same rules — lowercase, strip a leading `github:` or `@`, dedupe — so no login can newly slip past a comparison. Merge semantics are unchanged and now covered behaviourally, which matters because the failure direction is a doc becoming *more* visible than its owner set it to be.