### PR TITLE
The owner's CLI can read their own private doc

### DIFF
--- a/bin/tdoc-pull
+++ b/bin/tdoc-pull
@@ -69,9 +69,16 @@ fi
 # worker error must never clobber comments.json.
 if ! printf '%s' "$REMOTE" | json_is_array; then
   if printf '%s' "$REMOTE" | grep -q '"access_denied"'; then
-    echo "tdoc-pull: the worker refused to show '$SLUG' to this machine." >&2
-    echo "  This doc is private and the account token in $CONFIG_FILE does not own it." >&2
-    echo "  If it is yours, the token is stale — re-run: /tdoc publish $SLUG" >&2
+    # State the possibilities; do not pick one. The first live run of this
+    # message picked "your token does not own it" and was wrong: the token did
+    # own the doc, the worker was simply older than the fix that taught it to
+    # read tokens. Self-hosted workers can lag by any amount, so that case is
+    # permanent, not a launch-week detail.
+    echo "tdoc-pull: '$SLUG' is not readable by this machine ($BASE said access_denied)." >&2
+    echo "  The doc is private, so one of these is true:" >&2
+    echo "    - the account token in $CONFIG_FILE belongs to a different account" >&2
+    echo "    - this worker predates token-authenticated reads; redeploy it" >&2
+    echo "  If the doc is yours and the host is tdoc.dev, re-run: /tdoc publish $SLUG" >&2
   else
     echo "tdoc-pull: worker did not return a comment array (network error or bad slug?). Local comments.json left untouched." >&2
   fi

--- a/bin/tdoc-pull
+++ b/bin/tdoc-pull
@@ -53,12 +53,28 @@ mkdir -p "$(dirname "$OUT")"
 # Fetch the FULL history (all versions). Without version=all the worker returns
 # only the latest snapshot, which silently drops comments created on earlier
 # versions (root cause of "comments disappear on pull").
-REMOTE="$(curl -sS --connect-timeout 10 --max-time 30 "$BASE/api/comments?slug=$SLUG&version=all")"
+# Send the account token. This was the only CLI request that authenticated
+# with nothing at all, so on a private doc the worker saw an anonymous visitor
+# and denied the owner their own comments — and private is what FIRST-DOC.md
+# publishes every new user's first doc as. See #278.
+TOKEN="$(json_file_get "$CONFIG_FILE" upload_token)"
+if [ -n "$TOKEN" ]; then
+  REMOTE="$(curl -sS --connect-timeout 10 --max-time 30 \
+    -H "Authorization: Bearer $TOKEN" "$BASE/api/comments?slug=$SLUG&version=all")"
+else
+  REMOTE="$(curl -sS --connect-timeout 10 --max-time 30 "$BASE/api/comments?slug=$SLUG&version=all")"
+fi
 
 # Validate the response is a JSON array before touching local state. A transient
 # worker error must never clobber comments.json.
 if ! printf '%s' "$REMOTE" | json_is_array; then
-  echo "tdoc-pull: worker did not return a comment array (network error or bad slug?). Local comments.json left untouched." >&2
+  if printf '%s' "$REMOTE" | grep -q '"access_denied"'; then
+    echo "tdoc-pull: the worker refused to show '$SLUG' to this machine." >&2
+    echo "  This doc is private and the account token in $CONFIG_FILE does not own it." >&2
+    echo "  If it is yours, the token is stale — re-run: /tdoc publish $SLUG" >&2
+  else
+    echo "tdoc-pull: worker did not return a comment array (network error or bad slug?). Local comments.json left untouched." >&2
+  fi
   printf '%s\n' "$REMOTE" | head -c 400 >&2; echo >&2
   exit 1
 fi

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -1509,10 +1509,19 @@ t('a denied pull explains it is an access problem, not a network one', () => {
       encoding: 'utf8', timeout: 60000,
     });
     assert(r.status !== 0, 'a denial must fail');
