### PR TITLE
Components are structure, styles are treatment, and the list is open

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -280,8 +280,14 @@ When two fit, take the calmer one. The entries in full:
 a stat tile, a comparison matrix, a container frame or a label chip *is*,
 with no colour on it. Each `style/` entry gives the same parts its own
 treatment, so switching style changes how a component reads and never what
-it is. Section skeletons are still an empty slot — derive the document's
-shape from the prompt.
+it is.
+
+**The list is open.** A doc that needs a component nobody wrote down should
+have one. Build it from the tokens every style declares — `ink`, `rule`,
+`muted`, `surface`, `accent-fill`, `accent-stroke`, `accent-text`,
+`label-type` — and it is dressed correctly by every style, including any
+added later. The rest of the contract is in that file. Section skeletons
+are still an empty slot — derive the document's shape from the prompt.
 
 `visuals.md` is the visual-first floor: lead with charts, diagrams, tables, and
 stat tiles rather than paragraphs; pick the visual type that fits the data

--- a/SKILL.md
+++ b/SKILL.md
@@ -230,7 +230,8 @@ Three files are required reading before you write doc HTML, on every
 |---|---|---|
 | `$SKILL_DIR/authoring/voice.md` | how the prose reads | No. A floor — no switch, no doc exempt. |
 | `$SKILL_DIR/authoring/visuals.md` | how much of the doc is a picture | No. A floor — be visual-first, many visuals, varied types. |
-| `$SKILL_DIR/authoring/style/default.md` | what the page looks like | Only by naming another entry in `style/`. |
+| `$SKILL_DIR/authoring/structure/components.md` | what the parts are | No. The parts are the same in every style. |
+| `$SKILL_DIR/authoring/style/<picked>.md` | what those parts look like | Yes — you pick the entry that fits the content. |
 
 `$SKILL_DIR` is the installed skill directory resolved in "Setup check"
 above (`~/.claude/skills/tdoc`, or `~/.codex/skills/tdoc` under Codex) —
@@ -247,9 +248,21 @@ oversized tight-tracked headline, near-zero color, and a full technical-diagram
 vocabulary (thin frames, mono pill labels, numbered containers, solid/dashed
 arrows, one accent per figure, dot/hatch textured fills). The OpenAI-index
 aesthetic, done with open fonts — no brand assets, a look not an identity.
-Apply it unless the user names a different entry in `$SKILL_DIR/authoring/style/`.
+**Choose the style that fits the document you are about to write.** It is a
+judgment call, not a setting the user has to know exists: read what the content
+is, then pick. A user who names one has overridden you, and that stands — but
+saying nothing is not a vote for the default, it is leaving the choice to you.
 
-The other entries a user can name:
+- **`default`** — specs, explainers, anything carried by diagrams. The stark
+  register keeps the page quiet so the figures do the talking.
+- **`technical`** — dense engineering writeups, benchmarks, anything where the
+  identifiers and the numbers are the content. Opens dark-first.
+- **`paper`** — a long read meant to be read end to end: a vision doc, a
+  post-mortem with a story in it, an essay.
+- **`editorial`** — the same length, but argumentative: a position piece where
+  terms need marking as they are introduced.
+
+When two fit, take the calmer one. The entries in full:
 
 - `$SKILL_DIR/authoring/style/technical.md` — a cold engineering-blog register:
   mono for identifiers and metrics, neutral greys for structure, a single
@@ -263,8 +276,12 @@ The other entries a user can name:
   one clay accent. The Anthropic-blog aesthetic, done with open fonts (not
   the proprietary brand fonts, no logo/byline — a look, not an identity).
 
-`$SKILL_DIR/authoring/structure/` is still an empty mount point. Empty means
-no choice to make: derive the document's shape from the prompt.
+`$SKILL_DIR/authoring/structure/components.md` is the component library: what
+a stat tile, a comparison matrix, a container frame or a label chip *is*,
+with no colour on it. Each `style/` entry gives the same parts its own
+treatment, so switching style changes how a component reads and never what
+it is. Section skeletons are still an empty slot — derive the document's
+shape from the prompt.
 
 `visuals.md` is the visual-first floor: lead with charts, diagrams, tables, and
 stat tiles rather than paragraphs; pick the visual type that fits the data
@@ -316,7 +333,7 @@ that a GitHub page has opened and that the code is in the terminal; then keep
 working. Skip Step 0 entirely for the local-only and self-host destinations.
 
 1. Pick a slug from the prompt (kebab-case, ≤4 words).
-2. **Read `$SKILL_DIR/authoring/voice.md`, `$SKILL_DIR/authoring/visuals.md`, and `$SKILL_DIR/authoring/style/default.md`.**
+2. **Read `$SKILL_DIR/authoring/voice.md`, `$SKILL_DIR/authoring/visuals.md`, `$SKILL_DIR/authoring/structure/components.md`, and the `$SKILL_DIR/authoring/style/` entry you picked.**
    Voice constrains the prose as you generate it, not as a later cleanup
    pass. The style tells you which components to reach for and its palette —
    apply it unless the user named another entry in `$SKILL_DIR/authoring/style/`.
@@ -328,7 +345,7 @@ working. Skip Step 0 entirely for the local-only and self-host destinations.
      CSP and therefore create controls or empty panels that cannot work. If
      the idea needs computation, write `v1/widgets/<name>.html` and iframe it.
    - No external CDNs in the host unless requested. No build step.
-   - The default style is mandatory when the user names no style. A full-page
+   - Pick the style that fits the content when the user names none. A full-page
      custom design is allowed only when the user explicitly requests one;
      programmatic callers must make that exception visible with
      `--custom-template`.
@@ -482,7 +499,7 @@ comments you handled unless you reply on each one. Skipping comments
 silently is the #1 source of regression complaints.
 
 1. Read `~/tdocs/<slug>/comments.json` — filter to `status: "open"`.
-2. Read latest version's `index.html`, and re-read `$SKILL_DIR/authoring/voice.md` and `$SKILL_DIR/authoring/visuals.md`.
+2. Read latest version's `index.html`, and re-read `$SKILL_DIR/authoring/voice.md`, `$SKILL_DIR/authoring/visuals.md` and `$SKILL_DIR/authoring/structure/components.md`.
    A regeneration writes new prose, so the contract applies here exactly as
    it does on `/tdoc new`. Prose you carry over unchanged from the previous
    version stays as it is — do not re-edit untouched sections for voice, and
@@ -917,8 +934,8 @@ The overlay's template is modeled after the `conway-life` doc ("What if a doc co
 - pre: mono 15px, light gray background, left-rule, scrolling overflow
 - Code (inline): 0.92em mono, light-gray rounded chip
 
