### PR TITLE
The rest of the hosted command set stops needing jq

### DIFF
--- a/ONBOARDING.md
+++ b/ONBOARDING.md
@@ -108,7 +108,7 @@ The JSON has these fields you care about:
 
 ## Step 4 — Walk the user through `missing_steps`
 
-**On the hosted default this list is usually empty** — hosted publishing needs only Node 18+, curl and jq. If `ready_to_publish` is `true`, go straight to Step 5. Do not install wrangler, do not run `wrangler login`, and do not send the user to the Cloudflare dashboard; none of that is part of publishing to tdoc.dev.
+**On the hosted default this list is usually empty** — hosted publishing needs only Node 18+ and curl. If `ready_to_publish` is `true`, go straight to Step 5. Do not install wrangler, do not run `wrangler login`, and do not send the user to the Cloudflare dashboard; none of that is part of publishing to tdoc.dev.
 
 Otherwise, iterate over `missing_steps` **in order**. Each step has a `kind`:
 

--- a/README.md
+++ b/README.md
@@ -171,10 +171,12 @@ This is the "edit history" half of the Google-Docs feeling: nothing you write â€
 
 ## Requirements
 
-- Node 18+
-- `jq` (for publishing)
-- For publishing, ONE of:
-  - `wrangler` + a free Cloudflare account with R2 enabled (default), or
+- Node 18+ and `curl`. That is the whole list for publishing to tdoc.dev, which
+  is the default â€” the first publish signs you in with GitHub and needs no
+  other CLI, no account to create, and no cloud dashboard.
+- Self-hosting instead? Then also `jq`, plus ONE of:
+  - `wrangler` + a free Cloudflare account with R2 enabled
+    (`/tdoc publish --platform cloudflare <slug>`), or
   - `vercel` CLI + a free Vercel account (`/tdoc publish --platform vercel <slug>`)
 
 `/tdoc onboard` checks and installs these for you.

--- a/SKILL.md
+++ b/SKILL.md
@@ -641,7 +641,7 @@ GitHub Device Flow for commenter sign-in via the org-owned OAuth App in
 app; they do not register their own. Set the OAuth App callback URL to
 `https://<host>/auth/done` so GitHub's post-approve redirect is not a 404.
 
-Requires `jq`. Hosted needs no extra CLI. Cloudflare needs `wrangler`
+Hosted needs no extra CLI beyond Node 18+ and curl. Self-hosting needs `jq`. Cloudflare needs `wrangler`
 (`npm i -g wrangler`); Vercel needs `vercel` (`npm i -g vercel`).
 
 ```bash
@@ -680,7 +680,7 @@ installed, or might be partway through. You **must** drive the flow from
 
 1. Run `"$SKILL_DIR/bin/tdoc-doctor"` and parse the JSON. This is non-destructive.
    The doctor is target-aware and reports what it assessed under `.target`.
-   The default is `hosted` (tdoc.dev), which needs Node 18+, curl and jq —
+   The default is `hosted` (tdoc.dev), which needs only Node 18+ and curl —
    **no Cloudflare account, no wrangler, nothing to click in a dashboard.**
    Only pass `--platform cloudflare` / `--platform vercel` when the user has
    asked to self-host.
@@ -747,7 +747,8 @@ Prints the doctor JSON. Use this when the user reports a problem to localize
 which dep / Cloudflare resource is missing.
 
 ```bash
-"$SKILL_DIR/bin/tdoc-doctor" | jq .
+# jq is a self-host-only dependency, so read the report with node.
+"$SKILL_DIR/bin/tdoc-doctor" | node -e 'let s="";process.stdin.on("data",d=>s+=d).on("end",()=>console.log(JSON.stringify(JSON.parse(s),null,2)))'
 ```
 
 ## Troubleshooting

--- a/bin/lib/json.sh
+++ b/bin/lib/json.sh
@@ -1,0 +1,98 @@
+# tdoc shared JSON helpers — node, not jq.
+#
+# Node 18+ is already a hard requirement (the local server and the worker
+# bundle both run on it), so every bin script can read and write JSON without
+# a second dependency. jq is a self-host-only tool now: only the Cloudflare
+# and Vercel setup paths may assume it.
+#
+# Source this from a bin script:
+#   . "$(dirname "$0")/lib/json.sh"
+#
+# Four PRs removed jq from one script each before this file existed (#228,
+# #257, #273, #275). Add new JSON handling here rather than reaching for jq
+# in the next script.
+
+# json_get <dotted.path> — reads JSON on stdin, writes the value (no newline).
+# A missing path, a null, or unparseable input all produce empty output and
+# exit 0, which is what the callers' `// empty` jq filters meant.
+json_get() {
+  node -e '
+    let s = "";
+    process.stdin.on("data", (d) => { s += d; });
+    process.stdin.on("end", () => {
+      let o;
+      try { o = JSON.parse(s); } catch { process.exit(0); }
+      const v = process.argv[1].split(".").reduce((a, k) => (a == null ? a : a[k]), o);
+      if (v !== undefined && v !== null) process.stdout.write(String(v));
+    });
+  ' "$1"
+}
+
+# json_file_get <file> <dotted.path> — same, from a file. Missing file is empty.
+json_file_get() {
+  [ -f "$1" ] || return 0
+  json_get "$2" < "$1"
+}
+
+# json_str <string> — JSON-encode one string, quotes included.
+json_str() { node -e 'process.stdout.write(JSON.stringify(process.argv[1]))' "$1"; }
+
+# json_is_array — stdin parses as a JSON array? Exit status only.
+json_is_array() {
+  node -e '
+    let s = "";
+    process.stdin.on("data", (d) => { s += d; });
+    process.stdin.on("end", () => {
+      try { process.exit(Array.isArray(JSON.parse(s)) ? 0 : 1); } catch { process.exit(1); }
+    });
+  '
+}
+
+# json_file_is_array <file>
+json_file_is_array() {
+  [ -f "$1" ] || return 1
+  json_is_array < "$1"
+}
+
+# json_file_len <file> — element count of a JSON array file, 0 for anything else.
+json_file_len() {
+  [ -f "$1" ] || { printf 0; return 0; }
+  node -e '
+    const fs = require("fs");
+    try {
+      const v = JSON.parse(fs.readFileSync(process.argv[1], "utf8"));
+      process.stdout.write(String(Array.isArray(v) ? v.length : 0));
+    } catch { process.stdout.write("0"); }
+  ' "$1"
+}
+
+# json_pretty — pretty-print stdin. Invalid JSON passes through untouched so a
+# worker error page still reaches the user's eyes instead of vanishing.
+json_pretty() {
+  node -e '
+    let s = "";
+    process.stdin.on("data", (d) => { s += d; });
+    process.stdin.on("end", () => {
+      try { process.stdout.write(JSON.stringify(JSON.parse(s), null, 2) + "\n"); }
+      catch { process.stdout.write(s); }
+    });
+  '
+}
+
+# json_error — stdin is a worker response; write .error if this is an object
+# carrying one, and exit 0. Exit 1 when there is no error field.
+json_error() {
+  node -e '
+    let s = "";
+    process.stdin.on("data", (d) => { s += d; });
+    process.stdin.on("end", () => {
+      let o;
+      try { o = JSON.parse(s); } catch { process.exit(1); }
+      if (o && typeof o === "object" && !Array.isArray(o) && o.error !== undefined) {
+        process.stdout.write(String(o.error));
+        process.exit(0);
+      }
+      process.exit(1);
+    });
+  '
+}