-    assert(/private/.test(r.stderr) && /does not own it/.test(r.stderr),
+    assert(/access_denied/.test(r.stderr) && /private/.test(r.stderr),
       `the denial was not explained:\n      ${r.stderr.trim()}`);
     assert(/tdoc publish priv-doc/.test(r.stderr),
       `no way out was offered:\n      ${r.stderr.trim()}`);
+    // Both causes, neither asserted. The first live run of this message named
+    // the wrong one — the token owned the doc, the worker was just older than
+    // the fix — and sent the owner off to re-publish for nothing.
+    assert(/different account/.test(r.stderr),
+      `the wrong-account cause is missing:\n      ${r.stderr.trim()}`);
+    assert(/predates token-authenticated reads|redeploy/.test(r.stderr),
+      `the stale-worker cause is missing:\n      ${r.stderr.trim()}`);
+    assert(!/does not own it/.test(r.stderr),
+      `the message still asserts one cause as fact:\n      ${r.stderr.trim()}`);
     assert(!/network error/.test(r.stderr),
       `a denial was still blamed on the network:\n      ${r.stderr.trim()}`);
     assert(fs.readFileSync(path.join(doc, 'comments.json'), 'utf8') === original,

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -1438,5 +1438,122 @@ t('lib/json.sh survives the inputs that actually show up', () => {
 });
 
 
+
+// ---- tdoc-pull has to prove who it is (#278) ----
+// It was the only CLI request that sent no Authorization header at all, with
+// the token sitting in the same config file it had just read `.base` out of.
+// On a private doc the worker therefore saw an anonymous visitor and denied
+// the owner their own comments.
+
+t('tdoc-pull sends the account token', () => {
+  const port = 8150 + Math.floor(Math.random() * 200);
+  // A worker that behaves like the real one: no token, no private doc.
+  const stub = spawn(process.execPath, ['-e',
+    `require('http').createServer((q,s)=>{` +
+    `s.setHeader('content-type','application/json');` +
+    `const a=q.headers.authorization||'';` +
+    `if(a!=='Bearer sekret'){s.statusCode=403;return s.end('{"error":"access_denied"}');}` +
+    `s.end(JSON.stringify([{id:'c1',text:'owner can see this',version:1}]));` +
+    `}).listen(${port},'127.0.0.1');`], { stdio: 'ignore' });
+  const home = fs.mkdtempSync(path.join(os.tmpdir(), 'tdoc-pullauth-'));
+  try {
+    spawnSync('bash', ['-c', `for i in $(seq 1 100); do curl -sS -o /dev/null --max-time 1 ` +
+      `http://127.0.0.1:${port}/ && break; sleep 0.05; done`], { timeout: 15000 });
+    fs.mkdirSync(path.join(home, '.tdoc'), { recursive: true });
+    fs.writeFileSync(path.join(home, '.tdoc', 'published.json'), JSON.stringify({
+      platform: 'hosted', base: `http://127.0.0.1:${port}`, upload_token: 'sekret',
+      public_host: '127.0.0.1', github_login: 'owner',
+    }));
+    const doc = path.join(home, 'tdocs', 'priv-doc');
+    fs.mkdirSync(doc, { recursive: true });
+
+    const r = spawnSync(path.join(BIN, 'tdoc-pull'), ['priv-doc'], {
+      env: { ...process.env, HOME: home, TDOC_DIR: path.join(home, 'tdocs'),
+             TDOC_SKIP_UPDATE_CHECK: '1' },
+      encoding: 'utf8', timeout: 60000,
+    });
+    assert(r.status === 0, `pull was denied — the token was not sent: ${r.stderr}`);
+    const got = JSON.parse(fs.readFileSync(path.join(doc, 'comments.json'), 'utf8'));
+    assert(got.length === 1 && got[0].text === 'owner can see this',
+      `wrong comments pulled: ${JSON.stringify(got)}`);
+  } finally {
+    stub.kill();
+    fs.rmSync(home, { recursive: true, force: true });
+  }
+});
+
+t('a denied pull explains it is an access problem, not a network one', () => {
+  // "network error or bad slug?" sent people looking at their wifi. A denial
+  // has one likely cause and one fix, so say both.
+  const port = 8400 + Math.floor(Math.random() * 200);
+  const stub = spawn(process.execPath, ['-e',
+    `require('http').createServer((q,s)=>{s.setHeader('content-type','application/json');` +
+    `s.statusCode=403;s.end('{"error":"access_denied"}');}).listen(${port},'127.0.0.1');`],
+    { stdio: 'ignore' });
+  const home = fs.mkdtempSync(path.join(os.tmpdir(), 'tdoc-pulldenied-'));
+  try {
+    spawnSync('bash', ['-c', `for i in $(seq 1 100); do curl -sS -o /dev/null --max-time 1 ` +
+      `http://127.0.0.1:${port}/ && break; sleep 0.05; done`], { timeout: 15000 });
+    fs.mkdirSync(path.join(home, '.tdoc'), { recursive: true });
+    fs.writeFileSync(path.join(home, '.tdoc', 'published.json'), JSON.stringify({
+      platform: 'hosted', base: `http://127.0.0.1:${port}`, upload_token: 'stale',
+    }));
+    const doc = path.join(home, 'tdocs', 'priv-doc');
+    fs.mkdirSync(doc, { recursive: true });
+    const original = JSON.stringify([{ id: 'keep', text: 'local', version: 1 }]);
+    fs.writeFileSync(path.join(doc, 'comments.json'), original);
+
+    const r = spawnSync(path.join(BIN, 'tdoc-pull'), ['priv-doc'], {
+      env: { ...process.env, HOME: home, TDOC_DIR: path.join(home, 'tdocs'),
+             TDOC_SKIP_UPDATE_CHECK: '1' },
+      encoding: 'utf8', timeout: 60000,
+    });
+    assert(r.status !== 0, 'a denial must fail');
+    assert(/private/.test(r.stderr) && /does not own it/.test(r.stderr),
+      `the denial was not explained:\n      ${r.stderr.trim()}`);
+    assert(/tdoc publish priv-doc/.test(r.stderr),
+      `no way out was offered:\n      ${r.stderr.trim()}`);
+    assert(!/network error/.test(r.stderr),
+      `a denial was still blamed on the network:\n      ${r.stderr.trim()}`);
+    assert(fs.readFileSync(path.join(doc, 'comments.json'), 'utf8') === original,
+      'a denial must not touch local comments');
+  } finally {
+    stub.kill();
+    fs.rmSync(home, { recursive: true, force: true });
+  }
+});
+
+t('tdoc-pull still works against a config that has no token', () => {
+  // Self-host configs written before tokens, and local-only setups. Sending no
+  // header must stay a supported shape rather than becoming "Bearer ".
+  const port = 8480 + Math.floor(Math.random() * 100);
+  const stub = spawn(process.execPath, ['-e',
+    `require('http').createServer((q,s)=>{s.setHeader('content-type','application/json');` +
+    `if('authorization' in q.headers){s.statusCode=400;return s.end('{"error":"sent_empty_bearer"}');}` +
+    `s.end('[]');}).listen(${port},'127.0.0.1');`], { stdio: 'ignore' });
+  const home = fs.mkdtempSync(path.join(os.tmpdir(), 'tdoc-pullnotoken-'));
+  try {
+    spawnSync('bash', ['-c', `for i in $(seq 1 100); do curl -sS -o /dev/null --max-time 1 ` +
+      `http://127.0.0.1:${port}/ && break; sleep 0.05; done`], { timeout: 15000 });
+    fs.mkdirSync(path.join(home, '.tdoc'), { recursive: true });
+    fs.writeFileSync(path.join(home, '.tdoc', 'published.json'), JSON.stringify({
+      platform: 'hosted', base: `http://127.0.0.1:${port}`,
+    }));
+    fs.mkdirSync(path.join(home, 'tdocs', 'open-doc'), { recursive: true });
+    const r = spawnSync(path.join(BIN, 'tdoc-pull'), ['open-doc'], {
+      env: { ...process.env, HOME: home, TDOC_DIR: path.join(home, 'tdocs'),
+             TDOC_SKIP_UPDATE_CHECK: '1' },
+      encoding: 'utf8', timeout: 60000,
+    });
+    assert(r.status === 0, `a token-less config broke: ${r.stderr}`);
+    assert(!/sent_empty_bearer/.test(r.stdout + r.stderr),
+      'an empty token was sent as a header instead of being omitted');
+  } finally {
+    stub.kill();
+    fs.rmSync(home, { recursive: true, force: true });
+  }
+});
+
+
 console.log(`\n${pass} passed, ${fail} failed`);
 process.exit(fail ? 1 : 0);

--- a/test/hosted-oob-behavior.test.js
+++ b/test/hosted-oob-behavior.test.js
@@ -721,6 +721,161 @@ async function issue(worker, env, login = 'alice', label = login) {
     assert(!body.includes('id="tdoc-duplicate-btn"'), 'export must not include published chrome');
   });
 
+
+  // ---- the owner's CLI token can read their own private doc (#278) ----
+  // The read gate resolved identity only through a browser cookie, so
+  // `tdoc-pull` — which authenticates with the account token — was treated as
+  // an anonymous visitor and denied. FIRST-DOC.md publishes every new user's
+  // first doc as private, so the first doc they made was the one they could
+  // not iterate on.
+
+  // Publish a doc under `owner` with an access policy, and leave a comment on
+  // it as some signed-in reader so there is something to pull.
+  async function publishWith(env, owner, slug, access) {
+    const up = await worker.fetch(req('/api/upload', {
+      method: 'POST', token: owner.token,
+      body: { slug, version: 1, html: '<h1>P</h1>', meta: { title: 'P', slug, versions: [{ n: 1 }], access } },
+    }), env, {});
+    assert(up.status === 200, `upload ${up.status}: ${await up.text()}`);
+    return up;
+  }
+
+  await t('the owner token reads comments on their own private doc', async () => {
+    const env = makeEnv(mod.CommentsStore);
+    const owner = await issue(worker, env, 'owner');
+    await publishWith(env, owner, 'priv-doc', {
+      visibility: 'private', history_visibility: 'owner',
+      commenting: 'signed_in', allowed_users: ['reader'],
+    });
+    // A comment from an allowlisted reader — the thing /tdoc pull exists to fetch.
+    const readerCookie = await putSession(env, 'reader');
+    const post = await worker.fetch(req('/api/comments', {
+      method: 'POST', cookie: readerCookie,
+      body: { slug: 'priv-doc', version: 1, text: 'please fix the chart' },
+    }), env, {});
+    assert(post.status === 200, `reader comment ${post.status}: ${await post.text()}`);
+
+    // Anonymous — the behaviour that must not change.
+    const anon = await worker.fetch(req('/api/comments?slug=priv-doc&version=all'), env, {});
+    assert(anon.status !== 200, `anonymous read of a private doc returned ${anon.status}`);
+
+    // The owner's CLI token — this is the fix.
+    const r = await worker.fetch(req('/api/comments?slug=priv-doc&version=all', {
+      token: owner.token,
+    }), env, {});
+    assert(r.status === 200, `owner token denied: ${r.status} ${await r.clone().text()}`);
+    const list = await r.json();
+    assert(Array.isArray(list), `expected an array, got ${JSON.stringify(list).slice(0, 120)}`);
+    assert(list.length === 1 && list[0].text === 'please fix the chart',
+      `owner did not get the comment: ${JSON.stringify(list)}`);
+  });
+
+  await t('another account token is still denied the same private doc', async () => {
+    // The whole fix rests on this: reading over a token must grant exactly the
+    // docs that token can already overwrite, and nothing else.
+    const env = makeEnv(mod.CommentsStore);
+    const owner = await issue(worker, env, 'owner');
+    const stranger = await issue(worker, env, 'stranger');
+    await publishWith(env, owner, 'priv-doc', {
+      visibility: 'private', history_visibility: 'owner', allowed_users: [],
+    });
+
+    const r = await worker.fetch(req('/api/comments?slug=priv-doc&version=all', {
+      token: stranger.token,
+    }), env, {});
+    assert(r.status !== 200, `a stranger's token read a private doc: ${await r.clone().text()}`);
+    const body = await r.json();
+    assert(body.error === 'access_denied', `unexpected body ${JSON.stringify(body)}`);
+
+    // And the stranger cannot write it either — the same account-id comparison.
+    const w = await worker.fetch(req('/api/upload', {
+      method: 'POST', token: stranger.token,
+      body: { slug: 'priv-doc', version: 2, html: '<h1>X</h1>' },
+    }), env, {});
+    assert(w.status === 403, `stranger write should be 403, got ${w.status}`);
+  });
+
+  await t('a bearer token nobody issued is denied, and does not 500', async () => {
+    const env = makeEnv(mod.CommentsStore);
+    const owner = await issue(worker, env, 'owner');
+    await publishWith(env, owner, 'priv-doc', { visibility: 'private', allowed_users: [] });
+    for (const junk of ['not-a-token', '', 'Bearer', '../../etc/passwd']) {
+      const r = await worker.fetch(req('/api/comments?slug=priv-doc&version=all', { token: junk }), env, {});
+      assert(r.status !== 200, `junk token "${junk}" was accepted`);
+      assert(r.status < 500, `junk token "${junk}" caused ${r.status}`);
+    }
+  });
+
+  await t('the owner token opens the private doc HTML and sees every version', async () => {
+    // history_visibility: 'owner' hides the version picker from everyone else.
+    // Reading over the token has to count as the owner there too, or the CLI
+    // sees a doc that claims to have one version.
+    const env = makeEnv(mod.CommentsStore);
+    const owner = await issue(worker, env, 'owner');
+    for (const v of [1, 2, 3]) {
+      const up = await worker.fetch(req('/api/upload', {
+        method: 'POST', token: owner.token,
+        body: {
+          slug: 'multi-doc', version: v, html: `<h1>v${v}</h1>`,
+          meta: {
+            title: 'M', slug: 'multi-doc',
+            versions: [1, 2, 3].slice(0, v).map((n) => ({ n })),
+            access: { visibility: 'private', history_visibility: 'owner', allowed_users: [] },
+          },
+        },
+      }), env, {});
+      assert(up.status === 200, `upload v${v} ${up.status}: ${await up.text()}`);
+    }
+
+    const anon = await worker.fetch(req('/d/multi-doc/v/3'), env, {});
+    assert(anon.status !== 200, `anonymous opened a private doc: ${anon.status}`);
+
+    const r = await worker.fetch(req('/d/multi-doc/v/3', { token: owner.token }), env, {});
+    assert(r.status === 200, `owner token denied the HTML: ${r.status}`);
+    const body = await r.text();
+    assert(/v3/.test(body), 'the document body did not come back');
+    // All three versions reachable, not just the one being viewed.
+    const nav = body.match(/"versions":\s*(\[[^\]]*\])/);
+    assert(nav, 'the page did not carry a version list');
+    assert(JSON.parse(nav[1]).length === 3,
+      `owner should see 3 versions, saw ${JSON.parse(nav[1]).length}`);
+  });
+
+  await t('reading over a token does not sign the CLI in', async () => {
+    // The token proves ownership for the read and nothing more. If it were
+    // turned into a session, the page would render a signed-in identity that
+    // no browser ever authenticated, and a comment could be attributed to it.
+    const env = makeEnv(mod.CommentsStore);
+    const owner = await issue(worker, env, 'owner');
+    await publishWith(env, owner, 'ident-doc', { visibility: 'private', allowed_users: [] });
+
+    const r = await worker.fetch(req('/d/ident-doc/v/1', { token: owner.token }), env, {});
+    assert(r.status === 200, `owner token denied: ${r.status}`);
+    const body = await r.text();
+    const ident = body.match(/"identity":\s*(null|\{[^}]*\})/);
+    assert(ident, 'the page did not carry an identity field at all');
+    assert(ident[1] === 'null',
+      `a synthetic session was rendered into the page: ${ident[1]}`);
+
+    // And the token must not let it write a comment as anyone.
+    const w = await worker.fetch(req('/api/comments', {
+      method: 'POST', token: owner.token,
+      body: { slug: 'ident-doc', version: 1, text: 'from a token' },
+    }), env, {});
+    assert(w.status === 401, `a token should not post comments, got ${w.status}`);
+  });
+
+  await t('an unlisted doc still needs no token at all', async () => {
+    // The fix must not make anonymous reads harder anywhere.
+    const env = makeEnv(mod.CommentsStore);
+    const owner = await issue(worker, env, 'owner');
+    await publishWith(env, owner, 'open-doc', { visibility: 'unlisted' });
+    const r = await worker.fetch(req('/api/comments?slug=open-doc&version=all'), env, {});
+    assert(r.status === 200, `anonymous read of an unlisted doc broke: ${r.status}`);
+    assert(Array.isArray(await r.json()), 'unlisted read did not return an array');
+  });
+
+
   console.log(`\n${pass} passed, ${fail} failed`);
   process.exit(fail ? 1 : 0);
 })();

