### PR TITLE
fix: the technical style inherits the shared table treatment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -132,6 +132,12 @@ file and `.claude-plugin/plugin.json`.
 
 ### Fixed
 
+- **The technical style inherits the shared table treatment.** It was the only
+  house style defining its own `table` / `th` / `td` rules — filled cells with a
+  3px gutter — so a technical doc silently opted out of the table style every
+  other style inherits, and kept the look they had all moved off. Removed, and
+  a test now fails if any style file redefines a table or omits the sentence
+  saying it inherits.
 - **The first doc's slug is per-person, so onboarding stops colliding.** Hosted
   slugs are one flat global namespace and the recipe derived the slug from the
   document title, which handed every user the same one. The second person to

--- a/authoring/style/technical.md
+++ b/authoring/style/technical.md
@@ -74,9 +74,6 @@ body  { background:#fff; }
 .wrap a  { color:#737373; text-decoration:underline; }
 .tag     { font:13px ui-monospace,"SF Mono",Menlo,monospace; background:#f5f5f5; color:#171717; border-radius:4px; padding:1px 6px; }
 code     { font:.85em ui-monospace,"SF Mono",Menlo,monospace; background:#f0f0f0; color:#171717; padding:1px 5px; border-radius:3px; }
-table    { border-collapse:separate; border-spacing:3px; width:100%; }
-th       { color:#737373; text-align:left; font:600 11px/1 ui-monospace,Menlo,monospace; letter-spacing:.04em; text-transform:uppercase; padding:8px 10px; }
-td       { background:#f5f5f5; color:#171717; padding:9px 10px; border-radius:4px; }
 .callout { border-left:3px solid #ff4b2e; background:#fff5f3; padding:12px 16px; margin:16px 0; }
 ```
 
@@ -100,6 +97,12 @@ ink-on-white diagrams — never a limit on which visuals a doc has. A pipeline,
 an architecture, a flow, context bars, a bar chart, a timeline, a matrix: draw
 whatever the content needs, in this light palette, and let the invert give the
 dark version.
+
+
+Tables inherit the overlay default: one hairline card, ruled between rows,
+nothing filled. This style used to define its own — filled cells with a 3px
+gutter — which meant a technical doc silently opted out of the shared table
+treatment and kept the look every other style had moved off.
 
 ## Style is visual only
 

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -1564,5 +1564,23 @@ t('tdoc-pull still works against a config that has no token', () => {
 });
 
 
+// ---- one table treatment, inherited by every style (present and future) ----
+
+t('no house style defines its own table CSS', () => {
+  // The overlay's reader CSS carries the table treatment so every style gets
+  // the same one. A style that redefines table/th/td silently opts its docs out
+  // — technical.md did, so technical docs kept filled cells with a 3px gutter
+  // after every other style had moved to the ruled card.
+  const dir = path.join(__dirname, '..', 'authoring', 'style');
+  for (const f of fs.readdirSync(dir).filter(n => n.endsWith('.md') && n !== 'README.md')) {
+    const css = fs.readFileSync(path.join(dir, f), 'utf8');
+    const rules = css.split('\n').filter(l => /^\s*(body\s+)?(table|th|td)\s*[,{]/.test(l));
+    assert(rules.length === 0,
+      `${f} defines its own table CSS — tables must come from the overlay:\n      ${rules.join('\n      ')}`);
+    assert(/Tables inherit/.test(css),
+      `${f} does not say that tables inherit the overlay default`);
+  }
+});
+
 console.log(`\n${pass} passed, ${fail} failed`);
 process.exit(fail ? 1 : 0);


### PR DESCRIPTION
Refs #282.

#282 moved tables into the overlay's reader CSS so **every** style would inherit one treatment, present and future. Measuring the four style samples afterwards, only half picked it up:

| style | cell fill | header weight | padding |
|---|---|---|---|
| default | `rgb(245,245,245)` | 600 | `9px 10px` |
| technical | `rgb(245,245,245)` | 600 | `9px 10px` |
| editorial | transparent | 500 | `14px 18px` |
| paper | transparent | 500 | `14px 18px` |

## Why

`technical.md` defines its own rules:

```css
table { border-collapse:separate; border-spacing:3px; width:100%; }
th    { …uppercase mono… }
td    { background:#f5f5f5; padding:9px 10px; border-radius:4px; }
```

Author CSS beats the overlay's `:where()` by construction, so every technical doc opted out of the shared treatment and kept **exactly the look the change existed to remove**. It was also the only one of the four missing the "Tables inherit the overlay default" sentence the other three carry — which is what made it easy to miss.

The `default` sample shows the same fill, but `default.md` declares no table rules at all. That sample is a stale artifact, not a spec problem; regenerating it picks up the new treatment.

## Guard

The test fails if **any** style file defines a `table` / `th` / `td` rule, or omits the sentence saying it inherits. That closes the same hole for styles that do not exist yet, which was the point of putting the treatment in the overlay in the first place.

**Negative control:** putting a `td` rule back makes it fail.

`npm test` — 43 suites green.