--- a/bin/tdoc-agent-reply
+++ b/bin/tdoc-agent-reply
@@ -14,6 +14,8 @@
 # otherwise to http://localhost:${TDOC_PORT:-7878}.
 
 set -euo pipefail
+TDOC_BIN_DIR="$(cd "$(dirname "$0")" && pwd)"
+. "$TDOC_BIN_DIR/lib/json.sh"
 
 SLUG=""
 PARENT=""
@@ -82,28 +84,17 @@ if ! printf '%s' "$SLUG" | grep -Eq '^[a-z0-9]([a-z0-9-]*[a-z0-9])?$'; then
   exit 1
 fi
 
-if ! command -v jq >/dev/null 2>&1; then echo "needs jq" >&2; exit 1; fi
-
-PAYLOAD="$(jq -n \
-  --arg slug "$SLUG" \
-  --arg parent "$PARENT" \
-  --arg text "$TEXT" \
-  --arg status "$STATUS" \
-  --arg applied "$APPLIED_IN" \
-  --arg login "$LOGIN" \
-  --arg name "$NAME" \
-  --arg avatar "$AVATAR" \
-  '{
-    slug: $slug,
-    parent_id: $parent,
-    text: $text,
-    agent_login: $login,
-    agent_name: $name
-  }
-  + (if $status != "" then {status: $status} else {} end)
-  + (if $applied != "" then {applied_in: ($applied|tonumber)} else {} end)
-  + (if $avatar != "" then {agent_avatar_url: $avatar} else {} end)
-')"
+# The reply body is built by node, not jq: agent replies are a mandatory step
+# of /tdoc edit, and macOS ships no jq, so a jq dependency here takes the whole
+# comment loop down on a stock machine. See #276.
+PAYLOAD="$(node -e '
+  const [slug, parent, text, status, applied, login, name, avatar] = process.argv.slice(1);
+  const o = { slug, parent_id: parent, text, agent_login: login, agent_name: name };
+  if (status !== "") o.status = status;
+  if (applied !== "") o.applied_in = Number(applied);
+  if (avatar !== "") o.agent_avatar_url = avatar;
+  process.stdout.write(JSON.stringify(o));
+' "$SLUG" "$PARENT" "$TEXT" "$STATUS" "$APPLIED_IN" "$LOGIN" "$NAME" "$AVATAR")"
 
 # Post the reply and gate on the outcome.
 #