--- a/worker/worker.js
+++ b/worker/worker.js
@@ -305,6 +305,32 @@ function accessDeniedHtml({ status, title, body, slug, version }) {
 </div></body></html>`, { status });
 }
 
+// A CLI request proves who it is with the account token from
+// ~/.tdoc/published.json, not with a browser cookie, so getSession() sees an
+// anonymous visitor. Resolve the token exactly the way the upload path does and
+// accept it when it owns THIS doc.
+//
+// This grants read access to precisely the set of docs the same token can
+// already overwrite — requireDocWriteAccess compares the same two account ids —
+// so it widens nothing. It deliberately does NOT produce a session: the caller
+// keeps the real (possibly null) one, so no synthetic identity can be rendered
+// into a page or attributed to a comment.
+async function docOwnerToken(env, req, meta) {
+  const auth = req.headers.get('authorization') || '';
+  const m = auth.match(/^Bearer\s+(.+)$/);
+  if (!m) return null;
+  const token = m[1];
+  // Self-host: the worker's own admin token already writes anything here.
+  if (env.TDOC_UPLOAD_TOKEN && await timingSafeEqual(token, env.TDOC_UPLOAD_TOKEN)) {
+    return { kind: 'admin' };
+  }
+  const actor = await hostedTokenActor(env, token);
+  if (!actor) return null;
+  const ownerId = meta && meta.hosted && meta.hosted.account_id;
+  if (!ownerId || ownerId !== actor.account_id) return null;
+  return actor;
+}
+
 async function enforceDocAccess(env, req, slug, version) {
   const meta = await loadDocMeta(env, slug);
   // No meta yet (orphan R2 object) — treat as public so legacy uploads still work.
@@ -312,6 +338,12 @@ async function enforceDocAccess(env, req, slug, version) {
   const session = await getSession(env, req);
   if (canReadDoc(access, session, env, meta)) {
     return { ok: true, access, session, meta };
+  }
+  // Without this the owner is denied their own private doc from their own
+  // terminal: /tdoc pull is the documented pre-step to /tdoc edit, and
+  // FIRST-DOC.md publishes every new user's first doc as private. See #278.
+  if (await docOwnerToken(env, req, meta)) {
+    return { ok: true, access, session, meta, ownerToken: true };
   }
   if (!sessionLogin(session)) {
     return {
@@ -1206,7 +1238,8 @@ async function serveDocVersion(env, req, slug, version, isLanding) {
   let versions = [{ n: version, created: null }];
   try {
     const meta = gate.meta;
-    if (meta && Array.isArray(meta.versions) && canSeeHistory(gate.access, session, env, meta)) {
+    if (meta && Array.isArray(meta.versions)
+        && (gate.ownerToken || canSeeHistory(gate.access, session, env, meta))) {
       versions = meta.versions.map(v => ({ n: v.n, created: v.created || null }));
     } else if (meta && Array.isArray(meta.versions)) {
       const hit = meta.versions.find(v => Number(v.n) === version);


### PR DESCRIPTION
Fixes #278. Found in the end-to-end onboarding run, immediately after #277 made `tdoc-pull` runnable at all.

### The bug

```
$ tdoc-pull <slug>
{"error":"access_denied"}
```

on a doc owned by the account whose token is sitting in `~/.tdoc/published.json`.

tdoc has two ways to prove who you are: a browser cookie, and the account token the CLI keeps. `enforceDocAccess` only ever knew about the first — it resolved identity through `getSession(env, req)` and nothing else — so a terminal holding a perfectly valid token looked exactly like an anonymous visitor.

The token was not the problem. The same token on `/api/upload` answers `400` for an empty body, not `401`:

```
$ curl -H "Authorization: Bearer $TOKEN" ".../api/comments?slug=<slug>&version=all"
{"error":"access_denied"}
$ curl -X POST -H "Authorization: Bearer $TOKEN" -d '{}' .../api/upload
HTTP 400
```

It was recognised there and never consulted here.

### Why it closes the loop the product is built on

`/tdoc pull` is the documented pre-step to `/tdoc edit`: pull what people left, regenerate from it. `FIRST-DOC.md` Step 7 publishes every new user's first doc as `private`. So the first doc anyone made was the one they could not iterate on.

### Server

`enforceDocAccess` falls back to the Bearer token when the session cannot read. The token is resolved exactly the way the upload path does it (`hostedTokenActor`, or the self-host admin token), and accepted only when `actor.account_id === meta.hosted.account_id` — the same equality `requireDocWriteAccess` already enforces for writes. **Reading over a token therefore grants precisely the set of docs that token can already overwrite, and nothing else.**

Two deliberate restraints:

- **It does not synthesise a session.** The caller keeps the real (possibly null) one, so an identity no browser ever authenticated cannot be rendered into a page or attributed to a comment. A test pins this, and a test pins that the token still cannot POST a comment.
- **The version list follows the same owner** (`gate.ownerToken || canSeeHistory(...)`), or the CLI would open a doc that claims to have one version.

### Client

`tdoc-pull` sends the token. It was the only CLI request that authenticated with nothing at all, with the token sitting in the same file it had just read `.base` out of. A config with no token still sends no header rather than an empty `Bearer` — a test pins that too, for self-host configs written before tokens existed.

A denial also gets its own message. `"network error or bad slug?"` sent people to look at their wifi; a denial has one likely cause and one fix, so it now says both.

### Testing

Server, against the real `worker.fetch` with the fake KV/R2/DO harness:

- the owner reads comments on their own private doc, and gets the comment an allowlisted reader left
- **a second account's token is still refused** — and still cannot write it either
- unissued and malformed bearers (`""`, `Bearer`, `../../etc/passwd`) are refused without a 500
- the owner sees all three versions over a token on a `history_visibility: owner` doc
- reading over a token renders `identity: null` and cannot post a comment
- an unlisted doc still needs no token — anonymous reads are not made harder anywhere

Client: the header is sent and the comments arrive; a token-less config does not become an empty `Bearer`; a denial is explained and leaves `comments.json` untouched.

Every one was checked against a deliberate reintroduction of the bug it claims to catch — eight mutations, eight failures, including the security-critical one (dropping the `account_id` comparison, caught by the stranger test).

`npm test` green (43 suites).

### Note

The worker half only takes effect on tdoc.dev once the Worker redeploys.