### PR TITLE
/me becomes a docs hub: time sorting, folders, Recent, Starred

### DIFF
--- a/server/chrome.css
+++ b/server/chrome.css
@@ -64,7 +64,9 @@
   /* Default action button — icon and/or label, no border, hover bg only. */
   .tdoc-bar button { background: transparent; border: none; color: #555; padding: 6px 8px; border-radius: 6px; font: inherit; cursor: pointer; transition: background .12s, color .12s; display: inline-flex; align-items: center; gap: 6px; }
   .tdoc-bar button:hover { background: #f0f1f4; color: #1a1a1a; }
-  .tdoc-bar button.tdoc-star-btn { font-size: 15px; padding: 4px 7px; color: #b9bfca; line-height: 1; }
+  /* flex-shrink 0: when the narrow bar squeezes the title into its ellipsis,
+     the star must keep its full hit target rather than collapse. */
+  .tdoc-bar button.tdoc-star-btn { font-size: 15px; padding: 4px 7px; color: #b9bfca; line-height: 1; flex-shrink: 0; }
   .tdoc-bar button.tdoc-star-btn:hover { color: #f5a623; background: #f0f1f4; }
   .tdoc-bar button.tdoc-star-btn.is-starred { color: #f5a623; }
   .tdoc-bar button:disabled { opacity: 0.5; cursor: not-allowed; }

--- a/server/chrome.css
+++ b/server/chrome.css
@@ -56,7 +56,10 @@
   /* Breadcrumb: workspace · slug · v3 — separated by " / ". */
   .tdoc-bar .crumb { color: #555; font-weight: 500; padding: 4px 6px; border-radius: 6px; max-width: 24ch; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
   .tdoc-bar .crumb-sep { color: #c0c0c4; user-select: none; padding: 0 1px; }
-  .tdoc-bar .doc-title { color: #1a1a1a; font-weight: 600; font-size: 14px; min-width: 0; flex: 1 1 auto; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+  /* flex-grow 0 (was 1): the title must hug its text so the star sits right
+     beside it — growing pushed the star to the far end of the left cluster.
+     Shrink+min-width:0 keeps the ellipsis when space runs out. */
+  .tdoc-bar .doc-title { color: #1a1a1a; font-weight: 600; font-size: 14px; min-width: 0; flex: 0 1 auto; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 
   /* Default action button — icon and/or label, no border, hover bg only. */
   .tdoc-bar button { background: transparent; border: none; color: #555; padding: 6px 8px; border-radius: 6px; font: inherit; cursor: pointer; transition: background .12s, color .12s; display: inline-flex; align-items: center; gap: 6px; }

--- a/server/chrome.css
+++ b/server/chrome.css
@@ -61,6 +61,9 @@
   /* Default action button — icon and/or label, no border, hover bg only. */
   .tdoc-bar button { background: transparent; border: none; color: #555; padding: 6px 8px; border-radius: 6px; font: inherit; cursor: pointer; transition: background .12s, color .12s; display: inline-flex; align-items: center; gap: 6px; }
   .tdoc-bar button:hover { background: #f0f1f4; color: #1a1a1a; }
+  .tdoc-bar button.tdoc-star-btn { font-size: 15px; padding: 4px 7px; color: #b9bfca; line-height: 1; }
+  .tdoc-bar button.tdoc-star-btn:hover { color: #f5a623; background: #f0f1f4; }
+  .tdoc-bar button.tdoc-star-btn.is-starred { color: #f5a623; }
   .tdoc-bar button:disabled { opacity: 0.5; cursor: not-allowed; }
   .tdoc-bar button svg { flex-shrink: 0; }
 

--- a/server/chrome.js
+++ b/server/chrome.js
@@ -55,7 +55,11 @@
               versions.map(function (v) { return '<button role="option" data-version="' + v.n + '" class="' + (v.n === version ? 'current' : '') + '">v' + v.n + (v.n === version ? ' · current' : '') + '</button>'; }).join('') +
             '</div>' : '') +
         '</div>' +
-        '<span class="doc-title" id="tdoc-title">tdoc</span>');
+        '<span class="doc-title" id="tdoc-title">tdoc</span>' +
+        // Star sits beside the title (Google-Docs placement). Rendered only
+        // when the server hands us the viewer's state (signed-in reader on a
+        // published doc) — anonymous readers and site bars get nothing.
+        (o.viewerStar ? '<button id="tdoc-star-btn" class="tdoc-star-btn' + (o.viewerStar.starred ? ' is-starred' : '') + '" aria-pressed="' + (o.viewerStar.starred ? 'true' : 'false') + '" title="' + (o.viewerStar.starred ? 'Unstar' : 'Star') + '" aria-label="' + (o.viewerStar.starred ? 'Unstar this doc' : 'Star this doc') + '">' + (o.viewerStar.starred ? '★' : '☆') + '</button>' : ''));
 
     // Copy / Duplicate / Download all live inside the ⋯ menu now (matches the
     // overlay's redesigned right cluster) — no standalone Copy button.

--- a/server/shell.js
+++ b/server/shell.js
@@ -741,6 +741,29 @@
     })();
     // My docs
     wire('#tdoc-bar-mark','click',function(){ location.href='/me'; });
+    // Star (bar, beside the title). The button only exists when the server
+    // rendered it for a signed-in viewer; flip optimistically, revert on error.
+    wire('#tdoc-star-btn','click',function(e){
+      e.stopPropagation();
+      var btn = document.getElementById('tdoc-star-btn'); if (!btn) return;
+      var next = btn.getAttribute('aria-pressed') !== 'true';
+      function paintStar(on){
+        btn.classList.toggle('is-starred', on);
+        btn.textContent = on ? '★' : '☆';
+        btn.setAttribute('aria-pressed', on ? 'true' : 'false');
+        btn.title = on ? 'Unstar' : 'Star';
+        btn.setAttribute('aria-label', on ? 'Unstar this doc' : 'Star this doc');
+      }
+      paintStar(next);
+      fetch('/api/star', {
+        method: 'POST', credentials: 'same-origin',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ slug: cfg.slug, starred: next }),
+      }).then(function(r){
+        if (!r.ok) throw new Error('star failed');
+        flashToast(next ? 'Starred — find it in My docs' : 'Star removed');
+      }).catch(function(){ paintStar(!next); });
+    });
     // Publish (local mode) / Share (published mode)
     wire('#tdoc-publish-btn','click',function(e){ e.stopPropagation(); showPublishModal(); });
     wire('#tdoc-share-btn','click',function(e){ e.stopPropagation(); showShareModal(); });

--- a/server/shell.js
+++ b/server/shell.js
@@ -743,26 +743,36 @@
     wire('#tdoc-bar-mark','click',function(){ location.href='/me'; });
     // Star (bar, beside the title). The button only exists when the server
     // rendered it for a signed-in viewer; flip optimistically, revert on error.
+    // Star changes broadcast on 'tdoc-doc-state' so an open /me tab — and any
+    // other tab showing this doc — catches up without a manual refresh.
+    var starChannel = null;
+    try { starChannel = new BroadcastChannel('tdoc-doc-state'); } catch (e) {}
+    function paintBarStar(on){
+      var btn = document.getElementById('tdoc-star-btn'); if (!btn) return;
+      btn.classList.toggle('is-starred', on);
+      btn.textContent = on ? '★' : '☆';
+      btn.setAttribute('aria-pressed', on ? 'true' : 'false');
+      btn.title = on ? 'Unstar' : 'Star';
+      btn.setAttribute('aria-label', on ? 'Unstar this doc' : 'Star this doc');
+    }
+    if (starChannel) starChannel.onmessage = function(ev){
+      var d = ev.data || {};
+      if (d.type === 'star' && d.slug === cfg.slug) paintBarStar(!!d.starred);
+    };
     wire('#tdoc-star-btn','click',function(e){
       e.stopPropagation();
       var btn = document.getElementById('tdoc-star-btn'); if (!btn) return;
       var next = btn.getAttribute('aria-pressed') !== 'true';
-      function paintStar(on){
-        btn.classList.toggle('is-starred', on);
-        btn.textContent = on ? '★' : '☆';
-        btn.setAttribute('aria-pressed', on ? 'true' : 'false');
-        btn.title = on ? 'Unstar' : 'Star';
-        btn.setAttribute('aria-label', on ? 'Unstar this doc' : 'Star this doc');
-      }
-      paintStar(next);
+      paintBarStar(next);
       fetch('/api/star', {
         method: 'POST', credentials: 'same-origin',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ slug: cfg.slug, starred: next }),
       }).then(function(r){
         if (!r.ok) throw new Error('star failed');
+        if (starChannel) { try { starChannel.postMessage({ type: 'star', slug: cfg.slug, starred: next }); } catch (e) {} }
         flashToast(next ? 'Starred — find it in My docs' : 'Star removed');
-      }).catch(function(){ paintStar(!next); });
+      }).catch(function(){ paintBarStar(!next); });
     });
     // Publish (local mode) / Share (published mode)
     wire('#tdoc-publish-btn','click',function(e){ e.stopPropagation(); showPublishModal(); });

--- a/test/me-docs-experience.test.js
+++ b/test/me-docs-experience.test.js
@@ -325,6 +325,26 @@ function pane(html, id) {
     assert(stored.folders.length === 1 && stored.folders[0].name === 'Renamed', 'rename must persist');
   });
 
+  await t('doc-page bar carries the star beside the title — signed-in viewers only, state server-rendered', async () => {
+    const env = makeEnv(mod.CommentsStore);
+    await seedDoc(env, 'bar-doc', { owner: 'bob' });
+    // chrome.js/chrome.css ship inline on every page, so the button's source
+    // strings are always present. Only the RENDERED markup has the class
+    // attribute closed with a double quote — key the checks off that.
+    const rendered = /class="tdoc-star-btn( is-starred)?" aria-pressed="(true|false)"/;
+    const anonHtml = await (await worker.fetch(req('/d/bar-doc/v/1'), env, {})).text();
+    assert(!rendered.test(anonHtml), 'anonymous doc view must not render the bar star');
+    const cookie = await putSession(env, 'alice');
+    let html = await (await worker.fetch(req('/d/bar-doc/v/1', { cookie }), env, {})).text();
+    assert(/class="tdoc-star-btn" aria-pressed="false"/.test(html), 'signed-in view must render the empty-star state');
+    assert(!html.includes('class="tdoc-star-btn is-starred"'), 'unstarred doc must not render as starred');
+    await worker.fetch(req('/api/star', { method: 'POST', cookie, body: { slug: 'bar-doc', starred: true } }), env, {});
+    html = await (await worker.fetch(req('/d/bar-doc/v/1', { cookie }), env, {})).text();
+    assert(/class="tdoc-star-btn is-starred" aria-pressed="true"/.test(html), 'starred doc must render the filled state');
+    const me = await (await worker.fetch(req('/me', { cookie }), env, {})).text();
+    assert(!rendered.test(me), 'the /me site bar must not carry the doc star (rows have their own)');
+  });
+
   console.log(`\n${pass} passed, ${fail} failed`);
   process.exit(fail ? 1 : 0);
 })();

--- a/test/me-docs-experience.test.js
+++ b/test/me-docs-experience.test.js
@@ -1,0 +1,330 @@
+// /me docs-experience behavior: time sorting, recents (visited docs — owned
+// or not), starred docs, and personal folders. Runs worker.js in-process with
+// fake KV/R2/DO bindings (same harness shape as hosted-oob-behavior.test.js).
+//
+// The per-user state lives in stars:<login> / recents:<login> /
+// folders:<login> KV values; nothing here may touch another user's state or
+// leak access data into the catalog HTML.
+
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const { webcrypto } = require('crypto');
+
+if (typeof globalThis.crypto === 'undefined') globalThis.crypto = webcrypto;
+
+if (typeof Response !== 'undefined' && !Response.json) {
+  Response.json = (body, init = {}) => new Response(JSON.stringify(body), {
+    ...init,
+    headers: { 'Content-Type': 'application/json', ...(init.headers || {}) },
+  });
+}
+
+let pass = 0, fail = 0;
+function ok(n) { console.log(`  ✓ ${n}`); pass++; }
+function bad(n, e) { console.log(`  ✗ ${n}\n    ${e && e.message ? e.message : e}`); fail++; }
+async function t(n, fn) { try { await fn(); ok(n); } catch (e) { bad(n, e); } }
+function assert(c, m) { if (!c) throw new Error(m || 'assertion failed'); }
+
+class FakeKV {
+  constructor() { this.map = new Map(); }
+  async get(k) { return this.map.has(k) ? this.map.get(k) : null; }
+  async put(k, v) { this.map.set(k, String(v)); }
+  async delete(k) { this.map.delete(k); }
+  async list({ prefix = '' } = {}) {
+    return {
+      keys: [...this.map.keys()].filter(k => k.startsWith(prefix)).map(name => ({ name })),
+      list_complete: true,
+    };
+  }
+}
+
+class FakeR2 {
+  constructor() { this.map = new Map(); }
+  async put(k, v) { this.map.set(k, String(v)); }
+  async get(k) {
+    if (!this.map.has(k)) return null;
+    const v = this.map.get(k);
+    return { text: async () => v };
+  }
+  async head(k) {
+    if (!this.map.has(k)) return null;
+    return { size: Buffer.byteLength(this.map.get(k)) };
+  }
+  async delete(k) { this.map.delete(k); }
+  async list({ prefix = '' } = {}) {
+    return {
+      objects: [...this.map.keys()].filter(k => k.startsWith(prefix)).map(key => ({ key })),
+      truncated: false,
+    };
+  }
+}
+
+class FakeStorage {
+  constructor() { this.map = new Map(); }
+  async transaction(fn) {
+    const txn = {
+      get: async (k) => this.map.get(k),
+      put: async (k, v) => { this.map.set(k, v); },
+      delete: async (k) => { this.map.delete(k); },
+    };
+    return fn(txn);
+  }
+}
+
+class FakeDurableNamespace {
+  constructor(env, StoreClass) {
+    this.env = env;
+    this.StoreClass = StoreClass;
+    this.states = new Map();
+  }
+  idFromName(name) { return name; }
+  stateFor(id) {
+    if (!this.states.has(id)) this.states.set(id, { storage: new FakeStorage() });
+    return this.states.get(id);
+  }
+  get(id) {
+    return {
+      fetch: async (url, init = {}) => {
+        const store = new this.StoreClass(this.stateFor(id), this.env);
+        return store.fetch(new Request(url, init));
+      },
+    };
+  }
+}
+
+async function loadWorker() {
+  const root = path.join(__dirname, '..');
+  let src = fs.readFileSync(path.join(root, 'worker', 'worker.js'), 'utf8');
+  const readerCss = fs.readFileSync(path.join(root, 'server', 'reader.css'), 'utf8');
+  src = src.replace(
+    /const READER_CSS = `__TDOC_READER_CSS__`;/,
+    'const READER_CSS = ' + JSON.stringify(readerCss) + ';'
+  );
+  const chromeMod = fs.readFileSync(path.join(root, 'server', 'chrome.js'), 'utf8');
+  const shellMod = fs.readFileSync(path.join(root, 'server', 'shell.js'), 'utf8');
+  const probeJs = fs.readFileSync(path.join(root, 'server', 'frame-probe.js'), 'utf8');
+  const chromeCss = fs.readFileSync(path.join(root, 'server', 'chrome.css'), 'utf8');
+  src = src.replace('/* __TDOC_CHROME_MODULE__ */', chromeMod);
+  src = src.replace('/* __TDOC_SHELL_MODULE__ */', shellMod);
+  src = src.replace(/const CHROME_JS = `__TDOC_CHROME_JS__`;/, 'const CHROME_JS = ' + JSON.stringify(chromeMod) + ';');
+  src = src.replace(/const PROBE_JS = `__TDOC_PROBE_JS__`;/, 'const PROBE_JS = ' + JSON.stringify(probeJs) + ';');
+  src = src.replace(/const CHROME_CSS = `__TDOC_CHROME_CSS__`;/, 'const CHROME_CSS = ' + JSON.stringify(chromeCss) + ';');
+  const tmp = path.join(os.tmpdir(), `tdoc-worker-${Date.now()}-${Math.random().toString(16).slice(2)}.mjs`);
+  fs.writeFileSync(tmp, src);
+  const mod = await import(`file://${tmp}`);
+  try { fs.unlinkSync(tmp); } catch {}
+  return mod;
+}
+
+function makeEnv(StoreClass, extra = {}) {
+  const env = {
+    META: new FakeKV(),
+    DOCS: new FakeR2(),
+    TDOC_HOSTED_REGISTRATION: '1',
+    ...extra,
+  };
+  env.COMMENTS = new FakeDurableNamespace(env, StoreClass);
+  return env;
+}
+
+function req(pathname, { method = 'GET', body = null, cookie = '', host = 'tdoc.dev' } = {}) {
+  return new Request(`https://${host}${pathname}`, {
+    method,
+    headers: {
+      ...(cookie ? { Cookie: cookie.includes('=') ? cookie : `tdoc_sid=${cookie}` } : {}),
+      ...(body ? { 'Content-Type': 'application/json' } : {}),
+    },
+    body: body ? JSON.stringify(body) : undefined,
+  });
+}
+
+async function putSession(env, login) {
+  const id = [...crypto.getRandomValues(new Uint8Array(16))]
+    .map((b) => b.toString(16).padStart(2, '0')).join('');
+  await env.META.put(`session:${id}`, JSON.stringify({
+    login, name: login, avatar_url: '', created: new Date().toISOString(),
+  }));
+  return `tdoc_sid=${id}`;
+}
+
+async function seedDoc(env, slug, { owner, created = '2026-01-01T00:00:00.000Z', versions, title, access } = {}) {
+  const vs = versions || [{ n: 1, created }];
+  const meta = { title: title || slug, slug, created, versions: vs };
+  if (owner) meta.hosted = { account_id: `acct-${owner}`, github_login: owner };
+  if (access) meta.access = access;
+  await env.META.put(`meta:${slug}`, JSON.stringify(meta));
+  for (const v of vs) await env.DOCS.put(`docs/${slug}/v${v.n}/index.html`, `<h1>${slug}</h1>`);
+}
+
+function pane(html, id) {
+  const start = html.indexOf(`id="${id}"`);
+  assert(start >= 0, `pane ${id} missing`);
+  const end = html.indexOf('</section>', start);
+  return html.slice(start, end);
+}
+
+(async () => {
+  const mod = await loadWorker();
+  const worker = mod.default;
+  console.log('/me docs experience (sorting / recents / stars / folders)');
+
+  await t('/me sorts the catalog by last update, newest first, and renders sort + tabs', async () => {
+    const env = makeEnv(mod.CommentsStore);
+    const cookie = await putSession(env, 'alice');
+    await seedDoc(env, 'a-older', { owner: 'alice', versions: [{ n: 1, created: '2026-01-05T00:00:00.000Z' }] });
+    await seedDoc(env, 'z-newer', { owner: 'alice', versions: [
+      { n: 1, created: '2026-02-01T00:00:00.000Z' },
+      { n: 2, created: '2026-03-01T00:00:00.000Z' },
+    ] });
+    const r = await worker.fetch(req('/me', { cookie }), env, {});
+    assert(r.status === 200, `/me ${r.status}`);
+    const html = await r.text();
+    const iNew = html.indexOf('data-slug="z-newer"');
+    const iOld = html.indexOf('data-slug="a-older"');
+    assert(iNew >= 0 && iOld >= 0, 'both rows must render');
+    assert(iNew < iOld, 'latest-updated doc must come first (KV order is alphabetical, so this proves the sort)');
+    assert(html.includes('id="doc-sort"'), 'sort select missing');
+    assert(html.includes('data-updated="2026-03-01T00:00:00.000Z"'), 'rows must carry data-updated for client re-sort');
+    assert(html.includes('data-created='), 'rows must carry data-created');
+    assert(html.includes('data-pane="pane-recent"') && html.includes('data-pane="pane-starred"'), 'Recent/Starred tabs missing');
+    assert(html.includes('updated 2026-03-01'), 'row meta should show the update day');
+  });
+
+  await t('a signed-in visit to a readable doc records recents:<login>; /me shows it with a byline', async () => {
+    const env = makeEnv(mod.CommentsStore);
+    await seedDoc(env, 'bobs-doc', { owner: 'bob' });
+    const cookie = await putSession(env, 'alice');
+    const r = await worker.fetch(req('/d/bobs-doc/v/1', { cookie }), env, {});
+    assert(r.status === 200, `doc view ${r.status}`);
+    const recents = JSON.parse(await env.META.get('recents:alice'));
+    assert(recents && recents.items.length === 1 && recents.items[0].slug === 'bobs-doc',
+      `visit not recorded: ${await env.META.get('recents:alice')}`);
+    const me = await worker.fetch(req('/me', { cookie }), env, {});
+    const html = await me.text();
+    const recent = pane(html, 'pane-recent');
+    assert(recent.includes('data-slug="bobs-doc"'), 'Recent pane must list the visited doc');
+    assert(recent.includes('by bob'), 'Recent row must say whose doc it is');
+    // Not alice's doc — it must NOT appear in her own catalog list.
+    assert(!pane(html, 'pane-mine').includes('data-slug="bobs-doc"'), "someone else's doc must stay out of My docs");
+  });
+
+  await t('anonymous and denied visits record nothing; HEAD records nothing', async () => {
+    const env = makeEnv(mod.CommentsStore);
+    await seedDoc(env, 'open-doc', { owner: 'bob' });
+    await seedDoc(env, 'locked-doc', { owner: 'bob', access: { visibility: 'private' } });
+    await worker.fetch(req('/d/open-doc/v/1'), env, {});
+    assert([...env.META.map.keys()].every(k => !k.startsWith('recents:')), 'anonymous visit must not write recents');
+    const cookie = await putSession(env, 'alice');
+    const denied = await worker.fetch(req('/d/locked-doc/v/1', { cookie }), env, {});
+    assert(denied.status === 403, `private doc should deny alice, got ${denied.status}`);
+    assert(!(await env.META.get('recents:alice')), 'denied visit must not be recorded');
+    await worker.fetch(req('/d/open-doc/v/1', { cookie, method: 'HEAD' }), env, {});
+    assert(!(await env.META.get('recents:alice')), 'HEAD must not be recorded');
+  });
+
+  await t('revisits dedupe (newest first) and immediate reloads do not rewrite', async () => {
+    const env = makeEnv(mod.CommentsStore);
+    await seedDoc(env, 'doc-one', { owner: 'bob' });
+    await seedDoc(env, 'doc-two', { owner: 'bob' });
+    const cookie = await putSession(env, 'alice');
+    await worker.fetch(req('/d/doc-one/v/1', { cookie }), env, {});
+    const first = await env.META.get('recents:alice');
+    await worker.fetch(req('/d/doc-one/v/1', { cookie }), env, {});
+    assert(await env.META.get('recents:alice') === first, 'immediate reload must not rewrite the recents value');
+    await worker.fetch(req('/d/doc-two/v/1', { cookie }), env, {});
+    await worker.fetch(req('/d/doc-one/v/1', { cookie }), env, {});
+    const items = JSON.parse(await env.META.get('recents:alice')).items;
+    assert(items.length === 2, `expected 2 recents, got ${items.length}`);
+    assert(items[0].slug === 'doc-one' && items[1].slug === 'doc-two', 'revisit must move the doc to the head, not duplicate it');
+  });
+
+  await t('star/unstar round-trip: API + Starred pane; anonymous 401; unreadable 404', async () => {
+    const env = makeEnv(mod.CommentsStore);
+    await seedDoc(env, 'starrable', { owner: 'bob' });
+    await seedDoc(env, 'hidden', { owner: 'bob', access: { visibility: 'private' } });
+    const anon = await worker.fetch(req('/api/star', { method: 'POST', body: { slug: 'starrable', starred: true } }), env, {});
+    assert(anon.status === 401, `anon star should 401, got ${anon.status}`);
+    const cookie = await putSession(env, 'alice');
+    const star = await worker.fetch(req('/api/star', { method: 'POST', cookie, body: { slug: 'starrable', starred: true } }), env, {});
+    assert(star.status === 200, `star ${star.status}`);
+    assert(JSON.parse(await env.META.get('stars:alice')).items[0].slug === 'starrable', 'star not persisted');
+    const noDoc = await worker.fetch(req('/api/star', { method: 'POST', cookie, body: { slug: 'no-such-doc', starred: true } }), env, {});
+    assert(noDoc.status === 404, `missing doc should 404, got ${noDoc.status}`);
+    const priv = await worker.fetch(req('/api/star', { method: 'POST', cookie, body: { slug: 'hidden', starred: true } }), env, {});
+    assert(priv.status === 404, `unreadable doc must 404 (no existence oracle), got ${priv.status}`);
+    let html = await (await worker.fetch(req('/me', { cookie }), env, {})).text();
+    assert(pane(html, 'pane-starred').includes('data-slug="starrable"'), 'Starred pane must list the doc');
+    const unstar = await worker.fetch(req('/api/star', { method: 'POST', cookie, body: { slug: 'starrable', starred: false } }), env, {});
+    assert(unstar.status === 200, `unstar ${unstar.status}`);
+    assert(JSON.parse(await env.META.get('stars:alice')).items.length === 0, 'unstar must remove the item');
+    html = await (await worker.fetch(req('/me', { cookie }), env, {})).text();
+    assert(!pane(html, 'pane-starred').includes('data-slug="starrable"'), 'unstarred doc must leave the pane');
+  });
+
+  await t('starred/recent rows vanish when the doc becomes unreadable or is deleted', async () => {
+    const env = makeEnv(mod.CommentsStore);
+    await seedDoc(env, 'was-open', { owner: 'bob' });
+    const cookie = await putSession(env, 'alice');
+    await worker.fetch(req('/d/was-open/v/1', { cookie }), env, {});
+    await worker.fetch(req('/api/star', { method: 'POST', cookie, body: { slug: 'was-open', starred: true } }), env, {});
+    // Bob flips the doc private — alice's saved pointers must go dark.
+    const meta = JSON.parse(await env.META.get('meta:was-open'));
+    meta.access = { visibility: 'private' };
+    await env.META.put('meta:was-open', JSON.stringify(meta));
+    const html = await (await worker.fetch(req('/me', { cookie }), env, {})).text();
+    assert(!pane(html, 'pane-recent').includes('data-slug="was-open"'), 'Recent must drop unreadable docs');
+    assert(!pane(html, 'pane-starred').includes('data-slug="was-open"'), 'Starred must drop unreadable docs');
+  });
+
+  await t('folders: create → move → chip filter data; delete returns docs to root', async () => {
+    const env = makeEnv(mod.CommentsStore);
+    const cookie = await putSession(env, 'alice');
+    await seedDoc(env, 'my-doc', { owner: 'alice' });
+    const anon = await worker.fetch(req('/api/folders', { method: 'POST', body: { name: 'Work' } }), env, {});
+    assert(anon.status === 401, `anon create should 401, got ${anon.status}`);
+    const create = await worker.fetch(req('/api/folders', { method: 'POST', cookie, body: { name: 'Work' } }), env, {});
+    assert(create.status === 200, `create ${create.status}: ${await create.clone().text()}`);
+    const folder = (await create.json()).folder;
+    assert(folder && folder.id && folder.name === 'Work', 'create must return the folder');
+    const dup = await worker.fetch(req('/api/folders', { method: 'POST', cookie, body: { name: 'work' } }), env, {});
+    assert(dup.status === 400 && (await dup.json()).error === 'duplicate_name', 'duplicate names (case-insensitive) must 400');
+    const empty = await worker.fetch(req('/api/folders', { method: 'POST', cookie, body: { name: '   ' } }), env, {});
+    assert(empty.status === 400, 'blank name must 400');
+
+    const move = await worker.fetch(req('/api/folders/move', { method: 'POST', cookie, body: { slugs: ['my-doc'], folder: folder.id } }), env, {});
+    assert(move.status === 200, `move ${move.status}: ${await move.clone().text()}`);
+    let html = await (await worker.fetch(req('/me', { cookie }), env, {})).text();
+    assert(html.includes(`data-folder="${folder.id}"`), 'moved row must carry its folder id');
+    assert(html.includes('data-folder="Work"') === false && html.includes('>Work</button>'), 'folder chip must render by name');
+
+    const bogus = await worker.fetch(req('/api/folders/move', { method: 'POST', cookie, body: { slugs: ['my-doc'], folder: 'f_nope' } }), env, {});
+    assert(bogus.status === 404, `move to unknown folder should 404, got ${bogus.status}`);
+
+    const del = await worker.fetch(req('/api/folders?id=' + folder.id, { method: 'DELETE', cookie }), env, {});
+    assert(del.status === 200, `delete folder ${del.status}`);
+    html = await (await worker.fetch(req('/me', { cookie }), env, {})).text();
+    assert(html.includes('data-slug="my-doc"'), 'doc must survive folder deletion');
+    assert(html.includes('data-folder=""'), 'doc must fall back to the root after its folder is deleted');
+  });
+
+  await t('folders shelve only your own docs; rename works; state is per-login', async () => {
+    const env = makeEnv(mod.CommentsStore);
+    await seedDoc(env, 'bobs-doc', { owner: 'bob' });
+    await seedDoc(env, 'alices-doc', { owner: 'alice' });
+    const cookie = await putSession(env, 'alice');
+    const create = await worker.fetch(req('/api/folders', { method: 'POST', cookie, body: { name: 'Mine' } }), env, {});
+    const folder = (await create.json()).folder;
+    const foreign = await worker.fetch(req('/api/folders/move', { method: 'POST', cookie, body: { slugs: ['bobs-doc'], folder: folder.id } }), env, {});
+    assert(foreign.status === 403, `moving someone else's doc should 403, got ${foreign.status}`);
+    const rename = await worker.fetch(req('/api/folders', { method: 'PATCH', cookie, body: { id: folder.id, name: 'Renamed' } }), env, {});
+    assert(rename.status === 200 && (await rename.json()).folder.name === 'Renamed', 'rename failed');
+    // Bob's folder state is untouched by everything alice did.
+    assert(!(await env.META.get('folders:bob')), "alice's folder ops must never write bob's state");
+    const stored = JSON.parse(await env.META.get('folders:alice'));
+    assert(stored.folders.length === 1 && stored.folders[0].name === 'Renamed', 'rename must persist');
+  });
+
+  console.log(`\n${pass} passed, ${fail} failed`);
+  process.exit(fail ? 1 : 0);
+})();

--- a/test/run.js
+++ b/test/run.js
@@ -25,6 +25,7 @@ const OFFLINE = [
   'access.test.js',           // JUL-31 access policy (public/unlisted/private)
   'remote-access-route.test.js', // remote access mutation auth + meta-only guard
   'me-management.test.js',    // /me remote SoT management UI guard
+  'me-docs-experience.test.js', // /me sorting + recents + stars + folders (fake bindings)
   'jul36-owner-manage.test.js', // JUL-36 owner manage UX: server-gated data, token-only mutations, no native confirm()
   'runtime-provenance.test.js', // release provenance + content-hash redeploy
   'hosted-oob.test.js',       // hosted token bootstrap + scoped writes

--- a/worker/worker.js
+++ b/worker/worker.js
@@ -1756,8 +1756,11 @@ async function indexHtml(env, session, origin, nonce) {
   .tdoc-modal p { margin: 0 0 14px; color: #444; line-height: 1.5; }
   .tdoc-modal .actions { display: flex; gap: 8px; justify-content: flex-end; margin-top: 6px; }
   .tdoc-modal button { padding: 8px 16px; border-radius: 6px; border: 1px solid #ccc; background: #fff; }
+  .tdoc-modal button:hover { border-color: #999; }
   .tdoc-modal button.danger { background: var(--td-danger); border-color: var(--td-danger); color: #fff; }
   .tdoc-modal button.danger:hover { background: var(--td-danger-hover); border-color: var(--td-danger-hover); }
+  .tdoc-modal button.primary { background: var(--td-accent); border-color: var(--td-accent); color: #fff; font-weight: 600; }
+  .tdoc-modal button.primary:hover { background: var(--td-accent-hover); border-color: var(--td-accent-hover); }
   .tdoc-modal input[type="text"] { width: 100%; box-sizing: border-box; font: inherit; padding: 8px 10px; border: 1px solid var(--td-line); border-radius: 8px; margin: 0 0 14px; }
   .tdoc-modal input[type="text"]:focus { outline: 2px solid var(--td-accent-tint); border-color: var(--td-accent); }
   /* Google-Docs-style views: My docs / Recent / Starred are pure visibility
@@ -1767,7 +1770,12 @@ async function indexHtml(env, session, origin, nonce) {
   .tab:hover { color: var(--td-ink); }
   .tab.is-active { color: var(--td-accent); border-bottom-color: var(--td-accent); }
   .pane[hidden] { display: none !important; }
-  .toolbar select { font: inherit; padding: 8px 10px; border: 1px solid var(--td-line); border-radius: 8px; background: #fff; color: var(--td-ink); }
+  .toolbar select { -webkit-appearance: none; appearance: none; font: inherit; padding: 8px 30px 8px 12px;
+    border: 1px solid var(--td-line); border-radius: 8px; color: var(--td-ink); cursor: pointer;
+    background: #fff url("data:image/svg+xml;charset=utf-8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 12 8'%3E%3Cpath d='M1 1.5l5 5 5-5' fill='none' stroke='%23666' stroke-width='1.8' stroke-linecap='round' stroke-linejoin='round'/%3E%3C/svg%3E") no-repeat right 11px center;
+    background-size: 11px; }
+  .toolbar select:hover { border-color: #ccc; }
+  .toolbar select:focus { outline: 2px solid var(--td-accent-tint); border-color: var(--td-accent); }
   .folder-bar { display: flex; flex-wrap: wrap; gap: 8px; align-items: center; margin: 0 0 12px; }
   .chip { font: inherit; font-size: 13px; padding: 5px 12px; border-radius: 999px; border: 1px solid var(--td-line); background: #fff; color: var(--td-ink); }
   .chip.is-active { background: var(--td-accent-tint); border-color: var(--td-accent); color: var(--td-accent); font-weight: 600; }
@@ -1956,7 +1964,7 @@ ${rows.length === 0 ? '<p class="empty">No published docs yet. Hit <b>Create a d
       bg.querySelector('p').innerHTML = body;
       const goBtn = bg.querySelector('[data-act="go"]');
       goBtn.textContent = confirmLabel;
-      if (danger) goBtn.className = 'danger';
+      goBtn.className = danger ? 'danger' : 'primary';
       const done = (v) => { bg.remove(); resolve(v); };
       bg.querySelector('[data-act="cancel"]').onclick = () => done(false);
       bg.addEventListener('click', (e) => { if (e.target === bg) done(false); });
@@ -1980,7 +1988,9 @@ ${rows.length === 0 ? '<p class="empty">No published docs yet. Hit <b>Create a d
       const input = bg.querySelector('input');
       input.value = value;
       input.placeholder = placeholder;
-      bg.querySelector('[data-act="go"]').textContent = confirmLabel;
+      const goBtn = bg.querySelector('[data-act="go"]');
+      goBtn.textContent = confirmLabel;
+      goBtn.className = 'primary';
       const done = (v) => { bg.remove(); resolve(v); };
       const go = () => { const v = input.value.trim(); if (v) done(v); };
       bg.querySelector('[data-act="cancel"]').onclick = () => done(null);

--- a/worker/worker.js
+++ b/worker/worker.js
@@ -1141,7 +1141,7 @@ function injectReaderCss(html, css) {
 // local and production render 1:1. The published-mode bar + client cfg carry
 // the same fields the old overlay boot used, so identity/owner/manage/share behave as
 // before once the shell client wires them.
-function shellDocumentWorker(rawHtml, slug, version, identity, versions, isOwner, ownerManage, nonce, isLanding, canSeeMyDocsFlag, isCatalog, webAuth, stars) {
+function shellDocumentWorker(rawHtml, slug, version, identity, versions, isOwner, ownerManage, nonce, isLanding, canSeeMyDocsFlag, isCatalog, webAuth, stars, viewerStar) {
   // Unbundled worker (raw worker.js in tests): no shell builder inlined — serve
   // the author document bare rather than injecting anything.
   if (!SHELL) return rawHtml;
@@ -1166,7 +1166,7 @@ function shellDocumentWorker(rawHtml, slug, version, identity, versions, isOwner
   // doc carrying the /start CTA) — same rule the old overlay boot used.
   const hasCta = /<a[^>]+href="\/start"/.test(rawHtml || '');
   const onboardJs = ((slug === LANDING_SLUG || slug === START_SLUG || hasCta) && nonce) ? ONBOARD_JS : '';
-  const barInner = CHROME.buildBar ? CHROME.buildBar({ mode: 'published', slug, version, versions: vlist, isLanding: !!isLanding, isCatalog: !!isCatalog, stars: stars }) : '';
+  const barInner = CHROME.buildBar ? CHROME.buildBar({ mode: 'published', slug, version, versions: vlist, isLanding: !!isLanding, isCatalog: !!isCatalog, stars: stars, viewerStar: viewerStar || null }) : '';
   // Old-version strip — published + multi-version + viewing an old one (1:1
   // with the overlay: fork/landing and the latest version itself get nothing).
   let oldverHtml = '';
@@ -1310,13 +1310,22 @@ async function serveDocVersion(env, req, slug, version, isLanding) {
   // handled by the crawlable-content-URL plan (#258, separate PR). Stars are
   // landing-only chrome (the bar's GitHub star count).
   const stars = isLanding ? await fetchStars(env) : null;
+  // Viewer star state for the bar (beside the title, Google-Docs style):
+  // only for signed-in readers on non-landing pages. One KV get; sign-in
+  // elsewhere reloads the page, so server-rendered state stays fresh.
+  let viewerStar = null;
+  if (!isLanding && sessionLogin(session)) {
+    try {
+      viewerStar = { starred: (await loadStars(env, sessionLogin(session))).some((i) => i.slug === slug) };
+    } catch {}
+  }
   const render = shellDocumentWorker;
   return {
     ok: true,
     // session rides along so the /d/ route can record the visit (recents)
     // without a second session lookup.
     session,
-    response: html(render(raw, slug, version, identity, versions, isOwner, ownerManage, nonce, isLanding, canSeeMyDocs(env, session, requestOrigin(req)), false, !!env.GITHUB_CLIENT_SECRET, stars), {
+    response: html(render(raw, slug, version, identity, versions, isOwner, ownerManage, nonce, isLanding, canSeeMyDocs(env, session, requestOrigin(req)), false, !!env.GITHUB_CLIENT_SECRET, stars, viewerStar), {
       headers: { 'Content-Security-Policy': cspHeader(nonce) },
     }),
   };

--- a/worker/worker.js
+++ b/worker/worker.js
@@ -1313,6 +1313,9 @@ async function serveDocVersion(env, req, slug, version, isLanding) {
   const render = shellDocumentWorker;
   return {
     ok: true,
+    // session rides along so the /d/ route can record the visit (recents)
+    // without a second session lookup.
+    session,
     response: html(render(raw, slug, version, identity, versions, isOwner, ownerManage, nonce, isLanding, canSeeMyDocs(env, session, requestOrigin(req)), false, !!env.GITHUB_CLIENT_SECRET, stars), {
       headers: { 'Content-Security-Policy': cspHeader(nonce) },
     }),
@@ -1479,6 +1482,106 @@ function redirectTo(location, cookies) {
 // a quiet ⋯ Delete. No access data of any kind is computed or emitted here
 // (gate: response HTML must not contain `allowed_users` — there is nothing
 // here that could).
+// ---- personal docs state: stars, recents, folders ----
+// Per-user KV values, same shape discipline as the notifications inbox: one
+// small JSON blob per login, get→mutate→put, capped lists, only the four KV
+// ops the Vercel shim implements. Stars and recents are viewer-scoped (they
+// follow the signed-in reader across docs they do not own); folders organize
+// only the viewer's own catalog on /me.
+const RECENTS_MAX = 30;
+const STARS_MAX = 200;
+const FOLDERS_MAX = 50;
+const FOLDER_NAME_MAX = 60;
+// A reload of the doc already at the head of the recents list within this
+// window does not rewrite KV — visits are a signal, not an access log.
+const RECENT_REVISIT_MS = 5 * 60 * 1000;
+
+function personalKey(prefix, login) {
+  const n = normalizeGithubLogin(login);
+  return n ? `${prefix}:${n}` : null;
+}
+
+async function loadPersonal(env, key) {
+  if (!key) return null;
+  try {
+    const raw = await env.META.get(key);
+    if (!raw) return null;
+    const parsed = JSON.parse(raw);
+    return parsed && typeof parsed === 'object' ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
+function personalItems(state) {
+  if (!state || !Array.isArray(state.items)) return [];
+  return state.items.filter((i) => i && typeof i.slug === 'string');
+}
+
+async function loadStars(env, login) {
+  return personalItems(await loadPersonal(env, personalKey('stars', login)));
+}
+
+async function loadRecents(env, login) {
+  return personalItems(await loadPersonal(env, personalKey('recents', login)));
+}
+
+async function setDocStar(env, login, slug, starred) {
+  const key = personalKey('stars', login);
+  if (!key) return;
+  const items = personalItems(await loadPersonal(env, key)).filter((i) => i.slug !== slug);
+  if (starred) items.unshift({ slug, at: new Date().toISOString() });
+  await env.META.put(key, JSON.stringify({ items: items.slice(0, STARS_MAX) }));
+}
+
+async function recordDocVisit(env, login, slug) {
+  const key = personalKey('recents', login);
+  if (!key || !isValidSlug(slug)) return;
+  const items = personalItems(await loadPersonal(env, key));
+  if (items[0] && items[0].slug === slug
+      && Date.now() - (Date.parse(items[0].at) || 0) < RECENT_REVISIT_MS) return;
+  const next = [{ slug, at: new Date().toISOString() }, ...items.filter((i) => i.slug !== slug)];
+  await env.META.put(key, JSON.stringify({ items: next.slice(0, RECENTS_MAX) }));
+}
+
+function normalizeFolderState(state) {
+  const folders = state && Array.isArray(state.folders)
+    ? state.folders.filter((f) => f && typeof f.id === 'string' && typeof f.name === 'string')
+    : [];
+  const ids = new Set(folders.map((f) => f.id));
+  const docs = {};
+  if (state && state.docs && typeof state.docs === 'object') {
+    for (const [slug, fid] of Object.entries(state.docs)) {
+      // Drop mappings to folders that no longer exist — docs fall back to root.
+      if (typeof fid === 'string' && ids.has(fid)) docs[slug] = fid;
+    }
+  }
+  return { folders, docs };
+}
+
+async function loadFolderState(env, login) {
+  return normalizeFolderState(await loadPersonal(env, personalKey('folders', login)));
+}
+
+async function saveFolderState(env, login, state) {
+  const key = personalKey('folders', login);
+  if (!key) return;
+  await env.META.put(key, JSON.stringify(normalizeFolderState(state)));
+}
+
+function validFolderName(name) {
+  const n = String(name == null ? '' : name).replace(/[\x00-\x1f\x7f]/g, '').trim();
+  if (!n || n.length > FOLDER_NAME_MAX) return null;
+  return n;
+}
+
+// /me needs to know whether a recent/starred doc — possibly someone else's —
+// is still readable by this viewer. Policy evaluation stays out here so the
+// catalog renderer never touches access data; it only sees the verdict.
+function docReadableBy(env, session, meta) {
+  return canReadDoc(accessFromMeta(meta || {}), session, env, meta);
+}
+
 async function indexHtml(env, session, origin, nonce) {
   // Catalog is title/slug/version from KV meta only. Do NOT HEAD R2 or fold
   // comment logs here — that was N serial Durable-Object + R2 round trips
@@ -1495,37 +1598,89 @@ async function indexHtml(env, session, origin, nonce) {
   } while (cursor);
 
   const hosted = hostedRegistrationEnabled(env, origin);
-  const docs = (await Promise.all(list.map(async (k) => {
+  const catalog = await Promise.all(list.map(async (k) => {
     const slug = k.name.slice('meta:'.length);
     const metaRaw = await env.META.get(k.name);
     let meta = {};
     try { meta = JSON.parse(metaRaw || '{}'); } catch {}
-    const latest = meta.versions?.[meta.versions.length - 1]?.n || 1;
-    return { slug, title: meta.title || slug, latest, meta };
-  }))).filter((row) => {
+    const versions = Array.isArray(meta.versions) ? meta.versions : [];
+    const latest = versions[versions.length - 1]?.n || 1;
+    const created = meta.created || versions[0]?.created || '';
+    const updated = versions[versions.length - 1]?.created || created;
+    return { slug, title: meta.title || slug, latest, created, updated, meta };
+  }));
+  const docs = catalog.filter((row) => {
     if (hosted) return isDocOwnerSession(env, session, row.meta);
     // BYOK operator catalog: keep other people's hosted copies off the list (#146).
     const hostedLogin = hostedGithubLogin(row.meta);
     if (hostedLogin && hostedLogin !== sessionLogin(session)) return false;
     return true;
   });
+  // Newest activity first — the catalog default. The sort select re-orders
+  // client-side off each row's data-updated/data-created attributes.
+  docs.sort((a, b) => String(b.updated).localeCompare(String(a.updated)));
   const visible = docs;
 
-  const rows = visible.map(({ slug, title, latest }) => `<div class="doc-row" data-slug="${escapeHtml(slug)}" data-title="${escapeHtml(title)}">
+  // Viewer-scoped state: stars and recents may point at docs the viewer does
+  // not own (a colleague's shared doc). Rows render only for docs that still
+  // exist on this worker AND are still readable by this viewer.
+  const viewerLogin = sessionLogin(session);
+  const [starItems, recentItems, folderState] = viewerLogin
+    ? await Promise.all([loadStars(env, viewerLogin), loadRecents(env, viewerLogin), loadFolderState(env, viewerLogin)])
+    : [[], [], { folders: [], docs: {} }];
+  const bySlug = new Map(catalog.map((r) => [r.slug, r]));
+  const starredSet = new Set(starItems.map((i) => i.slug));
+  const readableRow = (slug) => {
+    const row = bySlug.get(slug);
+    return row && docReadableBy(env, session, row.meta) ? row : null;
+  };
+  const recentRows = recentItems
+    .map((i) => { const r = readableRow(i.slug); return r && { ...r, at: i.at }; })
+    .filter(Boolean);
+  const starRows = starItems
+    .map((i) => { const r = readableRow(i.slug); return r && { ...r, at: i.at }; })
+    .filter(Boolean);
+
+  const day = (iso) => (typeof iso === 'string' && iso.length >= 10 ? iso.slice(0, 10) : '');
+  const starBtn = (slug) => `<button class="star-btn${starredSet.has(slug) ? ' is-starred' : ''}" data-slug="${escapeHtml(slug)}" aria-pressed="${starredSet.has(slug)}" aria-label="${starredSet.has(slug) ? 'Unstar' : 'Star'} ${escapeHtml(slug)}">${starredSet.has(slug) ? '★' : '☆'}</button>`;
+
+  const rows = visible.map(({ slug, title, latest, created, updated }) => `<div class="doc-row" data-slug="${escapeHtml(slug)}" data-title="${escapeHtml(title)}" data-created="${escapeHtml(created)}" data-updated="${escapeHtml(updated)}" data-folder="${escapeHtml(folderState.docs[slug] || '')}">
       <label class="row-check">
         <input type="checkbox" class="doc-check" aria-label="Select ${escapeHtml(title)}">
       </label>
       <div class="doc-info">
         <a class="doc-title" href="/d/${encodeURIComponent(slug)}/v/${latest}">${escapeHtml(title)}</a>
-        <div class="doc-meta">${escapeHtml(slug)} · v${latest}</div>
+        <div class="doc-meta">${escapeHtml(slug)} · v${latest}${day(updated) ? ` · updated ${day(updated)}` : ''}</div>
       </div>
       <div class="row-actions">
+        ${starBtn(slug)}
         <button class="row-menu-btn" aria-label="More actions" aria-haspopup="true" aria-expanded="false">⋯</button>
         <div class="row-menu" hidden>
+          <button class="row-move" data-slug="${escapeHtml(slug)}" data-title="${escapeHtml(title)}">Move to folder…</button>
           <button class="row-delete" data-slug="${escapeHtml(slug)}" data-title="${escapeHtml(title)}">Delete…</button>
         </div>
       </div>
     </div>`);
+
+  // Recent / Starred panes: read-only rows (no select, no manage menu — the
+  // viewer may not own these docs), a byline for someone else's doc, and the
+  // same star toggle.
+  const flatRow = (row, label) => {
+    const owner = hostedGithubLogin(row.meta);
+    const by = owner && owner !== viewerLogin ? `by ${owner} · ` : '';
+    return `<div class="doc-row flat-row" data-slug="${escapeHtml(row.slug)}" data-title="${escapeHtml(row.title)}">
+      <div class="doc-info">
+        <a class="doc-title" href="/d/${encodeURIComponent(row.slug)}/v/${row.latest}">${escapeHtml(row.title)}</a>
+        <div class="doc-meta">${escapeHtml(by)}${label} ${day(row.at)}</div>
+      </div>
+      <div class="row-actions">${starBtn(row.slug)}</div>
+    </div>`;
+  };
+  const recentList = recentRows.map((r) => flatRow(r, 'visited')).join('');
+  const starList = starRows.map((r) => flatRow(r, 'starred')).join('');
+
+  const folderChips = folderState.folders.map((f) => `<button class="chip folder-chip" data-folder="${escapeHtml(f.id)}">${escapeHtml(f.name)}</button>`).join('');
+  const foldersJson = JSON.stringify(folderState.folders.map((f) => ({ id: f.id, name: f.name }))).replace(/</g, '\\u003c');
 
   return `<!doctype html><html><head><meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1"><title>My docs</title>
 <style>
@@ -1603,20 +1758,82 @@ async function indexHtml(env, session, origin, nonce) {
   .tdoc-modal button { padding: 8px 16px; border-radius: 6px; border: 1px solid #ccc; background: #fff; }
   .tdoc-modal button.danger { background: var(--td-danger); border-color: var(--td-danger); color: #fff; }
   .tdoc-modal button.danger:hover { background: var(--td-danger-hover); border-color: var(--td-danger-hover); }
+  .tdoc-modal input[type="text"] { width: 100%; box-sizing: border-box; font: inherit; padding: 8px 10px; border: 1px solid var(--td-line); border-radius: 8px; margin: 0 0 14px; }
+  .tdoc-modal input[type="text"]:focus { outline: 2px solid var(--td-accent-tint); border-color: var(--td-accent); }
+  /* Google-Docs-style views: My docs / Recent / Starred are pure visibility
+     switches over the already-rendered page — no fetch on tab change. */
+  .tabs { display: flex; gap: 4px; margin: 0 0 16px; border-bottom: 1px solid var(--td-line); }
+  .tab { border: none; background: none; font: inherit; font-weight: 600; color: var(--td-muted); padding: 8px 12px; border-bottom: 2px solid transparent; margin-bottom: -1px; }
+  .tab:hover { color: var(--td-ink); }
+  .tab.is-active { color: var(--td-accent); border-bottom-color: var(--td-accent); }
+  .pane[hidden] { display: none !important; }
+  .toolbar select { font: inherit; padding: 8px 10px; border: 1px solid var(--td-line); border-radius: 8px; background: #fff; color: var(--td-ink); }
+  .folder-bar { display: flex; flex-wrap: wrap; gap: 8px; align-items: center; margin: 0 0 12px; }
+  .chip { font: inherit; font-size: 13px; padding: 5px 12px; border-radius: 999px; border: 1px solid var(--td-line); background: #fff; color: var(--td-ink); }
+  .chip.is-active { background: var(--td-accent-tint); border-color: var(--td-accent); color: var(--td-accent); font-weight: 600; }
+  .chip.new-folder { color: var(--td-muted); border-style: dashed; }
+  .folder-tools { display: none; gap: 2px; }
+  .folder-tools.is-visible { display: inline-flex; }
+  .folder-tools button { font-size: 12px; border: none; background: none; color: var(--td-muted); padding: 4px 6px; border-radius: 6px; }
+  .folder-tools button:hover { background: var(--td-line); color: var(--td-ink); }
+  .star-btn { border: none; background: none; font-size: 17px; color: #ccc; padding: 2px 6px; border-radius: 6px; line-height: 1; }
+  .doc-row:hover .star-btn { color: var(--td-muted); }
+  .star-btn:hover { background: var(--td-line); color: #f5a623; }
+  .star-btn.is-starred, .doc-row:hover .star-btn.is-starred { color: #f5a623; }
+  .batch-actions { display: flex; gap: 8px; }
+  .batch-move { display: none; font: inherit; padding: 6px 12px; border-radius: 6px; border: 1px solid var(--td-accent); background: #fff; color: var(--td-accent); }
+  .batch-move.is-visible { display: inline-block; }
+  .batch-move:hover { background: var(--td-accent); color: #fff; }
+  .batch-move:disabled { opacity: 0.5; cursor: default; }
+  .row-move { display: block; width: 100%; text-align: left; border: none; background: none; color: var(--td-ink); padding: 8px 12px; border-radius: 6px; white-space: nowrap; }
+  .row-move:hover { background: var(--td-surface); }
+  .move-list { display: flex; flex-direction: column; gap: 4px; margin: 0 0 14px; max-height: 40vh; overflow: auto; }
+  .move-list button { text-align: left; padding: 8px 12px; border-radius: 6px; border: 1px solid var(--td-line); background: #fff; }
+  .move-list button:hover { background: var(--td-accent-tint); border-color: var(--td-accent); }
 </style>
 </head><body>
 <div class="wrap">
 <div class="page-hd"><h1>My docs</h1><button class="mk-btn" id="mk-open" type="button">Create a doc</button></div>
+<div class="tabs" role="tablist">
+  <button type="button" class="tab is-active" data-pane="pane-mine" role="tab" aria-selected="true">My docs</button>
+  <button type="button" class="tab" data-pane="pane-recent" role="tab" aria-selected="false">Recent</button>
+  <button type="button" class="tab" data-pane="pane-starred" role="tab" aria-selected="false">Starred</button>
+</div>
+<section class="pane" id="pane-mine">
 ${rows.length === 0 ? '<p class="empty">No published docs yet. Hit <b>Create a doc</b> to see how, or <a href="/templates">browse templates</a> for a look to start from.</p>' :
   `<div class="toolbar">
     <input type="search" id="doc-search" placeholder="Search title or slug…" autocomplete="off" aria-label="Search docs">
+    <select id="doc-sort" aria-label="Sort docs">
+      <option value="updated">Last updated</option>
+      <option value="created">Created</option>
+      <option value="title">Title</option>
+    </select>
+  </div>
+  <div class="folder-bar" id="folder-bar">
+    <button type="button" class="chip is-active" data-folder="">All docs</button>
+    ${folderChips}
+    <button type="button" class="chip new-folder" id="new-folder">+ New folder</button>
+    <span class="folder-tools" id="folder-tools">
+      <button type="button" id="folder-rename">Rename</button>
+      <button type="button" id="folder-delete">Delete folder</button>
+    </span>
   </div>
   <div class="batch-bar">
     <label class="select-all"><input type="checkbox" id="select-all"> <span id="select-all-label">Select all</span></label>
-    <button type="button" id="batch-delete" class="batch-delete">Delete selected</button>
+    <span class="batch-actions">
+      <button type="button" id="batch-move" class="batch-move">Move</button>
+      <button type="button" id="batch-delete" class="batch-delete">Delete selected</button>
+    </span>
   </div>
   <div class="doc-list">${rows.join('')}</div>
   <p id="no-match" class="empty" hidden>No matches.</p>`}
+</section>
+<section class="pane" id="pane-recent" hidden>
+  ${recentList ? `<div class="doc-list">${recentList}</div>` : '<p class="empty">Docs you open show up here.</p>'}
+</section>
+<section class="pane" id="pane-starred" hidden>
+  ${starList ? `<div class="doc-list">${starList}</div>` : '<p class="empty">Star docs to find them again quickly.</p>'}
+</section>
 </div>
 
 <div class="mk-bg" id="mk-bg" hidden>
@@ -1646,6 +1863,66 @@ ${rows.length === 0 ? '<p class="empty">No published docs yet. Hit <b>Create a d
     document.getElementById('mk-x').onclick = function () { show(false); };
     bg.addEventListener('click', function (e) { if (e.target === bg) show(false); });
     document.addEventListener('keydown', function (e) { if (e.key === 'Escape' && !bg.hidden) show(false); });
+  })();
+
+  // Tabs + stars — wired independently of the catalog block below, which
+  // bails out early when the viewer has no docs of their own (Recent and
+  // Starred can still have rows in that case).
+  (function () {
+    var tabs = Array.prototype.slice.call(document.querySelectorAll('.tab'));
+    tabs.forEach(function (tab) {
+      tab.addEventListener('click', function () {
+        tabs.forEach(function (t) {
+          var active = t === tab;
+          t.classList.toggle('is-active', active);
+          t.setAttribute('aria-selected', String(active));
+          var pane = document.getElementById(t.dataset.pane);
+          if (pane) pane.hidden = !active;
+        });
+      });
+    });
+
+    // Star toggle: optimistic flip (every button for the same slug, across
+    // panes), revert on failure. Session cookie authorizes /api/star.
+    function paintStar(slug, on) {
+      document.querySelectorAll('.star-btn').forEach(function (b) {
+        if (b.dataset.slug !== slug) return;
+        b.classList.toggle('is-starred', on);
+        b.textContent = on ? '★' : '☆';
+        b.setAttribute('aria-pressed', String(on));
+      });
+    }
+    document.addEventListener('click', async function (e) {
+      var btn = e.target && e.target.closest ? e.target.closest('.star-btn') : null;
+      if (!btn) return;
+      e.stopPropagation();
+      var slug = btn.dataset.slug;
+      var starred = !btn.classList.contains('is-starred');
+      paintStar(slug, starred);
+      try {
+        var res = await fetch('/api/star', {
+          method: 'POST',
+          credentials: 'same-origin',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ slug: slug, starred: starred }),
+        });
+        if (!res.ok) throw new Error('HTTP ' + res.status);
+        if (!starred) {
+          // Unstarring from the Starred pane removes the row right away.
+          var pane = document.getElementById('pane-starred');
+          if (pane) {
+            pane.querySelectorAll('.doc-row').forEach(function (row) {
+              if (row.dataset.slug === slug) row.remove();
+            });
+            if (!pane.querySelector('.doc-row')) {
+              pane.innerHTML = '<p class="empty">Star docs to find them again quickly.</p>';
+            }
+          }
+        }
+      } catch (err) {
+        paintStar(slug, !starred);
+      }
+    });
   })();
 
 (() => {
@@ -1686,6 +1963,79 @@ ${rows.length === 0 ? '<p class="empty">No published docs yet. Hit <b>Create a d
       goBtn.onclick = () => done(true);
       document.body.appendChild(bg);
     });
+  }
+  // Styled text prompt (folder names) — same modal chrome as showConfirm.
+  // Resolves the trimmed value, or null on cancel/backdrop.
+  function showPrompt({ title, confirmLabel, value = '', placeholder = '' }) {
+    return new Promise((resolve) => {
+      const bg = document.createElement('div');
+      bg.className = 'tdoc-modal-bg';
+      bg.innerHTML = '<div class="tdoc-modal">' +
+        '<h3></h3><input type="text" maxlength="60">' +
+        '<div class="actions">' +
+          '<button type="button" data-act="cancel">Cancel</button>' +
+          '<button type="button" data-act="go"></button>' +
+        '</div></div>';
+      bg.querySelector('h3').textContent = title;
+      const input = bg.querySelector('input');
+      input.value = value;
+      input.placeholder = placeholder;
+      bg.querySelector('[data-act="go"]').textContent = confirmLabel;
+      const done = (v) => { bg.remove(); resolve(v); };
+      const go = () => { const v = input.value.trim(); if (v) done(v); };
+      bg.querySelector('[data-act="cancel"]').onclick = () => done(null);
+      bg.querySelector('[data-act="go"]').onclick = go;
+      bg.addEventListener('click', (e) => { if (e.target === bg) done(null); });
+      input.addEventListener('keydown', (e) => { if (e.key === 'Enter') go(); });
+      document.body.appendChild(bg);
+      input.focus();
+    });
+  }
+  // Folder picker for Move — a button per destination, DOM-built (no
+  // innerHTML with user-named folders). Resolves {folder} or null.
+  function pickFolder(title) {
+    return new Promise((resolve) => {
+      const bg = document.createElement('div');
+      bg.className = 'tdoc-modal-bg';
+      const box = document.createElement('div');
+      box.className = 'tdoc-modal';
+      const h = document.createElement('h3');
+      h.textContent = title;
+      box.appendChild(h);
+      const done = (v) => { bg.remove(); resolve(v); };
+      const listBox = document.createElement('div');
+      listBox.className = 'move-list';
+      const add = (id, name) => {
+        const b = document.createElement('button');
+        b.type = 'button';
+        b.textContent = name;
+        b.onclick = () => done({ folder: id });
+        listBox.appendChild(b);
+      };
+      add('', 'All docs (no folder)');
+      FOLDERS.forEach((f) => add(f.id, f.name));
+      box.appendChild(listBox);
+      const actions = document.createElement('div');
+      actions.className = 'actions';
+      const cancel = document.createElement('button');
+      cancel.type = 'button';
+      cancel.textContent = 'Cancel';
+      cancel.onclick = () => done(null);
+      actions.appendChild(cancel);
+      box.appendChild(actions);
+      bg.appendChild(box);
+      bg.addEventListener('click', (e) => { if (e.target === bg) done(null); });
+      document.body.appendChild(bg);
+    });
+  }
+  async function moveDocs(slugs, folder) {
+    const res = await fetch('/api/folders/move', {
+      method: 'POST',
+      credentials: 'same-origin',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ slugs, folder: folder || null }),
+    });
+    if (!res.ok) throw new Error('HTTP ' + res.status);
   }
   // ⋯ overflow menu — one open at a time; a click anywhere else closes it.
   function closeMenus(except) {
@@ -1751,13 +2101,16 @@ ${rows.length === 0 ? '<p class="empty">No published docs yet. Hit <b>Create a d
 
   // Search + batch select — client-side only over the already-rendered rows.
   // No access data, no extra KV/R2; keep the catalog fast (#115).
-  const listEl = document.querySelector('.doc-list');
+  const listEl = document.querySelector('#pane-mine .doc-list');
   if (!listEl) return;
   const search = document.getElementById('doc-search');
   const selectAll = document.getElementById('select-all');
   const selectAllLabel = document.getElementById('select-all-label');
   const batchDelete = document.getElementById('batch-delete');
+  const batchMove = document.getElementById('batch-move');
   const noMatch = document.getElementById('no-match');
+  const FOLDERS = ${foldersJson};
+  let activeFolder = '';
 
   function visibleRows() {
     return Array.from(listEl.querySelectorAll('.doc-row')).filter((row) => !row.hidden);
@@ -1779,6 +2132,8 @@ ${rows.length === 0 ? '<p class="empty">No published docs yet. Hit <b>Create a d
     });
     batchDelete.classList.toggle('is-visible', n > 0);
     batchDelete.textContent = n <= 1 ? 'Delete' : ('Delete ' + n);
+    batchMove.classList.toggle('is-visible', n > 0);
+    batchMove.textContent = n <= 1 ? 'Move' : ('Move ' + n);
     const allVisibleChecked = visible.length > 0 && visible.every((row) => {
       const box = row.querySelector('.doc-check');
       return box && box.checked;
@@ -1804,7 +2159,8 @@ ${rows.length === 0 ? '<p class="empty">No published docs yet. Hit <b>Create a d
     let shown = 0;
     listEl.querySelectorAll('.doc-row').forEach((row) => {
       const hay = ((row.dataset.title || '') + ' ' + (row.dataset.slug || '')).toLowerCase();
-      const match = !q || hay.includes(q);
+      const inFolder = !activeFolder || (row.dataset.folder || '') === activeFolder;
+      const match = (!q || hay.includes(q)) && inFolder;
       row.hidden = !match;
       if (match) shown += 1;
       else {
@@ -1857,6 +2213,123 @@ ${rows.length === 0 ? '<p class="empty">No published docs yet. Hit <b>Create a d
     if (failed && ok) toast("Deleted " + ok + " · couldn't delete " + failed, 'error');
     else if (failed) toast("Couldn't delete", 'error');
     else toast('Deleted');
+  });
+
+  // Sort — re-orders the rendered rows off their data attributes; the server
+  // default is last-updated-first, matching the select's initial value.
+  const sortSel = document.getElementById('doc-sort');
+  sortSel.addEventListener('change', () => {
+    const key = sortSel.value;
+    const all = Array.from(listEl.querySelectorAll('.doc-row'));
+    all.sort((a, b) => {
+      if (key === 'title') {
+        return (a.dataset.title || '').localeCompare(b.dataset.title || '', undefined, { sensitivity: 'base' });
+      }
+      return (b.dataset[key] || '').localeCompare(a.dataset[key] || '');
+    });
+    all.forEach((row) => listEl.appendChild(row));
+  });
+
+  // Folders — chips filter the list; the ⋯ menu and the batch bar move docs.
+  // Create/rename/delete reload the page (the chip row and FOLDERS list are
+  // server-rendered); move updates rows in place.
+  const folderBar = document.getElementById('folder-bar');
+  const folderTools = document.getElementById('folder-tools');
+  function setFolder(id) {
+    activeFolder = id;
+    folderBar.querySelectorAll('.chip[data-folder]').forEach((c) => {
+      c.classList.toggle('is-active', c.dataset.folder === id);
+    });
+    folderTools.classList.toggle('is-visible', !!id);
+    applySearch();
+  }
+  folderBar.addEventListener('click', (e) => {
+    const chip = e.target && e.target.closest ? e.target.closest('.chip[data-folder]') : null;
+    if (chip) setFolder(chip.dataset.folder);
+  });
+  document.getElementById('new-folder').addEventListener('click', async () => {
+    const name = await showPrompt({ title: 'New folder', confirmLabel: 'Create', placeholder: 'Folder name' });
+    if (!name) return;
+    const res = await fetch('/api/folders', {
+      method: 'POST',
+      credentials: 'same-origin',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name }),
+    });
+    if (!res.ok) { toast("Couldn't create folder", 'error'); return; }
+    location.reload();
+  });
+  document.getElementById('folder-rename').addEventListener('click', async () => {
+    if (!activeFolder) return;
+    const cur = FOLDERS.find((f) => f.id === activeFolder);
+    const name = await showPrompt({ title: 'Rename folder', confirmLabel: 'Rename', value: cur ? cur.name : '' });
+    if (!name) return;
+    const res = await fetch('/api/folders', {
+      method: 'PATCH',
+      credentials: 'same-origin',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ id: activeFolder, name }),
+    });
+    if (!res.ok) { toast("Couldn't rename folder", 'error'); return; }
+    location.reload();
+  });
+  document.getElementById('folder-delete').addEventListener('click', async () => {
+    if (!activeFolder) return;
+    const cur = FOLDERS.find((f) => f.id === activeFolder);
+    const proceed = await showConfirm({
+      title: 'Delete folder "' + ((cur && cur.name) || '') + '"?',
+      body: 'Docs inside go back to All docs. No documents are deleted.',
+      confirmLabel: 'Delete folder',
+      danger: true,
+    });
+    if (!proceed) return;
+    const res = await fetch('/api/folders?id=' + encodeURIComponent(activeFolder), {
+      method: 'DELETE',
+      credentials: 'same-origin',
+    });
+    if (!res.ok) { toast("Couldn't delete folder", 'error'); return; }
+    location.reload();
+  });
+  document.querySelectorAll('.row-move').forEach((button) => {
+    button.addEventListener('click', async () => {
+      closeMenus(null);
+      const pick = await pickFolder('Move "' + (button.dataset.title || button.dataset.slug) + '" to…');
+      if (!pick) return;
+      try {
+        await moveDocs([button.dataset.slug], pick.folder);
+      } catch {
+        toast("Couldn't move", 'error');
+        return;
+      }
+      const row = button.closest('.doc-row');
+      row.dataset.folder = pick.folder || '';
+      applySearch();
+      toast('Moved');
+    });
+  });
+  batchMove.addEventListener('click', async () => {
+    const rows = selectedRows();
+    if (!rows.length) return;
+    const pick = await pickFolder(rows.length === 1
+      ? ('Move "' + (rows[0].dataset.title || rows[0].dataset.slug) + '" to…')
+      : ('Move ' + rows.length + ' docs to…'));
+    if (!pick) return;
+    batchMove.disabled = true;
+    try {
+      await moveDocs(rows.map((row) => row.dataset.slug), pick.folder);
+    } catch {
+      batchMove.disabled = false;
+      toast("Couldn't move", 'error');
+      return;
+    }
+    batchMove.disabled = false;
+    rows.forEach((row) => {
+      row.dataset.folder = pick.folder || '';
+      const box = row.querySelector('.doc-check');
+      if (box) box.checked = false;
+    });
+    applySearch();
+    toast('Moved');
   });
   syncBatchUi();
 })();
@@ -3385,6 +3858,15 @@ export default {
     if (docMatch && (method === 'GET' || method === 'HEAD')) {
       const [, slug, vStr] = docMatch;
       const res = await serveDocVersion(env, req, slug, Number(vStr));
+      // Google-Docs-style recents: remember the visit — owned or not — for
+      // the signed-in viewer's /me Recent tab. Only successful reads count
+      // (the access gate already passed), HEAD probes and anonymous readers
+      // don't, and the KV write never blocks the response.
+      if (res.ok && method === 'GET' && sessionLogin(res.session)) {
+        const record = recordDocVisit(env, res.session.login, slug).catch(() => {});
+        if (ctx && typeof ctx.waitUntil === 'function') ctx.waitUntil(record);
+        else await record;
+      }
       return res.response;
     }
 
@@ -3754,6 +4236,108 @@ export default {
       inbox = markInboxRead(inbox, { ids: body.ids, comment_id: body.comment_id });
       await env.META.put(key, JSON.stringify(inbox));
       return json({ ok: true, unread: inboxUnread(inbox) });
+    }
+
+    // ---- personal docs state (stars / folders) ----
+    // Viewer-scoped, cookie-authorized: stars follow the signed-in reader
+    // across any doc they can read; folders organize only their own catalog.
+    // No cross-user state is ever touched — each login mutates its own
+    // stars:<login> / folders:<login> KV value.
+    if (p === '/api/star' && method === 'POST') {
+      const s = await getSession(env, req);
+      if (!sessionLogin(s)) return json({ error: 'sign_in_required' }, { status: 401 });
+      let body = {};
+      try { body = await req.json(); } catch {}
+      const slug = body.slug;
+      const starred = !!body.starred;
+      if (!slug || !isValidSlug(slug)) return json({ error: 'invalid_slug' }, { status: 400 });
+      if (starred) {
+        // Star only docs that exist here and that this viewer can read —
+        // otherwise /api/star is an existence oracle for private slugs.
+        const meta = await loadDocMeta(env, slug);
+        if (!meta || !docReadableBy(env, s, meta)) return json({ error: 'not_found' }, { status: 404 });
+      }
+      await setDocStar(env, s.login, slug, starred);
+      return json({ ok: true, slug, starred });
+    }
+
+    if (p === '/api/folders' && method === 'POST') {
+      const s = await getSession(env, req);
+      if (!sessionLogin(s)) return json({ error: 'sign_in_required' }, { status: 401 });
+      let body = {};
+      try { body = await req.json(); } catch {}
+      const name = validFolderName(body.name);
+      if (!name) return json({ error: 'invalid_name' }, { status: 400 });
+      const state = await loadFolderState(env, s.login);
+      if (state.folders.length >= FOLDERS_MAX) return json({ error: 'too_many_folders' }, { status: 400 });
+      if (state.folders.some((f) => f.name.toLowerCase() === name.toLowerCase())) {
+        return json({ error: 'duplicate_name' }, { status: 400 });
+      }
+      const folder = { id: `f_${Date.now()}_${rand(4)}`, name, created: new Date().toISOString() };
+      state.folders.push(folder);
+      await saveFolderState(env, s.login, state);
+      return json({ ok: true, folder: { id: folder.id, name: folder.name } });
+    }
+
+    if (p === '/api/folders' && method === 'PATCH') {
+      const s = await getSession(env, req);
+      if (!sessionLogin(s)) return json({ error: 'sign_in_required' }, { status: 401 });
+      let body = {};
+      try { body = await req.json(); } catch {}
+      const name = validFolderName(body.name);
+      if (!name) return json({ error: 'invalid_name' }, { status: 400 });
+      const state = await loadFolderState(env, s.login);
+      const folder = state.folders.find((f) => f.id === body.id);
+      if (!folder) return json({ error: 'not_found' }, { status: 404 });
+      if (state.folders.some((f) => f !== folder && f.name.toLowerCase() === name.toLowerCase())) {
+        return json({ error: 'duplicate_name' }, { status: 400 });
+      }
+      folder.name = name;
+      await saveFolderState(env, s.login, state);
+      return json({ ok: true, folder: { id: folder.id, name: folder.name } });
+    }
+
+    if (p === '/api/folders' && method === 'DELETE') {
+      const s = await getSession(env, req);
+      if (!sessionLogin(s)) return json({ error: 'sign_in_required' }, { status: 401 });
+      const id = url.searchParams.get('id');
+      const state = await loadFolderState(env, s.login);
+      if (!state.folders.some((f) => f.id === id)) return json({ error: 'not_found' }, { status: 404 });
+      state.folders = state.folders.filter((f) => f.id !== id);
+      // normalizeFolderState in the save path drops the now-orphaned doc
+      // mappings, so the docs fall back to the root ("All docs").
+      await saveFolderState(env, s.login, state);
+      return json({ ok: true });
+    }
+
+    if (p === '/api/folders/move' && method === 'POST') {
+      const s = await getSession(env, req);
+      if (!sessionLogin(s)) return json({ error: 'sign_in_required' }, { status: 401 });
+      let body = {};
+      try { body = await req.json(); } catch {}
+      const folderId = body.folder == null ? null : String(body.folder);
+      const slugs = Array.isArray(body.slugs) ? body.slugs : [];
+      if (!slugs.length || slugs.length > 100 || !slugs.every((x) => typeof x === 'string' && isValidSlug(x))) {
+        return json({ error: 'invalid_slugs' }, { status: 400 });
+      }
+      const state = await loadFolderState(env, s.login);
+      if (folderId && !state.folders.some((f) => f.id === folderId)) {
+        return json({ error: 'folder_not_found' }, { status: 404 });
+      }
+      // Folders shelve the viewer's OWN catalog — moving someone else's doc
+      // is meaningless here and refused rather than silently recorded.
+      for (const slug of slugs) {
+        const meta = await loadDocMeta(env, slug);
+        if (!meta || !isDocOwnerSession(env, s, meta)) {
+          return json({ error: 'not_owner', slug }, { status: 403 });
+        }
+      }
+      for (const slug of slugs) {
+        if (folderId) state.docs[slug] = folderId;
+        else delete state.docs[slug];
+      }
+      await saveFolderState(env, s.login, state);
+      return json({ ok: true, moved: slugs.length, folder: folderId });
     }
 
     // ---- hosted publish token bootstrap ----

--- a/worker/worker.js
+++ b/worker/worker.js
@@ -1901,6 +1901,11 @@ ${rows.length === 0 ? '<p class="empty">No published docs yet. Hit <b>Create a d
 
     // Star toggle: optimistic flip (every button for the same slug, across
     // panes), revert on failure. Session cookie authorizes /api/star.
+    // One BroadcastChannel instance for this page: posts our own star changes
+    // (so open doc tabs repaint their bar star) and hears other tabs' changes
+    // (a channel never delivers a message back to the instance that sent it).
+    var channel = null;
+    try { channel = new BroadcastChannel('tdoc-doc-state'); } catch (e) {}
     function paintStar(slug, on) {
       document.querySelectorAll('.star-btn').forEach(function (b) {
         if (b.dataset.slug !== slug) return;
@@ -1908,6 +1913,54 @@ ${rows.length === 0 ? '<p class="empty">No published docs yet. Hit <b>Create a d
         b.textContent = on ? '★' : '☆';
         b.setAttribute('aria-pressed', String(on));
       });
+    }
+    function starredEmpty(pane) {
+      if (!pane.querySelector('.doc-row')) {
+        pane.innerHTML = '<p class="empty">Star docs to find them again quickly.</p>';
+      }
+    }
+    // A fresh star must show up when the user flips to the Starred tab NOW —
+    // the server render is behind us. Clone the essentials from any rendered
+    // row for that slug (My docs or Recent) into a flat row, DOM-built.
+    function addToStarredPane(slug) {
+      var pane = document.getElementById('pane-starred');
+      if (!pane) return;
+      var rows = Array.prototype.slice.call(document.querySelectorAll('.doc-row'));
+      if (rows.some(function (r) { return r.dataset.slug === slug && pane.contains(r); })) return;
+      var src = null;
+      rows.forEach(function (r) { if (!src && r.dataset.slug === slug && r.querySelector('.doc-title')) src = r; });
+      if (!src) return;
+      var list = pane.querySelector('.doc-list');
+      if (!list) {
+        pane.innerHTML = '<div class="doc-list"></div>';
+        list = pane.querySelector('.doc-list');
+      }
+      var row = document.createElement('div');
+      row.className = 'doc-row flat-row';
+      row.dataset.slug = slug;
+      row.dataset.title = src.dataset.title || slug;
+      var info = document.createElement('div');
+      info.className = 'doc-info';
+      var a = document.createElement('a');
+      a.className = 'doc-title';
+      a.href = src.querySelector('.doc-title').href;
+      a.textContent = src.dataset.title || slug;
+      var meta = document.createElement('div');
+      meta.className = 'doc-meta';
+      meta.textContent = 'starred ' + new Date().toISOString().slice(0, 10);
+      info.appendChild(a);
+      info.appendChild(meta);
+      var actions = document.createElement('div');
+      actions.className = 'row-actions';
+      var b = document.createElement('button');
+      b.className = 'star-btn is-starred';
+      b.dataset.slug = slug;
+      b.setAttribute('aria-pressed', 'true');
+      b.textContent = '★';
+      actions.appendChild(b);
+      row.appendChild(info);
+      row.appendChild(actions);
+      list.insertBefore(row, list.firstChild);
     }
     document.addEventListener('click', async function (e) {
       var btn = e.target && e.target.closest ? e.target.closest('.star-btn') : null;
@@ -1924,21 +1977,36 @@ ${rows.length === 0 ? '<p class="empty">No published docs yet. Hit <b>Create a d
           body: JSON.stringify({ slug: slug, starred: starred }),
         });
         if (!res.ok) throw new Error('HTTP ' + res.status);
-        if (!starred) {
-          // Unstarring from the Starred pane removes the row right away.
-          var pane = document.getElementById('pane-starred');
-          if (pane) {
-            pane.querySelectorAll('.doc-row').forEach(function (row) {
-              if (row.dataset.slug === slug) row.remove();
-            });
-            if (!pane.querySelector('.doc-row')) {
-              pane.innerHTML = '<p class="empty">Star docs to find them again quickly.</p>';
-            }
-          }
+        var pane = document.getElementById('pane-starred');
+        if (starred) {
+          addToStarredPane(slug);
+        } else if (pane) {
+          // Unstarring removes the row from the Starred pane right away.
+          pane.querySelectorAll('.doc-row').forEach(function (row) {
+            if (row.dataset.slug === slug) row.remove();
+          });
+          starredEmpty(pane);
         }
+        if (channel) { try { channel.postMessage({ type: 'star', slug: slug, starred: starred }); } catch (e2) {} }
       } catch (err) {
         paintStar(slug, !starred);
       }
+    });
+
+    // Server-rendered pages go stale two ways: a bfcache Back into an old
+    // copy, and star changes made from a doc page in another tab. Reload on
+    // both signals (deferred to the next focus while hidden) — this page has
+    // no client data layer to patch instead (deliberate; see issue #287).
+    var stale = false;
+    window.addEventListener('pageshow', function (e) { if (e.persisted) location.reload(); });
+    if (channel) channel.addEventListener('message', function (ev) {
+      var d = ev.data || {};
+      if (d.type !== 'star') return;
+      if (document.hidden) stale = true;
+      else location.reload();
+    });
+    document.addEventListener('visibilitychange', function () {
+      if (!document.hidden && stale) location.reload();
     });
   })();
 

--- a/worker/wrangler.preview.toml.template
+++ b/worker/wrangler.preview.toml.template
@@ -24,7 +24,10 @@ id = "PLACEHOLDER_PREVIEW_KV_ID"
 
 [vars]
 GITHUB_CLIENT_ID = "Ov23liZ1UAGOchvKPmlS"
-TDOC_OWNER = ""
+# Owner login so /me is reviewable on previews: device-code sign-in as this
+# GitHub user unlocks the BYOK operator catalog (all docs on the preview
+# worker). Hosted registration stays off — nobody else can mint tokens here.
+TDOC_OWNER = "yayashuxue"
 # KV writes get a 14-day TTL in worker.js when this is "1".
 # R2 objects expire via the bucket lifecycle rule expire-preview-14d.
 TDOC_PREVIEW = "1"


### PR DESCRIPTION
## What

Google-Docs-style catalog experience on `/me`, requested as: time sorting, folder move, recently-visited docs (including docs the viewer didn't author), and starred docs.

## How

All new state is **per-user KV** (`stars:<login>` / `recents:<login>` / `folders:<login>`), the same shape discipline as the notifications inbox — capped JSON lists, get→mutate→put, only the four KV ops the Vercel shim implements.

- **Time sorting** — the catalog now defaults to last-updated-first (previously KV key order = alphabetical). Rows carry `data-updated`/`data-created`; a sort select re-orders client-side (Last updated / Created / Title), and the row meta line shows the update day.
- **Recent** — a successful signed-in GET of `/d/:slug/v/:n` records the visit through `ctx.waitUntil` (deduped by slug, capped at 30, 5-minute reload debounce, never blocks the response). The Recent tab lists visited docs — owned or not — with a `by <owner>` byline. Anonymous readers, HEAD probes, landing renders, and access-denied requests record nothing.
- **Starred** — a ☆/★ toggle on every row across all three tabs + `POST /api/star`. Starring only accepts docs the viewer can read (404 otherwise, so the endpoint is not an existence oracle for private slugs).
- **Folders** — personal folders over the viewer's own catalog: chips filter the list, the ⋯ row menu and the batch bar move docs (`/api/folders` create/rename/delete + `/api/folders/move`). Deleting a folder returns its docs to All docs; moving a doc you don't own is refused (403).

Recent/Starred rows render only for docs that still exist **and** are still readable by the viewer. The readability check lives outside `indexHtml` (`docReadableBy`) so the catalog renderer still never touches access data — the `me-management.test.js` gate stays intact.

## Tests

- New `test/me-docs-experience.test.js`: fake-bindings behavioral suite (8 tests) covering sort order, visit recording + negative cases, star round-trip + auth, unreadable-doc hiding, and folder CRUD/move/ownership. Registered in the OFFLINE list.
- All 46 offline suites green; `bin/tdoc-bundle` builds and the bundle parses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)