@@ -131,8 +122,9 @@ post_reply() {
     echo "[tdoc] agent reply NOT posted: $url returned HTTP $http" >&2
     return 1
   fi
-  if printf '%s' "$body" | jq -e 'type == "object" and has("error")' >/dev/null 2>&1; then
-    echo "[tdoc] agent reply NOT posted: $(printf '%s' "$body" | jq -r '.error')" >&2
+  local err
+  if err="$(printf '%s' "$body" | json_error)"; then
+    echo "[tdoc] agent reply NOT posted: $err" >&2
     return 1
   fi
   return 0
@@ -145,14 +137,13 @@ if [ -f "$CONFIG_FILE" ]; then
   # tdoc-pull / tdoc-unpublish. Hosted used to fall into the cloudflare branch
   # and read absent .subdomain/.worker, producing https://null.null.workers.dev
   # and a 404 on every reply — silently, for every hosted user.
-  PLATFORM="$(jq -r '.platform // "cloudflare"' "$CONFIG_FILE")"
-  TOKEN="$(jq -r '.upload_token // empty' "$CONFIG_FILE")"
+  PLATFORM="$(json_file_get "$CONFIG_FILE" platform)"; PLATFORM="${PLATFORM:-cloudflare}"
+  TOKEN="$(json_file_get "$CONFIG_FILE" upload_token)"
   if [ "$PLATFORM" = "hosted" ] || [ "$PLATFORM" = "vercel" ]; then
-    BASE="$(jq -r '.base // empty' "$CONFIG_FILE")"
-    if [ "$BASE" = "null" ]; then BASE=""; fi
+    BASE="$(json_file_get "$CONFIG_FILE" base)"
   else
-    SUBDOMAIN="$(jq -r '.subdomain // empty' "$CONFIG_FILE")"
-    WORKER="$(jq -r '.worker // empty' "$CONFIG_FILE")"
+    SUBDOMAIN="$(json_file_get "$CONFIG_FILE" subdomain)"
+    WORKER="$(json_file_get "$CONFIG_FILE" worker)"
     if [ -n "$SUBDOMAIN" ] && [ -n "$WORKER" ]; then
       BASE="https://${WORKER}.${SUBDOMAIN}.workers.dev"
     else

--- a/bin/tdoc-pull
+++ b/bin/tdoc-pull
@@ -9,7 +9,9 @@
 # absent on the worker, e.g. created before publish) are merged in rather than
 # clobbered.
 set -euo pipefail
-"$(cd "$(dirname "$0")" && pwd)/tdoc-update-nag" >/dev/null || true
+TDOC_BIN_DIR="$(cd "$(dirname "$0")" && pwd)"
+. "$TDOC_BIN_DIR/lib/json.sh"
+"$TDOC_BIN_DIR/tdoc-update-nag" >/dev/null || true
 
 SLUG="${1:-}"
 if [ -z "$SLUG" ]; then echo "usage: tdoc-pull <slug>" >&2; exit 1; fi
@@ -29,20 +31,19 @@ if [ ! -f "$CONFIG_FILE" ]; then
   echo "no ~/.tdoc/published.json — run /tdoc publish <slug> first." >&2
   exit 1
 fi
-if ! command -v jq >/dev/null 2>&1; then echo "needs jq" >&2; exit 1; fi
 
 # Resolve the API base for the configured platform: hosted/vercel configs store
 # the URL directly in `.base`; cloudflare configs derive workers.dev.
-PLATFORM="$(jq -r '.platform // "cloudflare"' "$CONFIG_FILE")"
+PLATFORM="$(json_file_get "$CONFIG_FILE" platform)"; PLATFORM="${PLATFORM:-cloudflare}"
 if [ "$PLATFORM" = "hosted" ] || [ "$PLATFORM" = "vercel" ]; then
-  BASE="$(jq -r '.base // empty' "$CONFIG_FILE")"
+  BASE="$(json_file_get "$CONFIG_FILE" base)"
   if [ -z "$BASE" ] || [ "$BASE" = "null" ]; then
     echo "[tdoc] $CONFIG_FILE has no '.base' — delete it and re-run /tdoc publish to re-setup." >&2
     exit 1
   fi
 else
-  SUBDOMAIN="$(jq -r .subdomain "$CONFIG_FILE")"
-  WORKER_NAME="$(jq -r .worker "$CONFIG_FILE")"
+  SUBDOMAIN="$(json_file_get "$CONFIG_FILE" subdomain)"
+  WORKER_NAME="$(json_file_get "$CONFIG_FILE" worker)"
   BASE="https://${WORKER_NAME}.${SUBDOMAIN}.workers.dev"
 fi
 
@@ -56,7 +57,7 @@ REMOTE="$(curl -sS --connect-timeout 10 --max-time 30 "$BASE/api/comments?slug=$
 
 # Validate the response is a JSON array before touching local state. A transient
 # worker error must never clobber comments.json.
-if ! printf '%s' "$REMOTE" | jq -e 'type == "array"' >/dev/null 2>&1; then
+if ! printf '%s' "$REMOTE" | json_is_array; then
   echo "tdoc-pull: worker did not return a comment array (network error or bad slug?). Local comments.json left untouched." >&2
   printf '%s\n' "$REMOTE" | head -c 400 >&2; echo >&2
   exit 1
@@ -66,21 +67,31 @@ fi
 # any local-only comments (by id) that the worker doesn't know about. This
 # preserves comments authored locally before the doc was published, which would
 # otherwise be lost on the first pull.
-if [ -f "$OUT" ] && jq -e 'type == "array"' "$OUT" >/dev/null 2>&1; then
+if json_file_is_array "$OUT"; then
   cp "$OUT" "$OUT.bak"
-  MERGED="$(jq -n --argjson remote "$REMOTE" --slurpfile local "$OUT" '
-    ($local[0] // []) as $loc
-    | ($remote | map(.id)) as $remoteIds
-    | ($loc | map(select(.id as $i | ($remoteIds | index($i)) | not))) as $localOnly
-    | $remote + $localOnly
-  ')"
-  printf '%s\n' "$MERGED" | jq . > "$OUT"
-  LOCAL_ONLY="$(jq -n --argjson m "$MERGED" --argjson r "$REMOTE" '($m | length) - ($r | length)')"
+  # Merge in node: remote wins on id, local-only comments are appended. Reports
+  # the local-only count on stdout so the shell does not have to re-read the
+  # file to count. See #276 — jq is a self-host-only dependency now.
+  LOCAL_ONLY="$(printf '%s' "$REMOTE" | node -e '
+    const fs = require("fs");
+    const outPath = process.argv[1];
+    let s = "";
+    process.stdin.on("data", (d) => { s += d; });
+    process.stdin.on("end", () => {
+      const remote = JSON.parse(s);
+      let local = [];
+      try { const v = JSON.parse(fs.readFileSync(outPath, "utf8")); if (Array.isArray(v)) local = v; } catch {}
+      const remoteIds = new Set(remote.map((c) => c && c.id));
+      const localOnly = local.filter((c) => !remoteIds.has(c && c.id));
+      fs.writeFileSync(outPath, JSON.stringify(remote.concat(localOnly), null, 2) + "\n");
+      process.stdout.write(String(localOnly.length));
+    });
+  ' "$OUT")"
   if [ "$LOCAL_ONLY" -gt 0 ] 2>/dev/null; then
     echo "Merged $LOCAL_ONLY local-only comment(s) the worker didn't have (backup at $OUT.bak)."
   fi
 else
-  printf '%s\n' "$REMOTE" | jq . > "$OUT"
+  printf '%s' "$REMOTE" | json_pretty > "$OUT"
 fi
 
-echo "Pulled $(jq 'length' "$OUT") comments for $SLUG -> $OUT"
+echo "Pulled $(json_file_len "$OUT") comments for $SLUG -> $OUT"

--- a/bin/tdoc-unpublish
+++ b/bin/tdoc-unpublish
@@ -3,7 +3,9 @@
 #
 # Usage: tdoc-unpublish <slug>
 set -euo pipefail
-"$(cd "$(dirname "$0")" && pwd)/tdoc-update-nag" >/dev/null || true
+TDOC_BIN_DIR="$(cd "$(dirname "$0")" && pwd)"
+. "$TDOC_BIN_DIR/lib/json.sh"
+"$TDOC_BIN_DIR/tdoc-update-nag" >/dev/null || true
 
 SLUG="${1:-}"
 if [ -z "$SLUG" ]; then echo "usage: tdoc-unpublish <slug>" >&2; exit 1; fi
@@ -19,24 +21,22 @@ if [ ! -f "$CONFIG_FILE" ]; then
   echo "no ~/.tdoc/published.json — nothing to unpublish." >&2
   exit 1
 fi
-if ! command -v jq >/dev/null 2>&1; then echo "needs jq" >&2; exit 1; fi
-
-TOKEN="$(jq -r .upload_token "$CONFIG_FILE")"
+TOKEN="$(json_file_get "$CONFIG_FILE" upload_token)"
 # Resolve the API base for the configured platform: hosted/vercel configs store
 # the URL directly in `.base`; cloudflare configs derive workers.dev.
-PLATFORM="$(jq -r '.platform // "cloudflare"' "$CONFIG_FILE")"
+PLATFORM="$(json_file_get "$CONFIG_FILE" platform)"; PLATFORM="${PLATFORM:-cloudflare}"
 if [ "$PLATFORM" = "hosted" ] || [ "$PLATFORM" = "vercel" ]; then
-  BASE="$(jq -r '.base // empty' "$CONFIG_FILE")"
+  BASE="$(json_file_get "$CONFIG_FILE" base)"
   if [ -z "$BASE" ] || [ "$BASE" = "null" ]; then
     echo "[tdoc] $CONFIG_FILE has no '.base' — delete it and re-run /tdoc publish to re-setup." >&2
     exit 1
   fi
 else
-  SUBDOMAIN="$(jq -r .subdomain "$CONFIG_FILE")"
-  WORKER_NAME="$(jq -r .worker "$CONFIG_FILE")"
+  SUBDOMAIN="$(json_file_get "$CONFIG_FILE" subdomain)"
+  WORKER_NAME="$(json_file_get "$CONFIG_FILE" worker)"
   BASE="https://${WORKER_NAME}.${SUBDOMAIN}.workers.dev"
 fi
 
 curl -sS --connect-timeout 10 --max-time 60 -X DELETE "$BASE/api/doc?slug=$SLUG" \
-  -H "Authorization: Bearer $TOKEN" | jq .
+  -H "Authorization: Bearer $TOKEN" | json_pretty
 echo "Unpublished $SLUG."

--- a/bin/tdoc-update
+++ b/bin/tdoc-update
@@ -152,13 +152,14 @@ if [ "$AUTO" = "1" ]; then
 fi
 CONFIG_FILE="$HOME/.tdoc/published.json"
 if [ -f "$CONFIG_FILE" ]; then
+  # Find any locally-existing doc to re-publish — use the one with most-recent
+  # meta.json. This used to sit behind a `command -v jq` guard left over from an
+  # earlier version that parsed meta.json; nothing here calls jq, and the guard
+  # made a no-jq machine report "no local doc found" with docs sitting on disk.
   PUBLISHED_SLUG=""
-  if command -v jq >/dev/null 2>&1; then
-    # Find any locally-existing doc to re-publish — use the one with most-recent meta.json
-    NEWEST_DOC="$(find "$HOME/tdocs" -mindepth 2 -maxdepth 2 -name meta.json -print0 2>/dev/null \
-      | xargs -0 ls -t 2>/dev/null | head -1 || true)"
-    [ -n "$NEWEST_DOC" ] && PUBLISHED_SLUG="$(basename "$(dirname "$NEWEST_DOC")")"
-  fi
+  NEWEST_DOC="$(find "$HOME/tdocs" -mindepth 2 -maxdepth 2 -name meta.json -print0 2>/dev/null \
+    | xargs -0 ls -t 2>/dev/null | head -1 || true)"
+  [ -n "$NEWEST_DOC" ] && PUBLISHED_SLUG="$(basename "$(dirname "$NEWEST_DOC")")"
   echo
   if [ "$YES" = "1" ]; then
     if [ -n "$PUBLISHED_SLUG" ]; then

--- a/skills/tdoc/SKILL.md
+++ b/skills/tdoc/SKILL.md
@@ -641,7 +641,7 @@ GitHub Device Flow for commenter sign-in via the org-owned OAuth App in
 app; they do not register their own. Set the OAuth App callback URL to
 `https://<host>/auth/done` so GitHub's post-approve redirect is not a 404.
 
-Requires `jq`. Hosted needs no extra CLI. Cloudflare needs `wrangler`
+Hosted needs no extra CLI beyond Node 18+ and curl. Self-hosting needs `jq`. Cloudflare needs `wrangler`
 (`npm i -g wrangler`); Vercel needs `vercel` (`npm i -g vercel`).
 
 ```bash
@@ -680,7 +680,7 @@ installed, or might be partway through. You **must** drive the flow from
 
 1. Run `"$SKILL_DIR/bin/tdoc-doctor"` and parse the JSON. This is non-destructive.
    The doctor is target-aware and reports what it assessed under `.target`.
-   The default is `hosted` (tdoc.dev), which needs Node 18+, curl and jq —
+   The default is `hosted` (tdoc.dev), which needs only Node 18+ and curl —
    **no Cloudflare account, no wrangler, nothing to click in a dashboard.**
    Only pass `--platform cloudflare` / `--platform vercel` when the user has
    asked to self-host.
@@ -747,7 +747,8 @@ Prints the doctor JSON. Use this when the user reports a problem to localize
 which dep / Cloudflare resource is missing.
 
 ```bash
-"$SKILL_DIR/bin/tdoc-doctor" | jq .
+# jq is a self-host-only dependency, so read the report with node.
+"$SKILL_DIR/bin/tdoc-doctor" | node -e 'let s="";process.stdin.on("data",d=>s+=d).on("end",()=>console.log(JSON.stringify(JSON.parse(s),null,2)))'
 ```
 
 ## Troubleshooting

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -97,9 +97,13 @@ t('tdoc-publish defaults to hosted and treats Cloudflare/Vercel as self-host fla
 t('pull/unpublish read hosted base from published.json', () => {
   for (const f of ['tdoc-pull', 'tdoc-unpublish']) {
     const src = readBin(f);
-    assert(/PLATFORM="\$\(jq -r '\.platform \/\/ "cloudflare"'/.test(src), `${f}: platform detection missing`);
+    assert(/PLATFORM="\$\(json_file_get "\$CONFIG_FILE" platform\)"/.test(src),
+      `${f}: platform detection missing`);
+    assert(/PLATFORM="\$\{PLATFORM:-cloudflare\}"/.test(src),
+      `${f}: platform must still default to cloudflare for old configs`);
     assert(/"\$PLATFORM" = "hosted"/.test(src), `${f}: hosted platform branch missing`);
-    assert(/BASE="\$\(jq -r '\.base \/\/ empty'/.test(src), `${f}: hosted/vercel branch should read .base`);
+    assert(/BASE="\$\(json_file_get "\$CONFIG_FILE" base\)"/.test(src),
+      `${f}: hosted/vercel branch should read .base`);
   }
 });
 
@@ -498,7 +502,7 @@ t('tdoc-agent-reply gates on HTTP status and on 200-with-error bodies', () => {
   assert(/post_reply\(\)/.test(src), 'post_reply helper missing');
   assert(/http_code/.test(src) && /grep -qE '\^2/.test(src),
     'post_reply does not gate on 2xx HTTP status');
-  assert(/has\("error"\)/.test(src),
+  assert(/json_error/.test(src),
     'post_reply does not reject a 200 body carrying an "error" key');
   // Both transports must go through the helper and propagate its failure.
   const calls = src.split('\n').filter(l => /^\s*post_reply /.test(l));
@@ -627,11 +631,63 @@ t('tdoc-agent-reply base resolution matches tdoc-pull across platforms', () => {
     'hosted is not on the .base side of the platform branch');
   assert(/BASE="https:\/\/\$\{WORKER\}\.\$\{SUBDOMAIN\}\.workers\.dev"/.test(src),
     'cloudflare no longer derives the workers.dev base');
-  assert(/\.platform \/\/ "cloudflare"/.test(src),
+  assert(/PLATFORM="\$\{PLATFORM:-cloudflare\}"/.test(src),
     'legacy configs without .platform no longer default to cloudflare');
-  // A missing field must not become the literal string "null" in a hostname.
-  assert(/'\.subdomain \/\/ empty'/.test(src) && /'\.worker \/\/ empty'/.test(src),
-    'subdomain/worker are read without an // empty guard, so jq can yield "null"');
+});
+
+t('a legacy config with no .platform still resolves a workers.dev base', () => {
+  // The grep above says the default is written down; this says it survives a
+  // real run. #272's lesson: a claim tested by reading the source is a claim
+  // about the source, not about what the command does.
+  const home = fs.mkdtempSync(path.join(os.tmpdir(), 'tdoc-legacy-'));
+  try {
+    fs.mkdirSync(path.join(home, '.tdoc'), { recursive: true });
+    // No `platform` key at all — the shape configs had before hosted existed.
+    fs.writeFileSync(path.join(home, '.tdoc', 'published.json'), JSON.stringify({
+      subdomain: 'acme', worker: 'tdoc', upload_token: 'tok',
+    }));
+    const r = spawnSync(path.join(BIN, 'tdoc-agent-reply'), [
+      '--slug', 'legacy-doc', '--parent', 'c1', '--text', 'hi',
+    ], {
+      env: { ...process.env, HOME: home, TDOC_SKIP_UPDATE_CHECK: '1' },
+      encoding: 'utf8', timeout: 60000,
+    });
+    // acme is not a real subdomain, so this cannot succeed. What matters is
+    // WHICH host it tried: the legacy derivation, not localhost and not "null".
+    const out = r.stdout + r.stderr;
+    assert(/tdoc\.acme\.workers\.dev/.test(out),
+      `legacy config did not derive workers.dev:\n      ${out.trim()}`);
+    assert(!/null\.null/.test(out), `a missing field leaked as "null":\n      ${out.trim()}`);
+    assert(!/localhost/.test(out), `fell through to localhost instead:\n      ${out.trim()}`);
+  } finally {
+    fs.rmSync(home, { recursive: true, force: true });
+  }
+});
+
+t('a hosted config missing .base falls through to localhost, not to "null"', () => {
+  // json_file_get returns empty for both a missing key and an explicit null,
+  // which is what the old `// empty` filters guaranteed. If that ever changed,
+  // BASE would be the string "null" and every reply would 404 on
+  // https://null — the #226 bug, wearing a different hat.
+  const home = fs.mkdtempSync(path.join(os.tmpdir(), 'tdoc-nullbase-'));
+  try {
+    fs.mkdirSync(path.join(home, '.tdoc'), { recursive: true });
+    fs.writeFileSync(path.join(home, '.tdoc', 'published.json'), JSON.stringify({
+      platform: 'hosted', base: null, upload_token: 'tok',
+    }));
+    const r = spawnSync(path.join(BIN, 'tdoc-agent-reply'), [
+      '--slug', 'nullbase-doc', '--parent', 'c1', '--text', 'hi',
+    ], {
+      env: { ...process.env, HOME: home, TDOC_SKIP_UPDATE_CHECK: '1', TDOC_PORT: '7999' },
+      encoding: 'utf8', timeout: 60000,
+    });
+    const out = r.stdout + r.stderr;
+    assert(/localhost:7999/.test(out),
+      `an unusable base should fall through to local, got:\n      ${out.trim()}`);
+    assert(!/https:\/\/null/.test(out), `"null" was used as a host:\n      ${out.trim()}`);
+  } finally {
+    fs.rmSync(home, { recursive: true, force: true });
+  }
 });
 
 
