### PR TITLE
Draw generously, and let each doc find its own shape

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -286,14 +286,14 @@ it is.
 have one. Build it from the tokens every style declares — `ink`, `rule`,
 `muted`, `surface`, `accent-fill`, `accent-stroke`, `accent-text`,
 `label-type` — and it is dressed correctly by every style, including any
-added later. The rest of the contract is in that file. Section skeletons
-are still an empty slot — derive the document's shape from the prompt.
+added later. The rest of the contract is in that file.
 
-`visuals.md` is the visual-first floor: lead with charts, diagrams, tables, and
-stat tiles rather than paragraphs; pick the visual type that fits the data
-(bar, line/scatter, quadrant, matrix, timeline, stacked bar, flow — not a
-flowchart by default); most docs carry several different types. The style
-colors them; this file decides there should be many.
+Which sections a doc has is decided by the prompt and the material, per doc.
+
+`visuals.md` is the visual-first floor: draw generously, and pick the visual
+type that fits the data (bar, line/scatter, quadrant, matrix, timeline,
+stacked bar, flow). Most docs carry several different types. The style colors
+them; this file decides there should be many.
 
 ## Commands
 

--- a/authoring/README.md
+++ b/authoring/README.md
@@ -18,7 +18,7 @@ Four slots, separate because they answer different questions:
 |---|---|---|
 | `voice.md` | How does the prose read? | Nobody picks "sound like AI" — it applies by default |
 | `visuals.md` | Which component fits this data? | The data |
-| `structure/components.md` | What is that component, structurally? | Fixed across styles — that is what makes a style swappable |
+| `structure/components.md` | What is that component, structurally? | Fixed across styles — that is what makes a style swappable. The list is open |
 | `style/` | What does that component look like? | **The agent picks the entry that fits the content** |
 
 The last two are the axis that matters: a stat tile is the same stat tile in

--- a/authoring/structure/README.md
+++ b/authoring/structure/README.md
@@ -5,29 +5,5 @@ matrix, a container frame or a label chip *is*, with no colour on it. Every
 `style/` entry gives those same parts its own treatment, which is what makes
 a style swappable rather than a rewrite.
 
-**Section skeletons are still an empty slot.** A structure entry would answer
-"which sections does this kind of doc have":
-a post-mortem is timeline, blast radius, root cause, action items; a PRD
-is problem, user, non-goals, success measures.
-
-With this directory empty, the agent derives the shape from the prompt,
-exactly as it does today. Nothing changes until entries are added, and
-adding one must stay additive.
-
-## Structure is the half that saves work
-
-Recorded here so the reasoning is not lost: across the first 39 docs
-written with tdoc, the strongest signal was repetition of a single kind.
-Six separate docs across five near-duplicate slugs were all the same
-launch post, restarted from scratch each time. Other kinds show the cost
-as version depth instead — an explainer at v19, a user-feedback report at
-v10.
-
-Neither cost is a styling problem. Both are "what should this contain and
-in what order," which is what an entry here would answer.
-
-## Not a fill-in-the-blanks form
-
-An entry should describe what a section is *for* and what makes it good,
-so the agent can judge whether the material fits. A doc that emits empty
-headings the writer then has to fill in is worse than no template.
+Document shape is not kept here. Which sections a doc has is decided by the
+prompt and the material, per doc.

--- a/authoring/visuals.md
+++ b/authoring/visuals.md
@@ -6,20 +6,18 @@ words; this governs how much of the doc is a picture instead of words.
 
 ## Be visual-first
 
-A tdoc doc should lead with visuals, not paragraphs. If a claim has data, a
-comparison, a structure, a sequence, or a tradeoff in it, **draw it** — prose
-is the connective tissue between visuals, not the main body. Aim for a visual
-roughly every screenful. A wall of text with one diagram is a failure of this
-contract, not a neutral choice.
+Draw generously. If a claim has data, a comparison, a structure, a sequence, or
+a tradeoff in it, **draw it** — prose is the connective tissue between visuals,
+not the main body. Aim for a visual roughly every screenful, wherever in the
+doc the material earns one.
 
 Everything here is buildable as inline SVG or CSS — the host runs no author
 JS, so no chart library. An SVG chart is also a commentable artifact, which is
 the point of tdoc. Draw honestly: real numbers, labeled axes, no chartjunk.
 
-## Don't default to a flowchart. Match the visual to the data.
+## Match the visual to the data
 