-**The default style is mandatory when the user names no other style.** Use the
-CSS from `$SKILL_DIR/authoring/style/default.md` as written. Add only the
+**Pick a style from `$SKILL_DIR/authoring/style/` for every doc**, and use that
+entry's CSS as written. Add only the
 house style's components and tightly scoped CSS for content-specific charts,
 diagrams, and controls. Do not invent additional bare-element rules or change
 the content root's width, margins, or padding.

--- a/authoring/README.md
+++ b/authoring/README.md
@@ -1,15 +1,30 @@
 # authoring/
 
-What every generated doc must go through, and where the optional
-choices live. Read by the agent at generation time, not by the reader.
+The parts tdoc composes a doc from, and how they fit together. Read by the
+agent at generation time, not by the reader.
 
-Three slots, deliberately separate because they answer different questions:
+These are **references, not a pipeline.** An agent that already has a house
+voice and a design system — through `bin/tdoc-new` — is composing with tdoc,
+and takes what is useful here or none of it. The invariants that keep a doc
+working at all are a separate, much shorter list, enforced by
+`bin/tdoc-validate-template`: no author JavaScript in the host, one content
+root, the reserved `tdoc-*` names, a viewport meta, a body background. Those
+are MUST. Everything in this directory is what tdoc reaches for when nobody
+has said otherwise.
 
-| Slot | Question it answers | Status |
+Four slots, separate because they answer different questions:
+
+| Slot | Question it answers | Who decides |
 |---|---|---|
-| `voice.md` | How does the prose read? | **Always applied.** Not a choice. |
-| `style/` | What does the page look like? | Empty — reserved. |
-| `structure/` | Which sections does this kind of doc have? | Empty — reserved. |
+| `voice.md` | How does the prose read? | Nobody picks "sound like AI" — it applies by default |
+| `visuals.md` | Which component fits this data? | The data |
+| `structure/components.md` | What is that component, structurally? | Fixed across styles — that is what makes a style swappable |
+| `style/` | What does that component look like? | **The agent picks the entry that fits the content** |
+
+The last two are the axis that matters: a stat tile is the same stat tile in
+`paper` and in `technical`, and switching between them changes how it reads,
+never what it is. A style that starts inventing components, or a component
+that hardcodes a colour, has broken that split.
 
 ## voice.md is a floor, not an option
 

--- a/authoring/structure/README.md
+++ b/authoring/structure/README.md
@@ -1,8 +1,12 @@
-# structure/ — section skeletons
+# structure/ — the parts, and the shapes they go in
 
-**Empty. Reserved. The default is no structure at all.**
+`components.md` is the component library: what a stat tile, a comparison
+matrix, a container frame or a label chip *is*, with no colour on it. Every
+`style/` entry gives those same parts its own treatment, which is what makes
+a style swappable rather than a rewrite.
 
-A structure entry answers "which sections does this kind of doc have":
+**Section skeletons are still an empty slot.** A structure entry would answer
+"which sections does this kind of doc have":
 a post-mortem is timeline, blast radius, root cause, action items; a PRD
 is problem, user, non-goals, success measures.
 

--- a/authoring/structure/components.md
+++ b/authoring/structure/components.md
@@ -1,0 +1,107 @@
+# components — what the parts are, before anything colours them
+
+A component is defined here by its **shape and its job**. What it looks like is
+the style's answer, and every entry in `style/` gives its own. That split is the
+point: a stat tile is a stat tile in `paper` and in `technical`, and swapping the
+style should change how it reads, never what it is.
+
+These are reference implementations. Take one, adapt it, or write your own — an
+agent bringing its own design system is composing with tdoc, not fighting it.
+What follows is what tdoc reaches for when nobody has said otherwise.
+
+## Where each decision lives
+
+| Question | Answered by |
+|---|---|
+| Which component fits this data? | `visuals.md` |
+| What is that component, structurally? | this file |
+| What colour, stroke, type, texture? | `style/<name>.md` |
+| Which sections does the doc have? | the prompt, or a `structure/` entry |
+
+A style that starts inventing components has crossed into this file's territory,
+and a component that hardcodes a hex colour has crossed into the style's.
+
+## Page blocks
+
+**Diagram box** — the scroll wrapper every wide figure sits in, so a phone
+scrolls it instead of squashing it.
+
+```html
+<div class="diagram-box" data-tdoc-artifact>
+  <svg viewBox="…" role="img" aria-label="…">…</svg>
+  <p class="cap">One line on what the reader should take from it.</p>
+</div>
+```
+
+`data-tdoc-artifact` makes the whole block one comment anchor rather than
+leaving the reader to comment on fragments of its text.
+
+**Table scroll** — the same idea for tables: `<div class="tdoc-table-scroll">`
+around any table wide enough to overflow.
+
+**Stat tile row** — a few numbers that carry an argument on their own. Three or
+four; a fifth is a table.
+
+```html
+<div class="tiles">
+  <div class="tile"><b>11</b><span>what the number counts</span></div>
+</div>
+```
+
+**Note** — an aside that qualifies rather than warns. One rule, no fill, no
+icon: `<p class="note">`.
+
+## Figure parts
+
+These are the atoms of a drawn figure. Each style says what they look like.
+
+| Part | What it is | Structural rule |
+|---|---|---|
+| **Container frame** | A rectangle grouping one stage of a figure | No fill of its own; the style decides corner and stroke |
+| **Label chip** | The atomic noun of a figure — an input, a state, a stage | Short, uppercase, inside its own small box |
+| **Numbered group** | A frame holding several steps, titled in its corner | Title reads `1: Author`, `2: Review` |
+| **Description box** | One line explaining a step, inside the group it belongs to | Prose, not a label; keep it to a line |
+| **Primary arrow** | The path the reader should follow first | Solid |
+| **Secondary arrow** | A loop, a fallback, a return | Dashed — same weight, different dash |
+| **Accent fill** | The one thing in the figure that is not greyscale | **One accent per figure.** Two competing accents make neither mean anything |
+| **Textured variant** | The accent again, in a second state — live, transformed, stale | A texture over the fill, never instead of it: put the colour inside the `<pattern>` tile |
+
+## Data components
+
+`visuals.md` decides which of these the data calls for. Each is inline SVG,
+because the host runs no author JavaScript and an SVG figure is a commentable
+artifact — which is the whole point of putting it in a tdoc.
+
+| Component | Reads as | Structural rule |
+|---|---|---|
+| **Bar** | Quantities compared | One baseline; bars share a zero |
+| **Line** | A trend over time | Mark the points; a bare line hides how many readings there are |
+| **Scatter** | A tradeoff, X against Y | Both axes drawn, both labelled |
+| **Quadrant** | Position on two axes | Cross through the middle; label the axes, not the quadrants |
+| **Matrix** | A feature comparison | ✓ / ✗ / ~ — a dash means "not stated", which is not the same as "no" |
+| **Stat tiles** | A few key numbers | The number is the element; the label supports it |
+| **Timeline** | A sequence of events | One axis, marks in order, the current one distinguished |
+| **Flow** | A process with branches | Only when it truly branches. A list of steps is a list |
+| **Stacked bar** | Composition of a whole | Segments sum to the whole, and the whole is stated |
+| **Radar** | Many attributes, few items | Three or four items maximum before it turns to mud |
+| **Gauge** | A magnitude on a scale | The scale's ends are visible, or the reading means nothing |
+| **Small multiples** | The same chart repeated | Shared axes across every panel, or they cannot be compared |
+
+## Two rules that outlive any style
+
+**Draw to the edge of the viewBox.** The viewBox is the frame, not a mat.
+Padding baked into it indents the figure against every paragraph on the page —
+invisible at desktop width, obvious on a phone. If the leftmost stroke is at
+`x=14`, the viewBox starts at 14. Space between a figure and its neighbours is
+CSS margin on the wrapper, where it applies to the box and not to the picture.
+
+A set of figures drawn one at a time is the common way this goes wrong: each is
+individually reasonable, their ink starts at 6, 14, 20 and 34, and the row reads
+as broken. Draw a set on one geometry — same left edge, same right edge.
+
+**Nothing computes in the host.** Author `<script>`, `on*=` handlers and
+`<canvas>` are inert under the host CSP: no error, just a control that never
+works. A toggle is `:checked` plus sibling selectors; motion is CSS
+`@keyframes` with a `prefers-reduced-motion` guard; SVG styling goes in a
+`<style>` *inside* the `<svg>`. Anything that genuinely needs to compute belongs
+in a sandboxed widget island.