@@ -1084,6 +1140,303 @@ t('no jq call sits outside a self-host-only region (#272)', () => {
   assert(stray.length === 0,
     `jq is reachable from the hosted path:\n      ${stray.join('\n      ')}`);
 });
+
+
+// ---- the rest of the hosted command set must not need jq either (#276) ----
+// Four PRs removed jq from one script each (#228, #257, #273, #275) and each
+// left the next one standing, because every bin script re-implemented its own
+// config reads. tdoc-agent-reply is the worst of them: SKILL.md calls replying
+// on every comment "mandatory", so a jq gate there takes the whole comment
+// loop down on a stock macOS machine. These run the real binaries.
+
+// Build a PATH carrying everything except jq. A failing stub would not do:
+// `command -v jq` succeeds on any file that exists, runnable or not.
+function jqFreePath(home) {
+  const binDir = path.join(home, 'bin');
+  fs.mkdirSync(binDir, { recursive: true });
+  for (const dir of (process.env.PATH || '').split(':')) {
+    let entries = [];
+    try { entries = fs.readdirSync(dir); } catch { continue; }
+    for (const name of entries) {
+      if (name === 'jq') continue;
+      const target = path.join(binDir, name);
+      if (fs.existsSync(target)) continue;
+      try { fs.symlinkSync(path.join(dir, name), target); } catch {}
+    }
+  }
+  assert(!fs.existsSync(path.join(binDir, 'jq')), 'the jq-free PATH still has jq');
+  return binDir;
+}
+
+// A stand-in worker: serves a comment list, accepts agent replies, accepts
+// deletes. Routes are the ones the three scripts actually call.
+function startStubWorker(port, state) {
+  const child = spawn(process.execPath, ['-e',
+    `const st=${JSON.stringify(state)};` +
+    `require('http').createServer((q,s)=>{let b='';q.on('data',d=>b+=d);q.on('end',()=>{` +
+    `s.setHeader('content-type','application/json');` +
+    `const u=q.url.split('?')[0];` +
+    `if(u==='/api/comments')return s.end(JSON.stringify(st.comments));` +
+    `if(u==='/api/agent/reply'){st.lastReply=JSON.parse(b||'{}');` +
+    `return s.end(JSON.stringify({ok:true,echo:st.lastReply}));}` +
+    `if(u==='/api/doc')return s.end(JSON.stringify({ok:true,deleted:3}));` +
+    `s.statusCode=404;s.end('{}');});}).listen(${port},'127.0.0.1');`], { stdio: 'ignore' });
+  const up = spawnSync('bash', ['-c',
+    `for i in $(seq 1 100); do curl -sS -o /dev/null --max-time 1 ` +
+    `http://127.0.0.1:${port}/api/comments && exit 0; sleep 0.05; done; exit 1`],
+    { encoding: 'utf8', timeout: 15000 });
+  assert(up.status === 0, 'stub worker never came up');
+  return child;
+}
+
+function hostedHome(port) {
+  const home = fs.mkdtempSync(path.join(os.tmpdir(), 'tdoc-nojq2-'));
+  fs.mkdirSync(path.join(home, '.tdoc'), { recursive: true });
+  fs.writeFileSync(path.join(home, '.tdoc', 'published.json'), JSON.stringify({
+    platform: 'hosted', base: `http://127.0.0.1:${port}`,
+    public_host: '127.0.0.1', upload_token: 'tok', github_login: 'tester',
+  }));
+  return home;
+}
+
+const noJq = (r) => !/jq: command not found|needs jq/.test(r.stdout + r.stderr);
+
+t('tdoc-pull works with no jq on PATH, and still merges local-only comments', () => {
+  const port = 8900 + Math.floor(Math.random() * 200);
+  const remote = [{ id: 'r1', text: 'from worker', version: 1 }];
+  const stub = startStubWorker(port, { comments: remote });
+  const home = hostedHome(port);
+  try {
+    const binDir = jqFreePath(home);
+    const doc = path.join(home, 'tdocs', 'pull-doc');
+    fs.mkdirSync(doc, { recursive: true });
+    // One comment the worker has, one it does not. The local-only one is the
+    // whole point of the merge — losing it was a real data-loss bug once.
+    fs.writeFileSync(path.join(doc, 'comments.json'), JSON.stringify([
+      { id: 'r1', text: 'stale copy', version: 1 },
+      { id: 'local-only', text: 'authored before publish', version: 1 },
+    ]));
+
+    const r = spawnSync(path.join(BIN, 'tdoc-pull'), ['pull-doc'], {
+      env: { ...process.env, PATH: binDir, HOME: home, TDOC_DIR: path.join(home, 'tdocs'),
+             TDOC_SKIP_UPDATE_CHECK: '1' },
+      encoding: 'utf8', timeout: 60000,
+    });
+    assert(noJq(r), `tdoc-pull still needs jq:\n      ${r.stdout}\n      ${r.stderr}`);
+    assert(r.status === 0, `tdoc-pull exited ${r.status}: ${r.stderr}`);
+
+    const merged = JSON.parse(fs.readFileSync(path.join(doc, 'comments.json'), 'utf8'));
+    assert(merged.length === 2, `expected 2 merged comments, got ${merged.length}`);
+    assert(merged[0].text === 'from worker', 'the worker copy must win on a shared id');
+    assert(merged.some((c) => c.id === 'local-only'), 'the local-only comment was dropped');
+    assert(fs.existsSync(path.join(doc, 'comments.json.bak')), 'no backup was written');
+    assert(/Pulled 2 comments/.test(r.stdout), `wrong count reported: ${r.stdout}`);
+    assert(/Merged 1 local-only/.test(r.stdout), `merge not reported: ${r.stdout}`);
+  } finally {
+    stub.kill();
+    fs.rmSync(home, { recursive: true, force: true });
+  }
+});
+
+t('tdoc-pull refuses to clobber comments.json when the worker misbehaves', () => {
+  // The array check is the guard that keeps a 500 or an HTML error page from
+  // wiping local comments. It has to survive the move off jq.
+  const port = 9150 + Math.floor(Math.random() * 200);
+  const stub = spawn(process.execPath, ['-e',
+    `require('http').createServer((q,s)=>{s.statusCode=500;s.end('<html>bad gateway</html>');})` +
+    `.listen(${port},'127.0.0.1');`], { stdio: 'ignore' });
+  const home = hostedHome(port);
+  try {
+    spawnSync('bash', ['-c', `for i in $(seq 1 100); do curl -sS -o /dev/null --max-time 1 ` +
+      `http://127.0.0.1:${port}/ && break; sleep 0.05; done`], { timeout: 15000 });
+    const binDir = jqFreePath(home);
+    const doc = path.join(home, 'tdocs', 'pull-doc');
+    fs.mkdirSync(doc, { recursive: true });
+    const original = JSON.stringify([{ id: 'keep-me', text: 'precious', version: 1 }]);
+    fs.writeFileSync(path.join(doc, 'comments.json'), original);
+
+    const r = spawnSync(path.join(BIN, 'tdoc-pull'), ['pull-doc'], {
+      env: { ...process.env, PATH: binDir, HOME: home, TDOC_DIR: path.join(home, 'tdocs'),
+             TDOC_SKIP_UPDATE_CHECK: '1' },
+      encoding: 'utf8', timeout: 60000,
+    });
+    assert(noJq(r), `tdoc-pull still needs jq:\n      ${r.stderr}`);
+    assert(r.status !== 0, 'a non-array response must fail, not succeed');
+    assert(fs.readFileSync(path.join(doc, 'comments.json'), 'utf8') === original,
+      'local comments were clobbered by a bad worker response');
+    // The file surviving is not enough. Node's own JSON.parse would also throw
+    // on this input, so the file is safe either way — what the array guard buys
+    // is that the user reads a sentence instead of a stack trace, and sees the
+    // start of the response that confused it. Assert the sentence.
+    assert(/did not return a comment array/.test(r.stderr),
+      `no plain-language explanation:\n      ${r.stderr.trim()}`);
+    assert(/bad gateway/.test(r.stderr),
+      `the worker's actual response was not shown:\n      ${r.stderr.trim()}`);
+    assert(!/at JSON\.parse|node:internal/.test(r.stderr),
+      `a node stack trace reached the user:\n      ${r.stderr.trim()}`);
+    assert(!fs.existsSync(path.join(doc, 'comments.json.bak')),
+      'a bad response should not leave a spurious .bak behind');
+  } finally {
+    stub.kill();
+    fs.rmSync(home, { recursive: true, force: true });
+  }
+});
+
+t('tdoc-agent-reply posts with no jq on PATH, and builds the payload right', () => {
+  const port = 9400 + Math.floor(Math.random() * 200);
+  const stub = startStubWorker(port, { comments: [] });
+  const home = hostedHome(port);
+  try {
+    const binDir = jqFreePath(home);
+    // Quotes and non-ASCII in the reply text: hand-rolled JSON is where this
+    // kind of port usually breaks, and replies are written in the user's own
+    // language, so non-ASCII is the normal case rather than the edge one.
+    const text = 'Rewrote the "intro" — 已改成中文.';
+    const r = spawnSync(path.join(BIN, 'tdoc-agent-reply'), [
+      '--slug', 'reply-doc', '--parent', 'c1', '--text', text,
+      '--status', 'applied', '--applied-in', '2',
+    ], {
+      env: { ...process.env, PATH: binDir, HOME: home, TDOC_SKIP_UPDATE_CHECK: '1' },
+      encoding: 'utf8', timeout: 60000,
+    });
+    assert(noJq(r), `tdoc-agent-reply still needs jq:\n      ${r.stdout}\n      ${r.stderr}`);
+    assert(r.status === 0, `agent-reply exited ${r.status}: ${r.stderr}`);
+
+    const echoed = JSON.parse(r.stdout).echo;
+    assert(echoed.slug === 'reply-doc' && echoed.parent_id === 'c1', 'wrong identifiers');
+    assert(echoed.text === text, `text was mangled: ${echoed.text}`);
+    assert(echoed.status === 'applied', 'status was dropped');
+    assert(echoed.applied_in === 2,
+      `applied_in must be a number, got ${JSON.stringify(echoed.applied_in)}`);
+    assert(typeof echoed.agent_login === 'string', 'agent_login must always be present');
+    assert(!('agent_avatar_url' in echoed), 'an empty avatar must be omitted, not sent as ""');
+  } finally {
+    stub.kill();
+    fs.rmSync(home, { recursive: true, force: true });
+  }
+});
+
+t('tdoc-agent-reply still reports a 200-with-error as a failure', () => {
+  // The worker rejects some replies with a 200 body carrying {"error": ...}.
+  // Without this check a rejected reply is indistinguishable from a posted one,
+  // which is how comments silently go unanswered.
+  const port = 9650 + Math.floor(Math.random() * 200);
+  const stub = spawn(process.execPath, ['-e',
+    `require('http').createServer((q,s)=>{s.setHeader('content-type','application/json');` +
+    `s.end(JSON.stringify({error:'parent_not_found'}));}).listen(${port},'127.0.0.1');`],
+    { stdio: 'ignore' });
+  const home = hostedHome(port);
+  try {
+    spawnSync('bash', ['-c', `for i in $(seq 1 100); do curl -sS -o /dev/null --max-time 1 ` +
+      `http://127.0.0.1:${port}/ && break; sleep 0.05; done`], { timeout: 15000 });
+    const binDir = jqFreePath(home);
+    const r = spawnSync(path.join(BIN, 'tdoc-agent-reply'), [
+      '--slug', 'reply-doc', '--parent', 'missing', '--text', 'hi',
+    ], {
+      env: { ...process.env, PATH: binDir, HOME: home, TDOC_SKIP_UPDATE_CHECK: '1' },
+      encoding: 'utf8', timeout: 60000,
+    });
+    assert(noJq(r), `tdoc-agent-reply still needs jq:\n      ${r.stderr}`);
+    assert(r.status !== 0, 'a 200-with-error must exit non-zero');
+    assert(/parent_not_found/.test(r.stderr),
+      `the worker's reason should reach the user: ${r.stderr}`);
+  } finally {
+    stub.kill();
+    fs.rmSync(home, { recursive: true, force: true });
+  }
+});
+
+t('tdoc-unpublish works with no jq on PATH', () => {
+  const port = 9900 + Math.floor(Math.random() * 90);
+  const stub = startStubWorker(port, { comments: [] });
+  const home = hostedHome(port);
+  try {
+    const binDir = jqFreePath(home);
+    const r = spawnSync(path.join(BIN, 'tdoc-unpublish'), ['gone-doc'], {
+      env: { ...process.env, PATH: binDir, HOME: home, TDOC_SKIP_UPDATE_CHECK: '1' },
+      encoding: 'utf8', timeout: 60000,
+    });
+    assert(noJq(r), `tdoc-unpublish still needs jq:\n      ${r.stdout}\n      ${r.stderr}`);
+    assert(r.status === 0, `unpublish exited ${r.status}: ${r.stderr}`);
+    assert(/Unpublished gone-doc/.test(r.stdout), `no confirmation: ${r.stdout}`);
+    assert(/"deleted": 3/.test(r.stdout), `the worker response was not printed: ${r.stdout}`);
+  } finally {
+    stub.kill();
+    fs.rmSync(home, { recursive: true, force: true });
+  }
+});
+
+t('the hosted-capable scripts call jq nowhere at all (#276)', () => {
+  // tdoc-publish has genuine self-host regions, so its guard has to reason
+  // about ranges. These three have no self-host-only work in them: every line
+  // runs on hosted, so the correct budget is zero. A range-based guard would
+  // be the same mistake that let #272 through.
+  for (const f of ['tdoc-pull', 'tdoc-agent-reply', 'tdoc-unpublish']) {
+    const lines = readBin(f).split('\n');
+    const stray = [];
+    lines.forEach((l, i) => {
+      if (!/\bjq\b/.test(l)) return;
+      if (l.trim().startsWith('#')) return;   // prose about jq is fine
+      stray.push(`line ${i + 1}: ${l.trim().slice(0, 80)}`);
+    });
+    assert(stray.length === 0, `${f} reaches for jq:\n      ${stray.join('\n      ')}`);
+  }
+});
+
+t('the shared JSON helpers are sourced, not re-implemented per script', () => {
+  // The defect #276 names is not any one jq call, it is that each script grew
+  // its own config reader. Keep them on one implementation so the next fix
+  // lands once.
+  const lib = fs.readFileSync(path.join(BIN, 'lib', 'json.sh'), 'utf8');
+  for (const fn of ['json_get', 'json_file_get', 'json_str', 'json_is_array',
+                    'json_file_is_array', 'json_file_len', 'json_pretty', 'json_error']) {
+    assert(new RegExp(`^${fn}\\(\\) \\{`, 'm').test(lib), `lib/json.sh lost ${fn}`);
+  }
+  assert(!/\bjq\b/.test(lib.split('\n').filter((l) => !l.trim().startsWith('#')).join('\n')),
+    'lib/json.sh must not shell out to jq');
+
+  for (const f of ['tdoc-pull', 'tdoc-agent-reply', 'tdoc-unpublish']) {
+    const src = readBin(f);
+    assert(/^\. "\$TDOC_BIN_DIR\/lib\/json\.sh"$/m.test(src),
+      `${f} does not source the shared helpers`);
+    assert(/^TDOC_BIN_DIR="\$\(cd "\$\(dirname "\$0"\)" && pwd\)"$/m.test(src),
+      `${f} does not resolve its own bin dir before sourcing`);
+  }
+});
+
+t('lib/json.sh survives the inputs that actually show up', () => {
+  const lib = path.join(BIN, 'lib', 'json.sh');
+  const run = (script, input) => spawnSync('bash', ['-c', `. "${lib}"; ${script}`],
+    { input: input ?? '', encoding: 'utf8', timeout: 20000 });
+
+  // A missing key, a null, and unparseable input all have to read as empty —
+  // that is what the `// empty` jq filters they replaced did, and the callers
+  // test the result with [ -z ].
+  assert(run('json_get a.b', '{"a":{"b":"x"}}').stdout === 'x', 'nested read failed');
+  assert(run('json_get a.b', '{"a":{}}').stdout === '', 'missing key must read empty');
+  assert(run('json_get a', '{"a":null}').stdout === '', 'null must read empty');
+  assert(run('json_get a', 'not json').stdout === '', 'garbage must read empty, not crash');
+  assert(run('json_get a', 'not json').status === 0, 'garbage must not fail the caller');
+  assert(run('json_get a.b', '{"a":"scalar"}').stdout === '',
+    'descending into a scalar must read empty');
+
+  // Numbers and booleans come back as their text, since config values land in
+  // shell variables either way.
+  assert(run('json_get n', '{"n":42}').stdout === '42', 'numbers must stringify');
+  assert(run('json_get b', '{"b":false}').stdout === 'false', 'false must not read as empty');
+
+  assert(run('json_str \'a "b" 中\'').stdout === '"a \\"b\\" 中"', 'json_str mis-encodes');
+  assert(run('json_is_array', '[]').status === 0, '[] is an array');
+  assert(run('json_is_array', '{}').status !== 0, '{} is not an array');
+  assert(run('json_is_array', '<html>').status !== 0, 'an error page is not an array');
+  assert(run('json_error', '{"error":"nope"}').stdout === 'nope', 'json_error missed .error');
+  assert(run('json_error', '{"ok":true}').status !== 0, 'json_error fired without an error');
+  assert(run('json_error', '[{"error":"x"}]').status !== 0, 'an array is not an error object');
+  // An error page must reach the user rather than being swallowed as invalid.
+  assert(run('json_pretty', '<html>500</html>').stdout === '<html>500</html>',
+    'json_pretty ate a non-JSON body');
+});
+
 
 console.log(`\n${pass} passed, ${fail} failed`);
 process.exit(fail ? 1 : 0);


