### PR TITLE
Element-comment outline clips to its scroll container

### DIFF
--- a/server/frame-probe.js
+++ b/server/frame-probe.js
@@ -128,12 +128,37 @@
     hoverPill = document.createElement('button'); hoverPill.className = 'tdoc-comment-pill'; hoverPill.type = 'button'; hoverPill.style.display = 'none';
     hoverPill.setAttribute('aria-label', 'Comment on this');
     hoverPill.innerHTML = '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"/></svg>';
-    document.body.appendChild(hoverOutline); document.body.appendChild(hoverPill);
+    // Parent on <html>, NOT <body>: a transformed body (see the hostile fixture)
+    // becomes the containing block for absolute descendants, so viewport-derived
+    // coordinates written to a body child render shifted/scaled. <html> keeps
+    // document coordinates honest, and body clones (copyDoc) never include the UI.
+    document.documentElement.appendChild(hoverOutline); document.documentElement.appendChild(hoverPill);
     hoverPill.addEventListener('click', function (e) { e.preventDefault(); e.stopPropagation(); if (hoverEl) commentOnElement(hoverEl); });
+  }
+  // The element's VISIBLE box: its rect intersected with every clipping
+  // ancestor (overflow scroll/auto/hidden/clip). A wide graph inside an
+  // overflow-x container has a bounding rect far wider than what's on screen —
+  // painting the outline/pill from the raw rect runs them outside the
+  // container, across the page.
+  function clipRect(el) {
+    var r = el.getBoundingClientRect();
+    var L = r.left, T = r.top, R = r.right, B = r.bottom;
+    var p = el.parentElement;
+    while (p && p !== document.documentElement) {
+      var cs; try { cs = getComputedStyle(p); } catch (x) { break; }
+      if (/auto|scroll|hidden|clip/.test(cs.overflowX + cs.overflowY)) {
+        var pr = p.getBoundingClientRect();
+        if (pr.left > L) L = pr.left; if (pr.top > T) T = pr.top;
+        if (pr.right < R) R = pr.right; if (pr.bottom < B) B = pr.bottom;
+      }
+      p = p.parentElement;
+    }
+    return { left: L, top: T, right: R, bottom: B, width: Math.max(0, R - L), height: Math.max(0, B - T) };
   }
   function positionHover(el) {
     ensureHoverUI();
-    var r = el.getBoundingClientRect(), sx = window.scrollX || 0, sy = window.scrollY || 0;
+    var r = clipRect(el), sx = window.scrollX || 0, sy = window.scrollY || 0;
+    if (r.width < 12 || r.height < 12) { hideHover(); return; }   // scrolled out of its container
     hoverOutline.style.display = 'block';
     hoverOutline.style.left = (r.left + sx) + 'px'; hoverOutline.style.top = (r.top + sy) + 'px';
     hoverOutline.style.width = r.width + 'px'; hoverOutline.style.height = r.height + 'px';
@@ -142,7 +167,7 @@
   }
   function hideHover() { hoverEl = null; if (hoverOutline) hoverOutline.style.display = 'none'; if (hoverPill) hoverPill.style.display = 'none'; }
   function commentOnElement(el) {
-    var r = el.getBoundingClientRect();
+    var r = clipRect(el);   // visible box — the raw rect of a scroll-container child can be miles wide
     var label = el.getAttribute('aria-label') || el.getAttribute('alt') || el.getAttribute('data-tdoc-artifact') || el.tagName.toLowerCase();
     // Anchor the composer to the PILL the user just clicked (element top-right),
     // not the element box — a tall section would otherwise park the composer

--- a/test/artifact-shell.test.js
+++ b/test/artifact-shell.test.js
@@ -455,6 +455,35 @@ const SLUG = 'hostile-body-css';
       await page.waitForSelector('#tdoc-comment-layer .tdoc-margin-comment[data-comment-id="c_fixture_1"]', { timeout: 2000 });
     });
 