--- a/authoring/structure/components.md
+++ b/authoring/structure/components.md
@@ -5,16 +5,18 @@ the style's answer, and every entry in `style/` gives its own. That split is the
 point: a stat tile is a stat tile in `paper` and in `technical`, and swapping the
 style should change how it reads, never what it is.
 
-These are reference implementations. Take one, adapt it, or write your own — an
-agent bringing its own design system is composing with tdoc, not fighting it.
-What follows is what tdoc reaches for when nobody has said otherwise.
+**This list is open.** What follows is what tdoc reaches for when nobody has
+said otherwise, not the set of components a doc is allowed to contain. Take one,
+adapt it, or write something that is not here at all — see "Writing a component
+that is not on this list" below. An agent bringing its own design system is
+composing with tdoc, not fighting it.
 
 ## Where each decision lives
 
 | Question | Answered by |
 |---|---|
 | Which component fits this data? | `visuals.md` |
-| What is that component, structurally? | this file |
+| What is that component, structurally? | this file — or your own, see below |
 | What colour, stroke, type, texture? | `style/<name>.md` |
 | Which sections does the doc have? | the prompt, or a `structure/` entry |
 
@@ -86,6 +88,38 @@ artifact — which is the whole point of putting it in a tdoc.
 | **Radar** | Many attributes, few items | Three or four items maximum before it turns to mud |
 | **Gauge** | A magnitude on a scale | The scale's ends are visible, or the reading means nothing |
 | **Small multiples** | The same chart repeated | Shared axes across every panel, or they cannot be compared |
+
+## Writing a component that is not on this list
+
+The nine parts and twelve chart types above cover what has come up so far. They
+are not a vocabulary limit — a doc that needs a decision ladder, an org chart, a
+burndown, a seating plan should have one, and no permission is required.
+
+What a new component has to satisfy is short, and none of it is about taste:
+
+**Name tokens, not colours.** Every `style/` entry declares `ink`, `rule`,
+`muted`, `surface`, `accent-fill`, `accent-stroke`, `accent-text` and
+`label-type`. A component built from those is dressed correctly by all four
+styles — and by any style added later, which has to answer for the same tokens.
+A component with a pure-black stroke written into it looks wrong the moment
+somebody picks `paper`, where nothing is pure black.
+
+**Be one comment anchor.** A component assembled from `<div>`s is invisible to
+the overlay as a unit: readers end up commenting on fragments of its text.
+Either use a semantic tag — `<section>`, `<aside>`, `<details>` — or mark it
+`data-tdoc-artifact`. That is what makes it something a reader can point at,
+which is the reason it is in a tdoc rather than a screenshot.
+
+**Survive a phone.** Fluid widths, a `viewBox` rather than pixel `width`/
+`height`, and a scroll wrapper if it genuinely cannot narrow.
+
+**Compute nothing in the host.** The same rule as everything else: `:checked`
+for state, CSS `@keyframes` for motion, a sandboxed widget island if it truly
+needs to calculate.
+
+Meet those four and the component behaves like the ones listed here: it swaps
+style, it takes comments, it survives a regeneration. Nothing else is required
+of it, and it does not need to be added to this file to be used.
 
 ## Two rules that outlive any style
 

