### PR TITLE
Revert the table treatment: it was built on the injection layer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,15 +74,6 @@ file and `.claude-plugin/plugin.json`.
 
 ### Changed
 
-- **Tables are one bordered card, ruled inside, with nothing filled.** Every
-  cell used to be a rounded tinted chip separated by a 3px gutter, so a table
-  read as a pile of grey blocks rather than a grid: the gutters cut the columns
-  apart, leaving the eye nothing to scan down, and four rounded corners per cell
-  multiplied into noise on any real table. A hairline under each row does that
-  work now, inside a single hairline border, with a normal-case header in the
-  muted ink and roomier cells. It also survives dark mode, which is a whole-page
-  invert — a filled cell inverted into a slab where a hairline just changes
-  colour. Every style inherits it, including styles not written yet.
 - **The first doc is the reader's own portrait.** `FIRST-DOC.md` no longer
   builds a Conway's Game of Life lesson. It builds *What does AI know about
   you?* — a page assembled from the traces every AI assistant on the machine
@@ -132,12 +123,6 @@ file and `.claude-plugin/plugin.json`.
 
 ### Fixed
 
-- **The technical style inherits the shared table treatment.** It was the only
-  house style defining its own `table` / `th` / `td` rules — filled cells with a
-  3px gutter — so a technical doc silently opted out of the table style every
-  other style inherits, and kept the look they had all moved off. Removed, and
-  a test now fails if any style file redefines a table or omits the sentence
-  saying it inherits.
 - **The first doc's slug is per-person, so onboarding stops colliding.** Hosted
   slugs are one flat global namespace and the recipe derived the slug from the
   document title, which handed every user the same one. The second person to