-A flowchart is one option among many, and the most overused. Pick by what the
-data *is*:
+Pick by what the data *is*:
 
 | The data is… | Reach for |
 |---|---|

--- a/skills/tdoc/SKILL.md
+++ b/skills/tdoc/SKILL.md
@@ -286,14 +286,14 @@ it is.
 have one. Build it from the tokens every style declares — `ink`, `rule`,
 `muted`, `surface`, `accent-fill`, `accent-stroke`, `accent-text`,
 `label-type` — and it is dressed correctly by every style, including any
-added later. The rest of the contract is in that file. Section skeletons
-are still an empty slot — derive the document's shape from the prompt.
+added later. The rest of the contract is in that file.
 
-`visuals.md` is the visual-first floor: lead with charts, diagrams, tables, and
-stat tiles rather than paragraphs; pick the visual type that fits the data
-(bar, line/scatter, quadrant, matrix, timeline, stacked bar, flow — not a
-flowchart by default); most docs carry several different types. The style
-colors them; this file decides there should be many.
+Which sections a doc has is decided by the prompt and the material, per doc.
+
+`visuals.md` is the visual-first floor: draw generously, and pick the visual
+type that fits the data (bar, line/scatter, quadrant, matrix, timeline,
+stacked bar, flow). Most docs carry several different types. The style colors
+them; this file decides there should be many.
 
 ## Commands
 

--- a/test/authoring.test.js
+++ b/test/authoring.test.js
@@ -134,8 +134,13 @@ t('a style is picked and applied on the generation path, not merely listed', () 
 t('visuals.md is a wired-in visual-first floor', () => {
   assert(exists('authoring/visuals.md'), 'authoring/visuals.md missing');
   const v = read('authoring/visuals.md');
-  assert(/visual-first/i.test(v) && /flowchart/i.test(v),
-    'visuals.md is not the visual-first floor (no visual-first / flowchart guidance)');
+  assert(/visual-first/i.test(v), 'visuals.md lost its visual-first framing');
+  // The matcher is the working half: without it "be visual-first" collapses to
+  // whichever visual is easiest to produce for any subject.
+  assert(/Match the visual to the data/i.test(v), 'visuals.md lost the matcher heading');
+  for (const kind of ['bar chart', 'scatter', 'timeline', 'stacked bar']) {
+    assert(v.includes(kind), `visuals.md matcher no longer offers "${kind}"`);
+  }
   // must be $SKILL_DIR-anchored and on both generation paths, like voice.md
   const s = read('SKILL.md');
   const seg=(a,b)=>{const x=s.indexOf(a);const y=b?s.indexOf(b,x):s.length;return s.slice(x,y===-1?s.length:y);};


### PR DESCRIPTION
Follows #297 (same branch lineage — merge that one first).

## Two rules were producing one shape

*"Lead with visuals, not paragraphs"* reads as a rule about **where** a visual goes rather than how many there are. The matcher's easiest row to satisfy for any subject at all is *a few key numbers → stat tiles*, so that is what the opening became.

| | opens with a stat-tile row |
|---|---|
| all 71 docs in `~/tdocs` | 12 (17%) |
| the last 15 | **10 (67%)** |

The habit is tightening, not the guidance working. `visuals.md` now says draw generously and place a visual wherever the material earns one. `SKILL.md` restated the same sentence and now restates the new one.

## structure/ was arguing for something that should not exist

`structure/README.md` spent thirty lines making the case for section skeletons — which kinds of doc have which sections, why structure saves more work than styling — for a directory that has none. The argument also pointed the wrong way: document shape is a judgment from the prompt and the material, per doc, not a library to grow.

Two sentences replace the thirty. `components.md` stays, because components are the part that genuinely holds still across styles; document shape is not.

## Test

The matcher heading loses its negative framing, so the test that asserted on that wording now asserts the table itself — the matcher is the working half, and without it "be visual-first" collapses to whichever visual is cheapest to produce for any subject.

## Audit

Swept the generation path for other wording that fixes an output shape. `lead with` and `rather than paragraphs` are gone from both copies of SKILL.md. The remaining imperatives are invariants rather than taste — the `prefers-reduced-motion` guard, the body background, mobile responsiveness — and `templates/` ships no example document to be copied wholesale.

46 offline suites green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Xw9Mt3rV3ujnejPr41pqvz