--- a/authoring/style/default.md
+++ b/authoring/style/default.md
@@ -50,33 +50,27 @@ body { background:#fff; }
 .note { border-top:1px solid #e5e5e5; padding-top:12px; margin:20px 0; color:#555; font-size:15px; }
 ```
 
-## The diagram vocabulary (the OpenAI-index look)
+## Component treatment (the OpenAI-index look)
 
-This style has a full technical-diagram vocabulary, verified to render in
-tdoc. It draws ANY diagram — a pipeline, context-window bars, an architecture,
-a flow — from one small set. The style is the *treatment*, not a fixed set of
-shapes; it never limits what kind of visual a doc contains.
+`structure/components.md` says what these parts are. This is what they look
+like here — verified to render in tdoc. The register is thin black line on
+white with one pastel accent, and it draws any figure the content asks for.
 
-- **Container frames — sharp, not rounded.** Thin black rectangles
-  (`stroke:#111; stroke-width:1.3`), square corners, no fill, no shadow. Only
-  the small inner pill labels get a hairline `rx:0–1`.
-- **Mono pill labels.** Uppercase monospace, `~10.5px`, `letter-spacing:.04em`,
-  inside a thin (`stroke-width:1`) box — for the atomic nouns of the figure
-  (an input, a stage, a state). Use your own labels, not a reference's.
-- **Numbered container groups.** A big frame grouping steps, with a sans
-  weight-600 title inside its top-left corner (`1: Author`, `2: Review`).
-- **Description boxes.** Short sans (`~11px`) inside a thin box for a step's
-  one-line explanation.
-- **Arrows.** Thin (`1.2`), small round arrowhead, black for the main path; a
-  **dashed** (`stroke-dasharray:3 3`) variant for a secondary path or a loop.
-- **One accent per figure, filled solid.** Pink (`fill:#f7d7d1
-  stroke:#e0a99e`, text `#b3503c`) or blue (`fill:#dde7f9 stroke:#a9c0ee`,
-  text `#26407a`). Solid pastel is the base; a texture is the *variant*, not
-  the fill.
-- **Textured variants** via SVG `<pattern>` — the signature. A **dot** texture
-  over the pink for a live/active state; a **diagonal hatch** over the blue for
-  a transformed/compressed one. Put the solid color *inside* the pattern tile
-  so the texture reads on top of the fill, not over white:
+| Component | This style's treatment |
+|---|---|
+| Container frame | `stroke:#111; stroke-width:1.3`, square corners, no fill, no shadow |
+| Label chip | Uppercase mono `~10.5px`, `letter-spacing:.04em`, in a `stroke-width:1` box, `rx:0–1` |
+| Numbered group | Sans weight 600 title inside the frame's top-left corner |
+| Description box | Sans `~11px` inside a thin box |
+| Primary arrow | `stroke-width:1.2`, small round arrowhead, `#111` |
+| Secondary arrow | The same, `stroke-dasharray:3 3` |
+| Accent fill | Pink `fill:#f7d7d1 stroke:#e0a99e`, text `#b3503c`; or blue `fill:#dde7f9 stroke:#a9c0ee`, text `#26407a` |
+| Textured variant | Dot over the pink for a live state; diagonal hatch over the blue for a transformed one |
+| Stacked bar | Blue shades `#c4d4f5` / `#d4e0f8` / `#e8eefb` with `#a9c0ee` strokes and mono labels; a hatched segment marks a transformed part, a dashed baseline marks a limit |
+
+Solid pastel is the base and the texture is the *variant*, not the fill. Put
+the colour inside the pattern tile so the texture reads on top of it rather
+than over white:
 
 ```
 <pattern id="pdot" width="6" height="6" patternUnits="userSpaceOnUse">
@@ -87,21 +81,16 @@ shapes; it never limits what kind of visual a doc contains.
   <line x1="0" y1="0" x2="0" y2="7" stroke="#a9c0ee" stroke-width="1.5"/></pattern>
 ```
 
-- **Stacked bars for composition.** A vertical bar split into labeled segments
-  (blue shades `#c4d4f5` / `#d4e0f8` / `#e8eefb`, `#a9c0ee` strokes, mono
-  labels) reads a whole-made-of-parts — a context window, a version stack, a
-  budget. A hatch segment marks a transformed part; a dashed baseline marks a
-  limit.
-
-Keep it airy — generous white space between containers. Outside diagrams the
+Keep it airy — generous white space between containers. Outside figures the
 doc stays greyscale on white; the accent lives in the figures.
 
 ## Visuals are content-driven, never limited by the style
 
-The vocabulary above is a *palette for whatever visual the content needs* — it
-never decides whether a doc has a diagram, nor restricts it to these shapes. A
-doc with a bar chart, a table, a photo, or nothing follows its content; this
-style only says how such a thing looks in this register.
+The table above colours whatever the content needs. It does not decide whether
+a doc has a figure, nor which figure — `visuals.md` picks that from the data
+and `structure/components.md` says what the part is. A doc with a bar chart, a
+table, a photo, or nothing follows its content; this file only says how such a
+thing looks in this register.
 
 ## Style is visual only
 

--- a/authoring/style/default.md
+++ b/authoring/style/default.md
@@ -50,6 +50,26 @@ body { background:#fff; }
 .note { border-top:1px solid #e5e5e5; padding-top:12px; margin:20px 0; color:#555; font-size:15px; }
 ```
 
+## Tokens
+
+A component — including one this file has never heard of — dresses itself from
+these. That is what makes a component someone else wrote swap styles correctly:
+it names tokens, not colours.
+
+| Token | Value here |
+|---|---|
+| `ink` | `#0a0a0a` |
+| `rule` | `#111` for a figure frame, `#e5e5e5` for a hairline divider |
+| `muted` | `#555` |
+| `surface` | `#f5f5f5` |
+| `accent-fill` | `#f7d7d1` (pink) or `#dde7f9` (blue) — one per figure |
+| `accent-stroke` | `#e0a99e` / `#a9c0ee`, matching the fill |
+| `accent-text` | `#b3503c` / `#26407a`, matching the fill |
+| `label-type` | uppercase mono, `~10.5px`, `letter-spacing:.04em` |
+
+A texture is `accent-fill` with `accent-stroke` marks over it, drawn inside the
+`<pattern>` tile rather than on top of white.
+
 ## Component treatment (the OpenAI-index look)
 
 `structure/components.md` says what these parts are. This is what they look

--- a/authoring/style/editorial.md
+++ b/authoring/style/editorial.md
@@ -53,6 +53,27 @@ body { background:#f7f6f5; }
 .diagram-box { max-width:100%; overflow-x:auto; margin:20px 0; }
 ```
 
+## Component treatment
+
+`structure/components.md` says what these parts are. This style marks meaning
+with a coloured underline in prose, and figures follow the same logic: the blue
+is a pointer, not a decoration, and it lands on one element.
+
+| Component | This style's treatment |
+|---|---|
+| Container frame | `stroke:#b3bdc9; stroke-width:1`, square corners, no fill |
+| Label chip | Sans `~10.5px` in `#3a55f4`, on `#eef1fb`, `rx:2` |
+| Numbered group | Sans weight 600 title in `#0a0a0a`, above the frame |
+| Description box | Serif `~12px` — the reading voice, so a figure's prose matches the page's |
+| Primary arrow | `stroke:#0a0a0a; stroke-width:1.2` |
+| Secondary arrow | `stroke:#b3bdc9`, `stroke-dasharray:3 3` |
+| Accent fill | `fill:#eef1fb stroke:#3a55f4`, text `#2200ff` |
+| Textured variant | Hatch in `#3a55f4` over the same fill; the green `#4ba181` is reserved for a positive outcome and never used as a second accent |
+| Stacked bar | Blues `#eef1fb` / `#dbe3fa` / `#c3d0f6` with `#b3bdc9` strokes |
+
+The underline that marks a term in prose has no figure equivalent. Inside a
+drawing, emphasis is the accent fill.
+
 ## Visuals are content-driven, never dictated by the style
 
 **This style's diagram vocabulary works for ANY diagram type** — a pipeline, an architecture, a flow, context bars, a chart. The style is the visual *treatment*, never a limit on which visuals appear. Draw diagrams warm and understated: `#fff` node fills, `#b3bdc9` strokes, electric-blue `#3a55f4` on the focus node, terracotta `#cc7c5e` for a caveat path, serif or system labels.

--- a/authoring/style/editorial.md
+++ b/authoring/style/editorial.md
@@ -53,6 +53,27 @@ body { background:#f7f6f5; }
 .diagram-box { max-width:100%; overflow-x:auto; margin:20px 0; }
 ```
 
+## Tokens
+
+A component — including one this file has never heard of — dresses itself from
+these. That is what makes a component someone else wrote swap styles correctly:
+it names tokens, not colours.
+
+| Token | Value here |
+|---|---|
+| `ink` | `#0a0a0a` |
+| `rule` | `#b3bdc9` |
+| `muted` | `#5b6672` |
+| `surface` | `#eef1fb` |
+| `accent-fill` | `#eef1fb` |
+| `accent-stroke` | `#3a55f4` |
+| `accent-text` | `#2200ff` |
+| `label-type` | sans, `~10.5px` |
+
+`#4ba181` marks a positive outcome and `#cc7c5e` a negative one. Neither is a
+second accent — a component that reaches for them is making a claim about the
+result, not decorating.
+
 ## Component treatment
 
 `structure/components.md` says what these parts are. This style marks meaning

--- a/authoring/style/paper.md
+++ b/authoring/style/paper.md
@@ -55,6 +55,27 @@ body { background:#faf9f5; }
 .aside { border-left:2px solid #c15f3c; background:#f4efe7; padding:14px 18px; margin:20px 0; border-radius:0 6px 6px 0; }
 ```
 
+## Component treatment
+
+`structure/components.md` says what these parts are. On paper they are drawn
+warm and low-contrast: no pure black, no hard rectangle. The clay accent is the
+only saturated thing on the page and it stays rationed.
+
+| Component | This style's treatment |
+|---|---|
+| Container frame | `stroke:#dcd3c4; stroke-width:1.2`, `rx:3` — a softened corner, not a sharp one |
+| Label chip | Small-caps sans `~11px` in `#6b6355`, on `#f4efe7`, `rx:3` |
+| Numbered group | Serif title in `#141413`, inside the frame's top-left |
+| Description box | Sans `~11.5px` in `#6b6355`, no box |
+| Primary arrow | `stroke:#141413; stroke-width:1.2` |
+| Secondary arrow | `stroke:#b5ab99`, `stroke-dasharray:4 4` |
+| Accent fill | `fill:#f4e3dc stroke:#e3c4b6`, text `#c15f3c` |
+| Textured variant | Sparse dot in `#e3c4b6` over the same fill |
+| Stacked bar | Paper tints `#f4efe7` / `#ece5d8` / `#dcd3c4` with `#c9bfae` strokes |
+
+Figure labels are the body sans, not the display serif — the serif is for
+headings, and inside a drawing it turns decorative.
+
 ## Visuals are content-driven, never dictated by the style
 
 **This style's diagram vocabulary works for ANY diagram type** — a pipeline, an architecture, a flow, context bars, a chart. The style is the visual *treatment*, never a limit on which visuals appear. Draw diagrams warm: `#faf4ec` fills, `#dcd3c4` strokes, clay `#c15f3c` on the highlighted part, serif labels.

--- a/authoring/style/paper.md
+++ b/authoring/style/paper.md
@@ -55,6 +55,26 @@ body { background:#faf9f5; }
 .aside { border-left:2px solid #c15f3c; background:#f4efe7; padding:14px 18px; margin:20px 0; border-radius:0 6px 6px 0; }
 ```
 
+## Tokens
+
+A component — including one this file has never heard of — dresses itself from
+these. That is what makes a component someone else wrote swap styles correctly:
+it names tokens, not colours.
+
+| Token | Value here |
+|---|---|
+| `ink` | `#141413` — no pure black anywhere |
+| `rule` | `#dcd3c4` |
+| `muted` | `#6b6355` |
+| `surface` | `#f4efe7` |
+| `accent-fill` | `#f4e3dc` |
+| `accent-stroke` | `#e3c4b6` |
+| `accent-text` | `#c15f3c` |
+| `label-type` | small-caps sans, `~11px` — the display serif stays out of figures |
+
+Corners are softened (`rx:3`) rather than sharp, which is the one structural
+habit this style asks of a component.
+
 ## Component treatment
 
 `structure/components.md` says what these parts are. On paper they are drawn

--- a/authoring/style/technical.md
+++ b/authoring/style/technical.md
@@ -93,6 +93,26 @@ If a `<canvas>` or `<iframe>` is a *drawing* (a chart, a simulation) that should
 darken with the page rather than glow as a white slab, mark it
 `data-tdoc-dark="invert"` so it inverts with everything else.
 
+## Tokens
+
+A component — including one this file has never heard of — dresses itself from
+these. That is what makes a component someone else wrote swap styles correctly:
+it names tokens, not colours.
+
+| Token | Value here |
+|---|---|
+| `ink` | `#0a0a0a` |
+| `rule` | `#d4d4d4` |
+| `muted` | `#737373` |
+| `surface` | `#f5f5f5`, `#f0f0f0` for a code cell |
+| `accent-fill` | `#fff5f3` |
+| `accent-stroke` | `#ff4b2e` |
+| `accent-text` | `#ff4b2e` |
+| `label-type` | mono, `~10.5px` — identifiers and metrics are mono here, inside figures too |
+
+Draw with these light values and let the page-level invert carry the component
+into dark, the same way the rest of this style works.
+
 ## Component treatment
 
 `structure/components.md` says what these parts are. Here they are drawn in the

--- a/authoring/style/technical.md
+++ b/authoring/style/technical.md
@@ -93,6 +93,28 @@ If a `<canvas>` or `<iframe>` is a *drawing* (a chart, a simulation) that should
 darken with the page rather than glow as a white slab, mark it
 `data-tdoc-dark="invert"` so it inverts with everything else.
 
+## Component treatment
+
+`structure/components.md` says what these parts are. Here they are drawn in the
+one light palette above, so the page-level invert carries them into dark with
+everything else. Greys do the structural work and the red-orange is rationed to
+the single thing the figure is about.
+
+| Component | This style's treatment |
+|---|---|
+| Container frame | `stroke:#d4d4d4; stroke-width:1`, square corners, no fill |
+| Label chip | Mono `~10.5px` in `#525252`, on `#f5f5f5`, no border |
+| Numbered group | Mono title, `#737373`, above the frame rather than inside it |
+| Description box | Sans `~11px` in `#737373`, no box — the grey carries it |
+| Primary arrow | `stroke:#0a0a0a; stroke-width:1.2` |
+| Secondary arrow | `stroke:#a3a3a3`, `stroke-dasharray:3 3` |
+| Accent fill | `fill:#fff5f3 stroke:#ff4b2e`, text `#ff4b2e` — **one node per figure** |
+| Textured variant | Diagonal hatch in `#ff4b2e` at 35% over the same fill |
+| Stacked bar | Greys `#f0f0f0` / `#e5e5e5` / `#d4d4d4` with `#a3a3a3` strokes; the segment under discussion takes the accent |
+
+Metric labels are mono here, including inside figures — a number set in the
+body sans reads as prose and gets skimmed.
+
 ## Visuals are content-driven, never dictated by the style
 
 The style is a *treatment* — a system sans, mono identifiers, one red accent,

--- a/bin/tdoc-validate-template
+++ b/bin/tdoc-validate-template
@@ -228,14 +228,16 @@ def _points_x(tag):
     return nums[0::2]
 
 
-def check_svg_bounds(html):
-    """Nothing may be clipped by its own viewBox, and nothing may float inside it.
+def _svg_faults(html):
+    """Measure every figure once; the caller decides which faults it cares about.
 
-    Two separate faults. Overflow clips the drawing. Baked padding is the
-    quieter one: a viewBox larger than its ink indents the figure against the
-    prose column, and only shows once a narrow screen shrinks the column.
+    Returns (clipping, inset). Clipping is a defect in any house style — the
+    drawing is cut off. Inset is taste: a viewBox larger than its ink indents
+    the figure against the prose column, which matters when tdoc is the author
+    and is none of its business when somebody else's agent is.
     """
-    errors = []
+    clipping = []
+    inset = []
     for m in re.finditer(
         r'<svg[^>]*viewBox="\s*(-?[\d.]+)[\s,]+(-?[\d.]+)[\s,]+([\d.]+)[\s,]+([\d.]+)\s*"(.*?)</svg>',
         html, re.S,
@@ -269,9 +271,9 @@ def check_svg_bounds(html):
             continue
         mx, my = max(xs) + ox, (max(ys) + oy if ys else 0.0)
         if mx > vx + vw + 0.5:
-            errors.append("figure '%s' overflows its viewBox by %dpx across" % (name, round(mx - vx - vw)))
+            clipping.append("figure '%s' overflows its viewBox by %dpx across" % (name, round(mx - vx - vw)))
         if ys and my > vy + vh + 0.5:
-            errors.append("figure '%s' overflows its viewBox by %dpx down" % (name, round(my - vy - vh)))
+            clipping.append("figure '%s' overflows its viewBox by %dpx down" % (name, round(my - vy - vh)))
 
         # A <text> without an explicit anchor starts at its x, so it bounds the
         # ink on the left. text-anchor="middle" or "end" puts glyphs left of x,
@@ -282,12 +284,12 @@ def check_svg_bounds(html):
             xs.append(_attr(t.group(0), "x"))
         left = (min(xs) + ox) - vx
         if left > vw * 0.10:
-            errors.append(
+            inset.append(
                 "figure '%s' starts %d%% inside its own viewBox; set the viewBox to the "
                 "drawing's bounds so the figure lines up with the text column"
                 % (name, round(100 * left / vw))
             )
-    return errors
+    return clipping, inset
 
 
 def check_style_accent(html, style):
@@ -329,6 +331,13 @@ def validate(path: Path, *, style: str, custom_template: bool) -> list[str]:
         tags = ", ".join(sorted(set(parser.inline_prose_styles)))
         errors.append(f"inline styles override default prose elements: {tags}")
 
+    # Clipping is measured on both paths. A drawing cut off by its own viewBox
+    # is broken whoever wrote it; the house style has no opinion about it. The
+    # inset check is the taste half and stays below the return.
+    raw_html = path.read_text(encoding="utf-8", errors="replace")
+    clipping, inset = _svg_faults(raw_html)
+    errors.extend(clipping)
+
     if custom_template:
         return errors
 
@@ -365,10 +374,12 @@ def validate(path: Path, *, style: str, custom_template: bool) -> list[str]:
 
     if not body_background:
         errors.append(f"missing required body background for the '{style}' house style")
-    raw = path.read_text(encoding="utf-8", errors="replace")
-    if not custom_template:
-        errors.extend(check_style_contract(parser.styles, style))
-    errors.extend(check_svg_bounds(raw))
+    raw = raw_html
+    errors.extend(check_style_contract(parser.styles, style))
+    # Figure alignment is a house-style judgment, not a correctness one, so it
+    # only applies where tdoc is the author. An agent bringing its own design
+    # system reaches this file through --custom-template and returned above.
+    errors.extend(inset)
     errors.extend(check_style_accent(raw, style))
 
     return errors

--- a/skills/tdoc/SKILL.md
+++ b/skills/tdoc/SKILL.md
@@ -280,8 +280,14 @@ When two fit, take the calmer one. The entries in full:
 a stat tile, a comparison matrix, a container frame or a label chip *is*,
 with no colour on it. Each `style/` entry gives the same parts its own
 treatment, so switching style changes how a component reads and never what
-it is. Section skeletons are still an empty slot — derive the document's
-shape from the prompt.
+it is.
+
+**The list is open.** A doc that needs a component nobody wrote down should
+have one. Build it from the tokens every style declares — `ink`, `rule`,
+`muted`, `surface`, `accent-fill`, `accent-stroke`, `accent-text`,
+`label-type` — and it is dressed correctly by every style, including any
+added later. The rest of the contract is in that file. Section skeletons
+are still an empty slot — derive the document's shape from the prompt.
 
 `visuals.md` is the visual-first floor: lead with charts, diagrams, tables, and
 stat tiles rather than paragraphs; pick the visual type that fits the data

--- a/skills/tdoc/SKILL.md
+++ b/skills/tdoc/SKILL.md
@@ -230,7 +230,8 @@ Three files are required reading before you write doc HTML, on every
 |---|---|---|
 | `$SKILL_DIR/authoring/voice.md` | how the prose reads | No. A floor — no switch, no doc exempt. |
 | `$SKILL_DIR/authoring/visuals.md` | how much of the doc is a picture | No. A floor — be visual-first, many visuals, varied types. |
-| `$SKILL_DIR/authoring/style/default.md` | what the page looks like | Only by naming another entry in `style/`. |
+| `$SKILL_DIR/authoring/structure/components.md` | what the parts are | No. The parts are the same in every style. |
+| `$SKILL_DIR/authoring/style/<picked>.md` | what those parts look like | Yes — you pick the entry that fits the content. |
 
 `$SKILL_DIR` is the installed skill directory resolved in "Setup check"
 above (`~/.claude/skills/tdoc`, or `~/.codex/skills/tdoc` under Codex) —
@@ -247,9 +248,21 @@ oversized tight-tracked headline, near-zero color, and a full technical-diagram
 vocabulary (thin frames, mono pill labels, numbered containers, solid/dashed
 arrows, one accent per figure, dot/hatch textured fills). The OpenAI-index
 aesthetic, done with open fonts — no brand assets, a look not an identity.
-Apply it unless the user names a different entry in `$SKILL_DIR/authoring/style/`.
+**Choose the style that fits the document you are about to write.** It is a
+judgment call, not a setting the user has to know exists: read what the content
+is, then pick. A user who names one has overridden you, and that stands — but
+saying nothing is not a vote for the default, it is leaving the choice to you.
 
-The other entries a user can name:
+- **`default`** — specs, explainers, anything carried by diagrams. The stark
+  register keeps the page quiet so the figures do the talking.
+- **`technical`** — dense engineering writeups, benchmarks, anything where the
+  identifiers and the numbers are the content. Opens dark-first.
+- **`paper`** — a long read meant to be read end to end: a vision doc, a
+  post-mortem with a story in it, an essay.
+- **`editorial`** — the same length, but argumentative: a position piece where
+  terms need marking as they are introduced.
+
+When two fit, take the calmer one. The entries in full:
 
 - `$SKILL_DIR/authoring/style/technical.md` — a cold engineering-blog register:
   mono for identifiers and metrics, neutral greys for structure, a single
@@ -263,8 +276,12 @@ The other entries a user can name:
   one clay accent. The Anthropic-blog aesthetic, done with open fonts (not
   the proprietary brand fonts, no logo/byline — a look, not an identity).
 
-`$SKILL_DIR/authoring/structure/` is still an empty mount point. Empty means
-no choice to make: derive the document's shape from the prompt.
+`$SKILL_DIR/authoring/structure/components.md` is the component library: what
+a stat tile, a comparison matrix, a container frame or a label chip *is*,
+with no colour on it. Each `style/` entry gives the same parts its own
+treatment, so switching style changes how a component reads and never what
+it is. Section skeletons are still an empty slot — derive the document's
+shape from the prompt.
 
 `visuals.md` is the visual-first floor: lead with charts, diagrams, tables, and
 stat tiles rather than paragraphs; pick the visual type that fits the data
@@ -316,7 +333,7 @@ that a GitHub page has opened and that the code is in the terminal; then keep
 working. Skip Step 0 entirely for the local-only and self-host destinations.
 
 1. Pick a slug from the prompt (kebab-case, ≤4 words).
-2. **Read `$SKILL_DIR/authoring/voice.md`, `$SKILL_DIR/authoring/visuals.md`, and `$SKILL_DIR/authoring/style/default.md`.**
+2. **Read `$SKILL_DIR/authoring/voice.md`, `$SKILL_DIR/authoring/visuals.md`, `$SKILL_DIR/authoring/structure/components.md`, and the `$SKILL_DIR/authoring/style/` entry you picked.**
    Voice constrains the prose as you generate it, not as a later cleanup
    pass. The style tells you which components to reach for and its palette —
    apply it unless the user named another entry in `$SKILL_DIR/authoring/style/`.
@@ -328,7 +345,7 @@ working. Skip Step 0 entirely for the local-only and self-host destinations.
      CSP and therefore create controls or empty panels that cannot work. If
      the idea needs computation, write `v1/widgets/<name>.html` and iframe it.
    - No external CDNs in the host unless requested. No build step.
-   - The default style is mandatory when the user names no style. A full-page
+   - Pick the style that fits the content when the user names none. A full-page
      custom design is allowed only when the user explicitly requests one;
      programmatic callers must make that exception visible with
      `--custom-template`.
@@ -482,7 +499,7 @@ comments you handled unless you reply on each one. Skipping comments
 silently is the #1 source of regression complaints.
 
 1. Read `~/tdocs/<slug>/comments.json` — filter to `status: "open"`.
-2. Read latest version's `index.html`, and re-read `$SKILL_DIR/authoring/voice.md` and `$SKILL_DIR/authoring/visuals.md`.
+2. Read latest version's `index.html`, and re-read `$SKILL_DIR/authoring/voice.md`, `$SKILL_DIR/authoring/visuals.md` and `$SKILL_DIR/authoring/structure/components.md`.
    A regeneration writes new prose, so the contract applies here exactly as
    it does on `/tdoc new`. Prose you carry over unchanged from the previous
    version stays as it is — do not re-edit untouched sections for voice, and
@@ -917,8 +934,8 @@ The overlay's template is modeled after the `conway-life` doc ("What if a doc co
 - pre: mono 15px, light gray background, left-rule, scrolling overflow
 - Code (inline): 0.92em mono, light-gray rounded chip
 
-**The default style is mandatory when the user names no other style.** Use the
-CSS from `$SKILL_DIR/authoring/style/default.md` as written. Add only the
+**Pick a style from `$SKILL_DIR/authoring/style/` for every doc**, and use that
+entry's CSS as written. Add only the
 house style's components and tightly scoped CSS for content-specific charts,
 diagrams, and controls. Do not invent additional bare-element rules or change
 the content root's width, margins, or padding.

--- a/test/authoring.test.js
+++ b/test/authoring.test.js
@@ -58,6 +58,26 @@ t('every style gives the same components a treatment', () => {
     const missing = parts.filter(part => !text.includes(part));
     assert(missing.length === 0,
       `style/${entry}.md gives no treatment for: ${missing.join(', ')}`);
+    // Tokens are what let a component nobody anticipated pick up this style.
+    // Without them the listed parts still work and everything else is undressed,
+    // which is the failure that made styles unswappable in the first place.
+    const tokens = ['ink', 'rule', 'muted', 'surface',
+                    'accent-fill', 'accent-stroke', 'accent-text', 'label-type'];
+    const noToken = tokens.filter(tk => !new RegExp('`' + tk + '`').test(text));
+    assert(noToken.length === 0,
+      `style/${entry}.md declares no value for: ${noToken.join(', ')}`);
+  }
+});
+
+t('the component list is open, not a vocabulary limit', () => {
+  const c = read('authoring/structure/components.md');
+  assert(/not on this list/i.test(c),
+    'components.md does not say how to write a component it does not list');
+  // The extension contract is the whole point: meet these and a user's own
+  // component behaves like a listed one. If they drift, an invented component
+  // silently stops swapping style or stops being commentable.
+  for (const rule of ['token', 'data-tdoc-artifact']) {
+    assert(c.includes(rule), `components.md extension contract lost "${rule}"`);
   }
 });
 

--- a/test/authoring.test.js
+++ b/test/authoring.test.js
@@ -35,14 +35,30 @@ t('all three slots exist', () => {
   }
 });
 
-t('structure/ is still an empty mount point', () => {
-  // Adding entries is fine — but it must be a deliberate change that also
-  // teaches SKILL.md how to select one, not a stray file. This test is the
-  // reminder to do both.
-  const entries = fs.readdirSync(path.join(root, 'authoring/structure'));
-  assert(entries.length === 1 && entries[0] === 'README.md',
-    `authoring/structure gained ${entries.filter(e => e !== 'README.md').join(', ')} — ` +
-    `if that is intended, teach SKILL.md how a doc selects one, then update this test`);
+t('structure/ carries the component library, and SKILL.md knows about it', () => {
+  // structure/ stopped being an empty slot when the components moved out of
+  // style/default.md. A component here must stay style-free: the moment one
+  // hardcodes a colour, swapping style stops being a swap.
+  const c = read('authoring/structure/components.md');
+  assert(/stat tile|container frame|label chip/i.test(c),
+    'components.md does not describe the parts');
+  const hex = c.match(/#[0-9a-fA-F]{6}/g) || [];
+  assert(hex.length === 0, `components.md hardcodes colour: ${hex.join(', ')} — treatment belongs in style/`);
+  assert(read('SKILL.md').includes('authoring/structure/components.md'),
+    'SKILL.md does not point at the component library');
+});
+
+t('every style gives the same components a treatment', () => {
+  // The swap is only real if each style answers for the same parts. A style
+  // that skips one leaves that component undefined the moment it is selected.
+  const parts = ['Container frame', 'Label chip', 'Numbered group', 'Description box',
+                 'Primary arrow', 'Secondary arrow', 'Accent fill', 'Textured variant', 'Stacked bar'];
+  for (const entry of ['default', 'technical', 'paper', 'editorial']) {
+    const text = read(`authoring/style/${entry}.md`);
+    const missing = parts.filter(part => !text.includes(part));
+    assert(missing.length === 0,
+      `style/${entry}.md gives no treatment for: ${missing.join(', ')}`);
+  }
 });
 
 t('style/ ships a default entry with its vocabulary', () => {
@@ -54,7 +70,7 @@ t('style/ ships a default entry with its vocabulary', () => {
   for (const mark of ['Inter', 'pattern', 'hatch']) {
     assert(d.includes(mark), `default.md no longer carries "${mark}"`);
   }
-  assert(/diagram vocabulary/i.test(d), 'default.md lost its diagram vocabulary section');
+  assert(/component treatment/i.test(d), 'default.md lost its component treatment section');
 });
 
 t('the default style sets its stark typography', () => {
@@ -82,13 +98,17 @@ t('every style/ entry is selectable from SKILL.md', () => {
     '    An entry the agent cannot be told to use is a file nobody reads.');
 });
 
-t('the default style is applied on the generation path, not merely listed', () => {
+t('a style is picked and applied on the generation path, not merely listed', () => {
   const s = read('SKILL.md');
   const a = s.indexOf('### `/tdoc new');
   const b = s.indexOf('### `bin/tdoc-new');
   assert(a !== -1 && b !== -1, '/tdoc new section not found');
-  assert(s.slice(a, b).includes('authoring/style/default.md'),
-    '/tdoc new does not read authoring/style/default.md');
+  const section = s.slice(a, b);
+  assert(/authoring\/style\//.test(section), '/tdoc new does not read an authoring/style/ entry');
+  // The choice is the agent's. If this reverts to "the user names a style",
+  // every doc silently gets `default` again whatever the content is.
+  assert(/Choose the style that fits/.test(s),
+    'SKILL.md no longer asks the agent to choose a style from the content');
 });
 
 t('visuals.md is a wired-in visual-first floor', () => {


### PR DESCRIPTION
Refs #294.

## What was actually wrong

`authoring/structure/` was an empty mount point, so the components had nowhere to live and ended up inside `style/default.md` — ten shape definitions in a file that says, on line 57, that it is *"the treatment, not a fixed set of shapes"*. The file contradicted itself, and only `default` ever defined them:

| style | shape definitions | treatment values |
|---|---|---|
| `default.md` | **10** | 30 |
| `technical.md` | 0 | 28 |
| `paper.md` | 1 | 19 |
| `editorial.md` | 1 | 19 |

Selecting `technical` did not restyle a label chip or a numbered group — it left them undefined. Swapping style was not a swap; it was dropping the components on the floor.

## Three layers instead of two

| Layer | Answers | Where |
|---|---|---|
| Which component fits this data? | the data | `visuals.md` |
| What is that component? | fixed across styles | `structure/components.md` |
| What does it look like? | the agent's pick | `style/<entry>.md` |

`structure/components.md` holds the parts with no colour on them. All four styles answer for the same nine figure parts in their own palette.

## The list is open, and tokens are what make that work

Nine named parts with a per-style treatment each is still a closed set: a component nobody wrote down would have no treatment anywhere, so the moment a doc needs a decision ladder or a burndown, that component stops swapping style. Saying "write your own" without fixing that is an invitation to a broken doc.

Every style now declares the same eight tokens — `ink`, `rule`, `muted`, `surface`, `accent-fill`, `accent-stroke`, `accent-text`, `label-type` — and the listed components are expressed in them. A component built from tokens is dressed by all four styles, and by any entry added later, because a new style has to answer for the same names.

Verified by dressing an invented component from each entry in turn:

```
decision-ladder needs: ink, rule, muted, surface, accent-*, label-type
  default    ✓  ink=#0a0a0a   accent=#b3503c
  technical  ✓  ink=#0a0a0a   accent=#ff4b2e
  paper      ✓  ink=#141413   accent=#c15f3c
  editorial  ✓  ink=#0a0a0a   accent=#2200ff
```

The declarations existed only unevenly before — `default` had no surface value, `editorial` had no muted one — so this could not have worked by accident.

`components.md` gains the contract for a component it does not list: name tokens rather than colours, be one comment anchor, survive a phone, compute nothing in the host. Meet those and an invented component behaves like a listed one. It does not need to be added to the file to be used.

## The agent picks the style

*"Apply it unless the user names a different entry"* meant every doc silently got `default` whatever it contained, since a user who has never read the skill names nothing. SKILL.md now asks the agent to read the content and choose, with a line on what each entry is good for. Naming one still overrides.

## Enforcement tiers, per the issue

The issue's complaint reproduces. A reasonable doc from an external skill:

```
- '.wrap' sets color: #1a1a1a — 'default' says #0a0a0a
- '.wrap h1' font-weight: 700 — says 600
```

Six errors, none affecting whether the doc works. `--custom-template` already passed it, so the two-tier mechanism existed — it was framed as a rare exception rather than the posture for the programmatic path.

Sorting the checks surfaced a bug: the `custom_template` early return sat **above** the SVG check, so external docs got no clipping check at all.

| | tdoc authors | external agent |
|---|---|---|
| host JS, `<canvas>`, content root, viewport | ✓ | ✓ |
| figure clipping | ✓ | ✓ **(was skipped)** |
| figure alignment, typography, palette | ✓ | — |

## Wording

`authoring/README.md` said `style/` and `structure/` were *"Empty — reserved"*, which stopped being true four style entries ago, and framed the directory as what every doc *"must go through"*. It now says these are references and points at the short list of things that are genuinely MUST.

## Checks

46 offline suites green. Four tests hold the model: no component carries a hex, no style skips a part, no style skips a token, and `components.md` keeps saying how to write a component it does not list. Every one of those failures is silent otherwise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Xw9Mt3rV3ujnejPr41pqvz