+    await t('hover outline clips to a horizontal scroll container, not the full graph', async () => {
+      await page.setViewportSize({ width: 1400, height: 900 });
+      await page.goto(shellUrl, { waitUntil: 'networkidle' });
+      const frame = page.frames().find(f => f.url().includes(SLUG) && f !== page.mainFrame());
+      if (!frame) throw new Error('author frame not found');
+      await frame.evaluate(() => document.getElementById('wide-graph').scrollIntoView({ block: 'center' }));
+      let geo = null;
+      for (let i = 0; i < 20 && !geo; i++) {
+        await frame.evaluate(() => {
+          const g = document.getElementById('wide-graph');
+          const w = document.getElementById('scroll-wrap').getBoundingClientRect();
+          g.dispatchEvent(new MouseEvent('mousemove', { clientX: w.left + 40, clientY: w.top + w.height / 2, bubbles: true, view: window }));
+        });
+        await page.waitForTimeout(150);
+        geo = await frame.evaluate(() => {
+          const o = document.querySelector('.tdoc-hover-outline');
+          const p = document.querySelector('.tdoc-comment-pill');
+          if (!o || o.style.display === 'none' || !p || p.style.display === 'none') return null;
+          const wrap = document.getElementById('scroll-wrap').getBoundingClientRect();
+          return { oRight: o.getBoundingClientRect().right, pillRight: p.getBoundingClientRect().right, wrapRight: wrap.right, graphRight: document.getElementById('wide-graph').getBoundingClientRect().right };
+        });
+      }
+      if (!geo) throw new Error('hover outline never appeared over the wide graph');
+      // sanity: the graph really overflows its container in this fixture
+      if (geo.graphRight <= geo.wrapRight + 100) throw new Error('fixture graph does not overflow: ' + JSON.stringify(geo));
+      if (geo.oRight > geo.wrapRight + 2) throw new Error('outline escapes the scroll container: ' + JSON.stringify(geo));
+      if (geo.pillRight > geo.wrapRight + 2) throw new Error('pill escapes the scroll container: ' + JSON.stringify(geo));
+    });
+
     await t('resizing back to wide leaves no drawer residue on screen', async () => {
       // Narrow first so the drawer DOM gets created and populated, then widen:
       // the layer must not paint (it used to fall back to absolute top-left,

--- a/test/fixtures/tdocs/hostile-body-css/v1/index.html
+++ b/test/fixtures/tdocs/hostile-body-css/v1/index.html
@@ -28,5 +28,11 @@
   <p id="para-cluster">Two reviewers flagged this exact same sentence, so their pins must cluster into one count badge.</p>
   <canvas id="art-canvas" width="240" height="140" style="display:block;width:240px;height:140px;background:#334">A commentable artifact (canvas) for element-comment tests.</canvas>
   <p><a id="internal-link" href="/d/hostile-body-css/v/1">An internal link that must navigate the top page, not the frame.</a></p>
+  <div id="scroll-wrap" style="overflow-x:auto;width:100%">
+    <svg id="wide-graph" width="2400" height="120" style="display:block" role="img" aria-label="wide graph">
+      <rect x="0" y="0" width="2400" height="120" fill="#265"></rect>
+      <text x="20" y="60" fill="#fff">A 2400px-wide graph inside a horizontal scroll container — the hover outline must clip to the container.</text>
+    </svg>
+  </div>
   <div id="tall-spacer" style="height:1600px">Tall spacer so the doc scrolls (footer reveal-at-bottom test).</div>
 </body></html>


### PR DESCRIPTION
User repro: hovering a wide picture/graph inside a horizontal scroll container paints the element-comment box (dashed outline + pill) from the element's RAW bounding rect — which is the full unclipped width (thousands of px) — so the box runs outside the container, across the page.

Two probe fixes:
- `clipRect(el)`: the element's rect intersected with every clipping ancestor (`overflow` auto/scroll/hidden/clip). The hover outline/pill and the element-comment composer anchor now use the visible box; fully scrolled-out elements hide the hover UI instead of painting a sliver.
- Hover UI parents on `<html>`, not `<body>`: a transformed body (hostile fixture's `scale(0.98)`) becomes the containing block for absolute descendants, so viewport-derived coordinates rendered shifted. `<html>` keeps document coordinates honest — this was a pre-existing mispositioning the new regression test caught.

Fixture gains a 2400px-wide SVG in an `overflow-x` container; regression test asserts outline and pill stay within the container's box.

45 offline + 28 boundary suites green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)