### PR TITLE
feat: tables are a ruled card, not a grid of filled chips

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,15 @@ file and `.claude-plugin/plugin.json`.
 
 ### Changed
 
+- **Tables are one bordered card, ruled inside, with nothing filled.** Every
+  cell used to be a rounded tinted chip separated by a 3px gutter, so a table
+  read as a pile of grey blocks rather than a grid: the gutters cut the columns
+  apart, leaving the eye nothing to scan down, and four rounded corners per cell
+  multiplied into noise on any real table. A hairline under each row does that
+  work now, inside a single hairline border, with a normal-case header in the
+  muted ink and roomier cells. It also survives dark mode, which is a whole-page
+  invert — a filled cell inverted into a slab where a hairline just changes
+  colour. Every style inherits it, including styles not written yet.
 - **The first doc is the reader's own portrait.** `FIRST-DOC.md` no longer
   builds a Conway's Game of Life lesson. It builds *What does AI know about
   you?* — a page assembled from the traces every AI assistant on the machine

--- a/server/overlay.js
+++ b/server/overlay.js
@@ -325,12 +325,22 @@
   :where(body pre) { font-family: ui-monospace, "SF Mono", Menlo, monospace; font-size: 14.5px; line-height: 1.6; background: var(--td-surface-2); color: var(--td-pre-ink); border: 1px solid var(--td-line); border-radius: 10px; padding: 16px 18px; margin: 20px 0; overflow-x: auto; }
   :where(body pre code) { background: transparent; color: inherit; padding: 0; border-radius: 0; }
   :where(body hr) { border: 0; border-top: 1px solid var(--td-line); margin: 36px 0; }
-  /* Tables: rounded cells with gutters — header tint comes from the theme.
+  /* Tables: one bordered card, ruled inside, nothing filled. Every cell used to
+     be a rounded tinted chip with a 3px gutter, which read as a pile of grey
+     blocks rather than a grid — the gutters cut the columns apart so the eye
+     had nothing to scan down, and four rounded corners per cell multiplied into
+     noise on any real table. A hairline under each row does that work, and an
+     outer border makes the table one object instead of a loose stack.
+     border-spacing:0 with separate collapse, because border-radius on the table
+     needs separate to round and overflow:hidden to clip.
+     This is also what survives dark mode: that is a whole-page invert, and a
+     filled cell inverts into a slab where a hairline just changes colour.
      No negative horizontal margin: that clips the first column inside any
      overflow-x:auto wrapper (author skill tells agents to wrap tables). */
-  :where(body table) { border-collapse: separate; border-spacing: 3px; margin: 0 0 18px; font-size: 16px; }
-  :where(body th, body td) { padding: 10px 14px; background: var(--td-surface); border-radius: 8px; border: 0; text-align: left; }
-  :where(body th) { font-weight: 600; color: var(--td-th-ink); background: var(--td-th-bg); }
+  :where(body table) { border-collapse: separate; border-spacing: 0; width: 100%; margin: 6px 0 24px; font-size: 15.5px; font-variant-numeric: tabular-nums; border: 1px solid var(--td-line); border-radius: 12px; overflow: hidden; }
+  :where(body th, body td) { padding: 14px 18px; background: none; border: 0; border-bottom: 1px solid var(--td-line); border-radius: 0; text-align: left; vertical-align: middle; line-height: 1.5; }
+  :where(body th) { font-weight: 500; color: var(--td-muted); }
+  :where(body tbody tr:last-child td) { border-bottom: 0; }
   :where(body figcaption) { font-size: 13px; color: var(--td-muted); margin-top: 6px; text-align: center; }
   :where(body) ::selection { background: var(--td-selection); }
   /* Task lists: circle checkboxes, Claude Code style. Works for raw

--- a/test/reader-overflow.test.js
+++ b/test/reader-overflow.test.js
@@ -26,8 +26,18 @@ console.log('reader-overflow (tables + diagrams stay unclipped)');
 t('overlay table style has no negative horizontal margin', () => {
   assert(!/body table[^}]*margin:\s*[^;]*-\d+px/.test(src),
     'table rule still uses a negative margin (clips inside overflow wrappers)');
-  assert(src.includes(':where(body table) { border-collapse: separate; border-spacing: 3px; margin: 0 0 18px; font-size: 16px; }'),
-    'default table margin must be 0 0 18px with no left pull');
+  // Pin the property, not the exact spacing — the guard is against a left pull
+  // clipping the first column inside an overflow wrapper, not against ever
+  // changing the vertical rhythm.
+  const rule = src.match(/:where\(body table\) \{[^}]*\}/);
+  assert(rule, 'the default table rule is gone');
+  const margin = rule[0].match(/margin:\s*([^;]+);/);
+  assert(margin, 'the default table rule sets no margin');
+  const sides = margin[1].trim().split(/\s+/);
+  const horizontal = sides.length >= 2 ? [sides[1], sides[3] ?? sides[1]] : [sides[0], sides[0]];
+  for (const v of horizontal) {
+    assert(!v.startsWith('-'), `table margin pulls sideways (${margin[1].trim()})`);
+  }
 });
 
 t('overlay never display:block a document table', () => {


### PR DESCRIPTION
Reported: tables render as a pile of grey blocks.

## The cause

```css
:where(body table) { border-collapse: separate; border-spacing: 3px; }
:where(body th, body td) { background: var(--td-surface); border-radius: 8px; border: 0; }
```

Every cell is a **rounded tinted chip**, and the 3px gutter separates them. So there is no continuous edge to scan down a column, and four rounded corners per cell multiply into noise the moment the table has more than a couple of rows.

Filled cells are also the worst case for this particular reader: dark mode is a whole-page `filter: invert`, so every cell inverted into a slab, where a hairline just changes colour.

## The shape it should be

Measured against a reference table, and matched:

| | before | after |
|---|---|---|
| cell fill | `rgb(240,240,238)` | `rgba(0,0,0,0)` |
| outer border | none | `1px` hairline, `12px` radius |
| row rule | none | `1px` hairline |
| header | tinted band, weight 600, full ink | no fill, weight 500, muted ink, normal case |
| cell padding | `10px 14px` | `14px 18px` |
| numerals | proportional | `tabular-nums` |

`border-spacing: 0` with `separate` collapse rather than `collapse`, because `border-radius` on a table needs `separate` to round and `overflow: hidden` to clip.

Verified by computed style against a rendered table rather than by reading the CSS — the auto-description of the screenshot reported a tinted header row that measurement showed is transparent.

## Where it lives

The overlay's injected reader CSS, so **every house style inherits it, including styles that do not exist yet**. `style/default.md` already says "Tables inherit the overlay default"; that sentence now points at something worth inheriting.

## Test

`overlay table style has no negative horizontal margin` pinned the exact margin string, while its name says it guards against a left pull clipping the first column inside a scroll wrapper. It now parses the margin and asserts the horizontal sides are not negative, so vertical rhythm can change without tripping a guard aimed at something else.

`npm test` — 43 suites green.