### PR DESCRIPTION
Fixes #276.

### What this fixes

Third end-to-end run on a simulated new-user machine (fresh clone of `main`, PATH rebuilt without `jq` or `wrangler`, hosted config only). After #273 and #275, publishing works and the doctor correctly reports `target=hosted ready_to_publish=true missing_steps=[]`.

The next two documented commands then fail:

```
$ tdoc-pull what-ai-knows-serena
needs jq
$ tdoc-agent-reply --slug ... --parent ... --status applied
needs jq
```

`tdoc-unpublish` had the same gate.

`tdoc-agent-reply` is the one that matters most: SKILL.md's `/tdoc edit` calls replying on every comment *"mandatory ... a hard requirement, not a suggestion"*. So on a stock macOS machine the second half of the product loop — comment, edit, get answered — could not run at all, while the doctor said the machine was ready.

### The actual defect was the layer, not the fifth script

Four PRs have now removed a jq dependency from exactly one script each: #228, #257, #273, #275. Each was correct and each left the next one standing, because there was no shared JSON layer — every bin script re-implemented config reads with its own `jq -r` calls behind its own `command -v jq` gate.

So this adds `bin/lib/json.sh` (`json_get`, `json_file_get`, `json_str`, `json_is_array`, `json_file_is_array`, `json_file_len`, `json_pretty`, `json_error`), sourced by `tdoc-pull`, `tdoc-agent-reply` and `tdoc-unpublish`. Those three now call jq nowhere at all. Node 18+ was already a hard requirement; jq is a self-host-only dependency, and `tdoc-publish`'s Cloudflare/Vercel paths still use it behind `require_jq_for_selfhost`.

