### PR TITLE
Figures line up with the text column, and the validator checks it

### DIFF
--- a/authoring/visuals.md
+++ b/authoring/visuals.md
@@ -49,6 +49,33 @@ black bars on white with one accent; in `paper` it is clay bars on warm
 paper; in `technical` it flips with the theme. Same chart type, styled per
 style.
 
+## Draw to the edge of the viewBox
+
+A figure sits in the same column as the prose, so its drawing has to start
+where the text starts. The viewBox is the frame, not a mat: padding baked into
+it pushes the ink inward and the figure reads as indented against every
+paragraph around it.
+
+Set the viewBox to the drawing's own bounds. If the leftmost stroke is at
+`x=14`, the viewBox starts at 14 — not at 0 with fourteen units of nothing.
+Space between a figure and the text above it is the job of CSS margin on the
+wrapper, where it applies to the box rather than the picture inside it.
+
+Two failures, both invisible until a phone narrows the column:
+
+- **Baked padding.** `viewBox="0 0 120 64"` around ink that spans `x=34..86`
+  wastes 28% of the width on each side. At a 164px card that is 46px of
+  indent, against a paragraph that starts at 0.
+- **Ragged starts across a set.** A row of glyphs drawn one at a time ends up
+  with each one starting somewhere different — 6, 14, 20, 34 — and the row
+  reads as broken even though every figure is individually fine. Draw a set on
+  one geometry: same left edge, same right edge, same optical weight.
+
+`bin/tdoc-validate-template` fails a figure whose ink starts more than 10% of
+the width inside its own box, for the shapes it can parse. It cannot see
+inside a `<path>`, so a hand-drawn arrow figure is on you: check that the
+left-hand ink is flush before shipping it.
+
 ## Keep them commentable and responsive
 
 Wrap wide charts in `<div class="diagram-box">` (or `tdoc-table-scroll` for

--- a/bin/tdoc-validate-template
+++ b/bin/tdoc-validate-template
@@ -213,34 +213,80 @@ def _attr(tag, name, default=0.0):
     return float(m.group(1)) if m else default
 
 
+# Shapes whose extents this parser can compute exactly. A figure containing
+# anything else — a <path>, a <use>, an <image> — has geometry we cannot read,
+# so the inset check skips it rather than guessing. Overflow is still checked
+# from whatever shapes are present, which is how it has always behaved.
+_OPAQUE_TAGS = ("<path", "<use", "<image", "<foreignObject", "<textPath")
+
+
+def _points_x(tag):
+    m = re.search(r'points="([^"]+)"', tag)
+    if not m:
+        return []
+    nums = [float(n) for n in re.findall(r"-?\d+(?:\.\d+)?", m.group(1))]
+    return nums[0::2]
+
+
 def check_svg_bounds(html):
-    """Nothing may be clipped by its own viewBox."""
+    """Nothing may be clipped by its own viewBox, and nothing may float inside it.
+
+    Two separate faults. Overflow clips the drawing. Baked padding is the
+    quieter one: a viewBox larger than its ink indents the figure against the
+    prose column, and only shows once a narrow screen shrinks the column.
+    """
     errors = []
-    for m in re.finditer(r'<svg[^>]*viewBox="0 0 ([\d.]+) ([\d.]+)"(.*?)</svg>', html, re.S):
-        vw, vh, body = float(m.group(1)), float(m.group(2)), m.group(3)
+    for m in re.finditer(
+        r'<svg[^>]*viewBox="\s*(-?[\d.]+)[\s,]+(-?[\d.]+)[\s,]+([\d.]+)[\s,]+([\d.]+)\s*"(.*?)</svg>',
+        html, re.S,
+    ):
+        vx, vy, vw, vh = (float(m.group(i)) for i in range(1, 5))
+        body = m.group(5)
         label = re.search(r'aria-label="([^"]*)"', m.group(0))
         name = label.group(1)[:44] if label else "unlabelled figure"
         tr = re.search(r'<g transform="translate\(([-\d.]+),\s*([-\d.]+)\)"', body)
         ox, oy = (float(tr.group(1)), float(tr.group(2))) if tr else (0.0, 0.0)
-        mx = my = 0.0
+
+        xs, ys = [], []
         for r in re.finditer(r"<rect[^>]*>", body):
             tag = r.group(0)
-            mx = max(mx, _attr(tag, "x") + _attr(tag, "width"))
-            my = max(my, _attr(tag, "y") + _attr(tag, "height"))
+            x, y = _attr(tag, "x"), _attr(tag, "y")
+            xs += [x, x + _attr(tag, "width")]
+            ys += [y, y + _attr(tag, "height")]
         for c in re.finditer(r"<circle[^>]*>", body):
             tag = c.group(0)
-            mx = max(mx, _attr(tag, "cx") + _attr(tag, "r"))
-            my = max(my, _attr(tag, "cy") + _attr(tag, "r"))
+            cx, cy, rr = _attr(tag, "cx"), _attr(tag, "cy"), _attr(tag, "r")
+            xs += [cx - rr, cx + rr]
+            ys += [cy - rr, cy + rr]
         for L in re.finditer(r"<line[^>]*>", body):
             tag = L.group(0)
-            mx = max(mx, _attr(tag, "x1"), _attr(tag, "x2"))
-            my = max(my, _attr(tag, "y1"), _attr(tag, "y2"))
-        mx += ox
-        my += oy
-        if mx > vw + 0.5:
-            errors.append("figure '%s' overflows its viewBox by %dpx across" % (name, round(mx - vw)))
-        if my > vh + 0.5:
-            errors.append("figure '%s' overflows its viewBox by %dpx down" % (name, round(my - vh)))
+            xs += [_attr(tag, "x1"), _attr(tag, "x2")]
+            ys += [_attr(tag, "y1"), _attr(tag, "y2")]
+        for poly in re.finditer(r"<(?:polyline|polygon)[^>]*>", body):
+            xs += _points_x(poly.group(0))
+
+        if not xs:
+            continue
+        mx, my = max(xs) + ox, (max(ys) + oy if ys else 0.0)
+        if mx > vx + vw + 0.5:
+            errors.append("figure '%s' overflows its viewBox by %dpx across" % (name, round(mx - vx - vw)))
+        if ys and my > vy + vh + 0.5:
+            errors.append("figure '%s' overflows its viewBox by %dpx down" % (name, round(my - vy - vh)))
+
+        # A <text> without an explicit anchor starts at its x, so it bounds the
+        # ink on the left. text-anchor="middle" or "end" puts glyphs left of x,
+        # which we cannot measure, so those figures opt out of the inset check.
+        if any(t in body for t in _OPAQUE_TAGS) or 'text-anchor=' in body:
+            continue
+        for t in re.finditer(r"<text[^>]*>", body):
+            xs.append(_attr(t.group(0), "x"))
+        left = (min(xs) + ox) - vx
+        if left > vw * 0.10:
+            errors.append(
+                "figure '%s' starts %d%% inside its own viewBox; set the viewBox to the "
+                "drawing's bounds so the figure lines up with the text column"
+                % (name, round(100 * left / vw))
+            )
     return errors
 
 

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -138,6 +138,52 @@ t('tdoc default-template validator accepts scoped widget CSS', () => {
   }
 });
 