--- a/authoring/style/technical.md
+++ b/authoring/style/technical.md
@@ -74,6 +74,9 @@ body  { background:#fff; }
 .wrap a  { color:#737373; text-decoration:underline; }
 .tag     { font:13px ui-monospace,"SF Mono",Menlo,monospace; background:#f5f5f5; color:#171717; border-radius:4px; padding:1px 6px; }
 code     { font:.85em ui-monospace,"SF Mono",Menlo,monospace; background:#f0f0f0; color:#171717; padding:1px 5px; border-radius:3px; }
+table    { border-collapse:separate; border-spacing:3px; width:100%; }
+th       { color:#737373; text-align:left; font:600 11px/1 ui-monospace,Menlo,monospace; letter-spacing:.04em; text-transform:uppercase; padding:8px 10px; }
+td       { background:#f5f5f5; color:#171717; padding:9px 10px; border-radius:4px; }
 .callout { border-left:3px solid #ff4b2e; background:#fff5f3; padding:12px 16px; margin:16px 0; }
 ```
 
@@ -97,12 +100,6 @@ ink-on-white diagrams — never a limit on which visuals a doc has. A pipeline,
 an architecture, a flow, context bars, a bar chart, a timeline, a matrix: draw
 whatever the content needs, in this light palette, and let the invert give the
 dark version.
-
-
-Tables inherit the overlay default: one hairline card, ruled between rows,
-nothing filled. This style used to define its own — filled cells with a 3px
-gutter — which meant a technical doc silently opted out of the shared table
-treatment and kept the look every other style had moved off.
 
 ## Style is visual only
 

--- a/server/overlay.js
+++ b/server/overlay.js
@@ -325,22 +325,12 @@
   :where(body pre) { font-family: ui-monospace, "SF Mono", Menlo, monospace; font-size: 14.5px; line-height: 1.6; background: var(--td-surface-2); color: var(--td-pre-ink); border: 1px solid var(--td-line); border-radius: 10px; padding: 16px 18px; margin: 20px 0; overflow-x: auto; }
   :where(body pre code) { background: transparent; color: inherit; padding: 0; border-radius: 0; }
   :where(body hr) { border: 0; border-top: 1px solid var(--td-line); margin: 36px 0; }
-  /* Tables: one bordered card, ruled inside, nothing filled. Every cell used to
-     be a rounded tinted chip with a 3px gutter, which read as a pile of grey
-     blocks rather than a grid — the gutters cut the columns apart so the eye
-     had nothing to scan down, and four rounded corners per cell multiplied into
-     noise on any real table. A hairline under each row does that work, and an
-     outer border makes the table one object instead of a loose stack.
-     border-spacing:0 with separate collapse, because border-radius on the table
-     needs separate to round and overflow:hidden to clip.
-     This is also what survives dark mode: that is a whole-page invert, and a
-     filled cell inverts into a slab where a hairline just changes colour.
+  /* Tables: rounded cells with gutters — header tint comes from the theme.
      No negative horizontal margin: that clips the first column inside any
      overflow-x:auto wrapper (author skill tells agents to wrap tables). */
-  :where(body table) { border-collapse: separate; border-spacing: 0; width: 100%; margin: 6px 0 24px; font-size: 15.5px; font-variant-numeric: tabular-nums; border: 1px solid var(--td-line); border-radius: 12px; overflow: hidden; }
-  :where(body th, body td) { padding: 14px 18px; background: none; border: 0; border-bottom: 1px solid var(--td-line); border-radius: 0; text-align: left; vertical-align: middle; line-height: 1.5; }
-  :where(body th) { font-weight: 500; color: var(--td-muted); }
-  :where(body tbody tr:last-child td) { border-bottom: 0; }
+  :where(body table) { border-collapse: separate; border-spacing: 3px; margin: 0 0 18px; font-size: 16px; }
+  :where(body th, body td) { padding: 10px 14px; background: var(--td-surface); border-radius: 8px; border: 0; text-align: left; }
+  :where(body th) { font-weight: 600; color: var(--td-th-ink); background: var(--td-th-bg); }
   :where(body figcaption) { font-size: 13px; color: var(--td-muted); margin-top: 6px; text-align: center; }
   :where(body) ::selection { background: var(--td-selection); }
   /* Task lists: circle checkboxes, Claude Code style. Works for raw

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -1564,23 +1564,5 @@ t('tdoc-pull still works against a config that has no token', () => {
 });
 
 
-// ---- one table treatment, inherited by every style (present and future) ----
-
-t('no house style defines its own table CSS', () => {
-  // The overlay's reader CSS carries the table treatment so every style gets
-  // the same one. A style that redefines table/th/td silently opts its docs out
-  // — technical.md did, so technical docs kept filled cells with a 3px gutter
-  // after every other style had moved to the ruled card.
-  const dir = path.join(__dirname, '..', 'authoring', 'style');
-  for (const f of fs.readdirSync(dir).filter(n => n.endsWith('.md') && n !== 'README.md')) {
-    const css = fs.readFileSync(path.join(dir, f), 'utf8');
-    const rules = css.split('\n').filter(l => /^\s*(body\s+)?(table|th|td)\s*[,{]/.test(l));
-    assert(rules.length === 0,
-      `${f} defines its own table CSS — tables must come from the overlay:\n      ${rules.join('\n      ')}`);
-    assert(/Tables inherit/.test(css),
-      `${f} does not say that tables inherit the overlay default`);
-  }
-});
-
 console.log(`\n${pass} passed, ${fail} failed`);
 process.exit(fail ? 1 : 0);

--- a/test/reader-overflow.test.js
+++ b/test/reader-overflow.test.js
@@ -26,18 +26,8 @@ console.log('reader-overflow (tables + diagrams stay unclipped)');
 t('overlay table style has no negative horizontal margin', () => {
   assert(!/body table[^}]*margin:\s*[^;]*-\d+px/.test(src),
     'table rule still uses a negative margin (clips inside overflow wrappers)');
-  // Pin the property, not the exact spacing — the guard is against a left pull
-  // clipping the first column inside an overflow wrapper, not against ever
-  // changing the vertical rhythm.
-  const rule = src.match(/:where\(body table\) \{[^}]*\}/);
-  assert(rule, 'the default table rule is gone');
-  const margin = rule[0].match(/margin:\s*([^;]+);/);
-  assert(margin, 'the default table rule sets no margin');
-  const sides = margin[1].trim().split(/\s+/);
-  const horizontal = sides.length >= 2 ? [sides[1], sides[3] ?? sides[1]] : [sides[0], sides[0]];
-  for (const v of horizontal) {
-    assert(!v.startsWith('-'), `table margin pulls sideways (${margin[1].trim()})`);
-  }
+  assert(src.includes(':where(body table) { border-collapse: separate; border-spacing: 3px; margin: 0 0 18px; font-size: 16px; }'),
+    'default table margin must be 0 0 18px with no left pull');
 });
 
 t('overlay never display:block a document table', () => {


### PR DESCRIPTION
Reverts #282 and #283.

## Why

Both put the table style in the overlay's **injected reader CSS** — the 39 `:where()` rules stamped into every document at render time. #283 went further and added a test forbidding any house style from defining table CSS, which made the injected layer the *only* place a table can be described. That turned a dependence on injection into an enforced constraint.

Template injection is being sunset. The direction is that the agent learns the treatment from the authoring contract and **writes it into each document**, rather than inheriting it at render time. Building on the layer that is going away — and then locking styles out of the alternative — is the wrong way round.

## What this does not change

The original report stands: a table of rounded tinted chips separated by 3px gutters reads as a pile of grey blocks, the gutters cut the columns apart so there is nothing to scan down, and filled cells invert into slabs under a whole-page dark filter. **That is all still true after this revert.**

The fix belongs in `authoring/`, next to `voice.md` and `visuals.md`, which are already required reading before every generation. "Every style, including styles not written yet" is then carried by a contract the agent reads, not by CSS it inherits — which is the same guarantee, on the layer that is staying.

## Scope

The two commits touched only the table rules in the overlay, the technical style's own table CSS, and the two tests guarding them. Nothing else is reverted.

`npm test` — 43 suites green.