### Two things found along the way

**`tdoc-update` had a dead jq guard.** `command -v jq` wrapped a block of `find` / `ls` / `basename` — a leftover from a version that parsed `meta.json`. Nothing inside called jq, so on a no-jq machine `tdoc-update --yes` printed "no local doc found to redeploy" with docs sitting on disk.

**The docs said what the code said.** SKILL.md, ONBOARDING.md and README all listed jq as a hosted requirement, and SKILL.md's own onboarding step piped `tdoc-doctor` through `jq .` — so the command that diagnoses a bare machine could not run on one. README's Requirements section also still described publishing as a choice between wrangler and vercel, which stopped being true when hosted became the default; that paragraph is rewritten.

### Testing

The new tests run the real binaries against a stub worker, on a PATH built by symlinking every executable **except** jq. That shape comes from #272: a test that greps the source proves something about the source. Masking jq with a failing stub does not work either — `command -v jq` succeeds on any file that exists.

- `tdoc-pull` — merges local-only comments, worker wins on a shared id, writes a backup, reports the right count
- `tdoc-pull` bad response — a 500 HTML page must not clobber `comments.json`, and must produce a sentence rather than a node stack trace
- `tdoc-agent-reply` — payload shape end to end: quotes and non-ASCII in the reply text (replies are written in the user's own language, so non-ASCII is the normal case), `applied_in` as a number not a string, an empty avatar omitted rather than sent as `""`
- `tdoc-agent-reply` — a 200 body carrying `{"error": ...}` still exits non-zero and surfaces the reason
- `tdoc-unpublish` — succeeds and prints the worker response
- legacy config with no `.platform` still derives `workers.dev`; a hosted config with `base: null` falls through to localhost rather than `https://null`
- static guard: zero jq in all three scripts (unlike `tdoc-publish`, none of them has self-host-only work, so the correct budget is zero rather than a range)
- unit coverage of the helpers: missing key, explicit null, unparseable input, descending into a scalar, numbers, `false`, and a non-JSON body passing through `json_pretty` untouched

Each of these was checked against a deliberate reintroduction of the bug it claims to catch — nine mutations, nine failures. One did not fail on the first try: removing `tdoc-pull`'s array guard left the file safe anyway, because node's own `JSON.parse` throws on an HTML error page. The file surviving was not the property worth pinning, so that test now asserts the user-facing message instead.

`npm test` green (43 suites), plus `onboarding.test.js` (16) run separately since it is gated.