+t('validator rejects a figure whose ink floats inside its own viewBox', () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'tdoc-viewbox-'));
+  const page = (svg) => `<!doctype html><html><head>
+      <meta name="viewport" content="width=device-width, initial-scale=1">
+      <style>body { background: #fff; }</style>
+      </head><body><div class="wrap"><h1>Title</h1>${svg}</div></body></html>`;
+  const run = (name, svg) => {
+    const html = path.join(dir, name);
+    fs.writeFileSync(html, page(svg));
+    return spawnSync(path.join(BIN, 'tdoc-validate-template'), [html], { encoding: 'utf8' });
+  };
+  try {
+    // ink spans x=34..86 in a 120-wide box: 28% of the width wasted each side,
+    // which reads as an indent against every paragraph on the page
+    const padded = run('padded.html',
+      '<svg viewBox="0 0 120 64" aria-label="Padded"><rect x="34" y="8" width="52" height="48"/></svg>');
+    assert(padded.status !== 0, 'baked viewBox padding should be rejected');
+    assert(/inside its own viewBox/.test(padded.stderr), padded.stderr);
+
+    // same drawing, viewBox set to its bounds
+    const flush = run('flush.html',
+      '<svg viewBox="0 0 120 64" aria-label="Flush"><rect x="6" y="8" width="108" height="48"/></svg>');
+    assert(flush.status === 0, `flush figure rejected: ${flush.stderr}`);
+
+    // a non-zero viewBox origin is the documented way to tighten a drawing,
+    // so the offset must be measured against min-x rather than assumed zero
+    const shifted = run('shifted.html',
+      '<svg viewBox="12 4 696 215" aria-label="Shifted"><rect x="14" y="6" width="692" height="210"/></svg>');
+    assert(shifted.status === 0, `tightened viewBox rejected: ${shifted.stderr}`);
+
+    // geometry inside a <path> is not parseable here, so those figures opt out
+    // rather than being failed on a guess
+    const opaque = run('opaque.html',
+      '<svg viewBox="0 0 120 64" aria-label="Path"><path d="M34,8 L86,56"/><rect x="34" y="8" width="52" height="48"/></svg>');
+    assert(opaque.status === 0, `figure containing <path> should skip the inset check: ${opaque.stderr}`);
+
+    // clipping is a different fault and must still be caught
+    const overflow = run('overflow.html',
+      '<svg viewBox="0 0 120 64" aria-label="Over"><rect x="6" y="8" width="160" height="20"/></svg>');
+    assert(overflow.status !== 0, 'overflow check regressed');
+    assert(/overflows its viewBox/.test(overflow.stderr), overflow.stderr);
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
 t('tdoc default-template validator rejects global restyling by default', () => {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'tdoc-template-'));
   try {


### PR DESCRIPTION
A doc generated by this skill put its glyph row 64px right of the prose on a phone. The figures were individually fine. What was wrong is that each had been drawn wherever felt natural inside its viewBox, so their ink started at 6, 14, 20 and 34 in a 120-wide box — and nothing in the contract said not to, so nothing caught it.

| glyph | ink starts at | wasted each side |
|---|---|---|
| Bar | 6 | 5% |
| Scatter | 14 | 12% |
| Radar | 20 | 17% |
| Stacked | 34 | **28%** |

At a 164px card that last one is 46px of indent against a paragraph starting at 0. It is invisible at desktop width and obvious on a phone, which is why it shipped.

## The rule

`visuals.md` now says the viewBox is the frame, not a mat: set it to the drawing's bounds, and put space between a figure and its neighbours in CSS margin on the wrapper, where it applies to the box rather than the picture inside it. It also names the second failure — a *set* of figures drawn one at a time ends up with ragged starts even when each one is individually reasonable.

## The check

`tdoc-validate-template` already refused a drawing that overflows its viewBox. It now also refuses one that floats inside it, at more than 10% of the width. Two supporting fixes were needed to make that possible:

- The viewBox regex only matched `0 0 W H`. A figure tightened to a non-zero origin — which is exactly what the new rule asks for — escaped the overflow check entirely. It now parses all four numbers.
- `polyline` / `polygon` points now count toward the extents. A chart drawn from points was previously invisible to the check.

**It declines to judge what it cannot measure.** A figure containing `<path>`, `<use>` or `<image>` has geometry this parser cannot read, and `text-anchor="middle"` or `"end"` puts glyphs to the left of the `x` the element declares. Both opt out of the inset check rather than being failed on a guess. Overflow still runs on whatever shapes are present.

## What this breaks

Three docs already in `~/tdocs` fail the new check, at 11%, 12% and 21%. I checked each: they are the same fault, not false positives. They are only re-validated when someone regenerates them, so nothing published breaks today — but a regeneration of those docs will now stop until the figures are tightened, which is the intended outcome.

The 10% threshold leaves room for deliberate breathing space inside a bordered card. The fixed version of the doc that prompted this sits at 5% and passes.

## Checks

46 offline suites green. The new test covers the padded case, the flush case, a tightened non-zero-origin viewBox, the `<path>` opt-out, and an overflow regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Xw9Mt3rV3ujnejPr41pqvz