### PR TITLE
Comment: cancel clears the highlight; a prose selection can't paint a table

### DIFF
--- a/server/overlay.js
+++ b/server/overlay.js
@@ -2687,6 +2687,10 @@
   }
   function closeClusterPopover() { clusterPop.classList.remove('open'); clusterPop._key = null; }
   document.addEventListener('click', (e) => {
+    // Click anywhere outside an open new-comment sheet cancels it (and clears
+    // the pending highlight). Skip the same click cycle that opened it — the
+    // data-tdoc-select path opens on click, which would otherwise self-close.
+    if (popup && !popup.contains(e.target) && performance.now() - popupOpenedAt > 250) closePopup();
     if (!clusterPop.contains(e.target) && !e.target.closest?.('.tdoc-pin-cluster')) closeClusterPopover();
     // Inbox / Share / profile chrome is overlay UI. A click there must not
     // count as "outside the card" or opening a notification would pin the
@@ -3006,6 +3010,10 @@
   // floating card (most-transient-first so one Esc peels one layer).
   document.addEventListener('keydown', (e) => {
     if (e.key !== 'Escape') return;
+    // A new-comment sheet is the most modal thing on screen; Escape cancels it
+    // first — and closePopup() clears the pending highlight, so the yellow does
+    // not linger after cancel. (Only the × used to do this.)
+    if (popup) { closePopup(); return; }
     if (state.reanchoringId) { exitReanchor(); return; }
     if (clusterPop.classList.contains('open')) { closeClusterPopover(); return; }
     if (state.pinnedId) { const id = state.pinnedId; state.pinnedId = null; hideCardIfIdle(id); markPinActive(id, false); setActiveComment(null); }
@@ -3510,6 +3518,7 @@
 
   // ========== Popup (new-comment): text + element anchors ==========
   let popup = null;
+  let popupOpenedAt = 0;   // guards the opening click from self-closing the sheet
   let pendingElementOutline = null;
 
   function setPendingTextHighlight(range) {
@@ -3550,6 +3559,7 @@
     hideHoverUI();
     popup = document.createElement('div');
     popup.className = 'tdoc-popup';
+    popupOpenedAt = performance.now();
     const needsSignIn = isPublished && !identity;
     const preview = anchor.kind === 'text'
       ? `"${escapeHtml(anchor.text.slice(0, 80))}${anchor.text.length > 80 ? '…' : ''}"`
@@ -4097,6 +4107,31 @@
     maybeOpenSelectionPopup(invite);
   }, true);
 
+  // A text selection should stay inside one "artifact context": bare prose, or
+  // the inside of a single commentable artifact. A drag that starts in prose and
+  // overshoots into a table used to paint the whole table (the pending highlight
+  // spans every text node the range crosses) and fold table text into a prose
+  // comment. Clamp the range to the start's context so the selection is what the
+  // reader actually meant. Selecting *within* one artifact (both ends inside the
+  // same table) is untouched — that is a legitimate comment on that text.
+  function artifactContextOf(node) {
+    const el = node && (node.nodeType === 1 ? node : node.parentElement);
+    return el ? el.closest(COMMENTABLE) : null;   // null = the bare prose column
+  }
+  function clampRangeToArtifactContext(range) {
+    const startCtx = artifactContextOf(range.startContainer);
+    const endCtx = artifactContextOf(range.endContainer);
+    if (startCtx === endCtx) return range;        // same context — nothing to clamp
+    try {
+      if (endCtx && !endCtx.contains(range.startContainer)) {
+        range.setEndBefore(endCtx);               // bled forward into an artifact — stop before it
+      } else if (startCtx && !startCtx.contains(range.endContainer)) {
+        range.setStartAfter(startCtx);            // started inside an artifact, ran out — start after it
+      }
+    } catch (e) { /* setEnd/StartBefore can throw on detached / cross-root nodes */ }
+    return range;
+  }
+
   function maybeOpenSelectionPopup(target, event) {
     // Selected text wins over "comment whole artifact." If there's a real text
     // selection, open the text-selection popup regardless of whether the
@@ -4105,12 +4140,16 @@
     // because they're driven by different gestures (hover vs. drag-select).
     if (target && target.nodeType === 1 && isInUI(target)) return;
     const sel = window.getSelection();
-    const text = sel && sel.toString().trim();
+    let text = sel && sel.toString().trim();
     if (!text || text.length < 2 || !sel.rangeCount) return;
     const anchorNode = sel.anchorNode;
     const anchorEl = anchorNode?.nodeType === 1 ? anchorNode : anchorNode?.parentElement;
     if (anchorEl && isInUI(anchorEl)) return;
-    const range = sel.getRangeAt(0).cloneRange();
+    const range = clampRangeToArtifactContext(sel.getRangeAt(0).cloneRange());
+    // The clamp may have trimmed a bled-into artifact; re-derive from the range
+    // so text, highlight, and the committed anchor all agree.
+    text = range.toString().trim();
+    if (!text || text.length < 2) return;
     const ctx = getContext(range, 60);
     // Re-anchor mode: rebind an existing unanchored comment to this selection
     // instead of creating a new one. Captured fallback position is refreshed

--- a/test/ui.test.js
+++ b/test/ui.test.js
@@ -452,6 +452,63 @@ async function tPub(name, fn) {
     await page.click('.tdoc-popup .head .x').catch(() => {});
   });
 
+  await t('A prose selection bleeding into a table does NOT highlight the whole table', async () => {
+    // Regression: a drag that starts in prose and overshoots into a table used
+    // to paint every cell (the pending highlight spans the range) and fold table
+    // text into the comment. The range must clamp to the prose before the table.
+    const res = await page.evaluate(() => {
+      const table = document.querySelector('.wrap table');
+      const p = table && [...document.querySelectorAll('.wrap p')]
+        .find(x => x.compareDocumentPosition(table) & Node.DOCUMENT_POSITION_FOLLOWING && x.firstChild);
+      const lastCell = table && [...table.querySelectorAll('td')].pop();
+      if (!p || !lastCell || !lastCell.firstChild) return { skip: true };
+      const r = document.createRange();
+      r.setStart(p.firstChild, 0);
+      r.setEnd(lastCell.firstChild, Math.min(3, lastCell.firstChild.textContent.length));
+      const sel = window.getSelection(); sel.removeAllRanges(); sel.addRange(r);
+      const rect = r.getBoundingClientRect();
+      document.dispatchEvent(new MouseEvent('mouseup', { bubbles: true, clientX: rect.right - 5, clientY: rect.bottom - 5 }));
+      const hl = window.CSS && CSS.highlights && CSS.highlights.get('tdoc-pending');
+      let spansTable = false, ranges = 0;
+      if (hl) for (const rg of hl) { ranges++; if (rg.intersectsNode && rg.intersectsNode(table)) spansTable = true; }
+      return { popup: !!document.querySelector('.tdoc-popup'), ranges, spansTable };
+    });
+    if (res.skip) { console.log('  (fixture has no prose-then-table, skipping)'); return; }
+    if (!res.popup) throw new Error('selection did not open the comment popup');
+    if (res.spansTable) throw new Error('pending highlight still spans the table — clamp failed');
+    await page.keyboard.press('Escape').catch(() => {});
+  });
+
+  await t('Escape and click-outside cancel the popup AND clear the pending highlight', async () => {
+    const hlCount = () => page.evaluate(() => {
+      const hl = window.CSS && CSS.highlights && CSS.highlights.get('tdoc-pending');
+      let n = 0; if (hl) for (const _ of hl) n++; return n;
+    });
+    async function openOnProse() {
+      return page.evaluate(() => {
+        const p = [...document.querySelectorAll('.wrap p')].find(x => x.firstChild && x.textContent.trim().length > 12);
+        const r = document.createRange();
+        r.setStart(p.firstChild, 0); r.setEnd(p.firstChild, Math.min(12, p.firstChild.textContent.length));
+        const sel = window.getSelection(); sel.removeAllRanges(); sel.addRange(r);
+        const rect = r.getBoundingClientRect();
+        document.dispatchEvent(new MouseEvent('mouseup', { bubbles: true, clientX: rect.right - 4, clientY: rect.bottom - 4 }));
+        return !!document.querySelector('.tdoc-popup');
+      });
+    }
+    // Escape
+    if (!await openOnProse()) throw new Error('popup did not open (Escape case)');
+    if (await hlCount() < 1) throw new Error('no pending highlight after opening');
+    await page.keyboard.press('Escape');
+    if (await page.$('.tdoc-popup')) throw new Error('Escape did not close the popup');
+    if (await hlCount() !== 0) throw new Error('Escape did not clear the pending highlight');
+    // click-outside (wait past the 250ms self-close guard)
+    if (!await openOnProse()) throw new Error('popup did not open (click-outside case)');
+    await page.waitForTimeout(320);
+    await page.click('.wrap h1', { position: { x: 5, y: 5 } }).catch(() => page.click('.tdoc-bar .doc-title').catch(() => {}));
+    if (await page.$('.tdoc-popup')) throw new Error('click-outside did not close the popup');
+    if (await hlCount() !== 0) throw new Error('click-outside did not clear the pending highlight');
+  });
+
   await t('Drag STARTED INSIDE canvas does NOT open popup (passes through)', async () => {
     const canvas = await page.$('canvas');
     if (!canvas) { console.log('  (no canvas, skipping)'); return; }


### PR DESCRIPTION
Fixes #280. Both bugs reproduced on the real overlay, verified fixed live.

**1. Highlight lingered after cancel.** Only the × ran `closePopup()`. Escape
(focus outside the textarea) and click-outside — the natural cancel gestures —
left the popup open and the yellow highlight painted. Now both cancel the sheet
and clear the highlight; a `popupOpenedAt` guard stops the opening click from
self-closing.

**2. A prose selection grazing a table lit up the whole table.** The range was
raw, so a drag from a paragraph into a `<table>` spanned paragraph→table and the
CSS Highlight API painted every cell (and folded table text into the prose
comment). A text selection is now clamped to one artifact context — bleed from
prose into an artifact (or out of one) clamps to the boundary, so highlight,
anchor text, and comment agree. Selecting within a single artifact is untouched.

### Verified live (before → after)
| gesture | before | after |
|---|---|---|
| select prose→table | whole table highlighted | highlight stops before the table |
| Escape | popup + highlight stay | both cleared |
| click-outside | popup + highlight stay | both cleared |

### Tests
`ui.test.js` gains two regressions: a prose→table selection whose pending
highlight must not span the table, and Escape + click-outside that must close
the popup AND clear the highlight. Offline suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)