### PR TITLE
Reject content that escapes the content root

### DIFF
--- a/bin/tdoc-validate-template
+++ b/bin/tdoc-validate-template
@@ -54,6 +54,7 @@ class ContractParser(HTMLParser):
         self.styles: list[str] = []
         self.has_viewport = False
         self.primary_roots = 0
+        self.stray_body_children: list[str] = []
         self.has_footer = False
         self.inline_prose_styles: list[str] = []
         self.author_scripts = 0
@@ -98,6 +99,11 @@ class ContractParser(HTMLParser):
                 classes = set(attrs.get("class", "").split())
                 if tag in {"main", "article"} or classes.intersection(ROOT_CLASSES):
                     self.primary_roots += 1
+                elif tag not in {"script", "style", "template", "noscript"}:
+                    # A sibling of the content root. Almost always the tail of a
+                    # document whose root was closed early by one stray </div>:
+                    # everything after it lands here and loses the reading column.
+                    self.stray_body_children.append(tag)
             if tag not in VOID_TAGS:
                 self.body_depth += 1
 
@@ -317,6 +323,16 @@ def validate(path: Path, *, style: str, custom_template: bool) -> list[str]:
         errors.append('missing <meta name="viewport">')
     if parser.primary_roots != 1:
         errors.append("expected exactly one direct body content root (.wrap, main, article, .content, or .container)")
+    # Only when a root exists. A doc with no root at all is a supported shape —
+    # the template applies the column to body itself via :has() — and its
+    # headings are not "escaped", they are the document.
+    if parser.primary_roots >= 1 and parser.stray_body_children:
+        kinds = ", ".join(f"<{t}>" for t in sorted(set(parser.stray_body_children))[:6])
+        errors.append(
+            "%d element(s) sit outside the content root (%s); the reading column does not "
+            "apply to them. One unbalanced </div> closing the root early is the usual cause"
+            % (len(parser.stray_body_children), kinds)
+        )
     if parser.has_footer:
         errors.append("author <footer> is reserved; the tdoc shell supplies the footer")
     if parser.author_scripts:

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -138,6 +138,41 @@ t('tdoc default-template validator accepts scoped widget CSS', () => {
   }
 });
 
+t('validator rejects content that escapes the content root', () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'tdoc-root-'));
+  const run = (name, body) => {
+    const html = path.join(dir, name);
+    fs.writeFileSync(html, `<!doctype html><html><head>
+      <meta name="viewport" content="width=device-width, initial-scale=1">
+      <style>body { background: #fff; }</style>
+      </head><body>${body}</body></html>`);
+    return spawnSync(path.join(BIN, 'tdoc-validate-template'), [html], { encoding: 'utf8' });
+  };
+  try {
+    // One stray </div> closes .wrap early and the rest of the document becomes a
+    // sibling of it. Every check still passes — the doc has a content root, its
+    // CSS is in contract — but the reading column stops applying and the page
+    // renders full-bleed. Only the nesting shows it.
+    const escaped = run('escaped.html',
+      '<div class="wrap"><h1>T</h1><div class="tiles"><div class="tile">n</div></div></div>' +
+      '<h2>Everything after this is outside</h2><p>and loses the column</p>');
+    assert(escaped.status !== 0, 'content outside the root should be rejected');
+    assert(/outside the content root/.test(escaped.stderr), escaped.stderr);
+
+    const nested = run('nested.html',
+      '<div class="wrap"><h1>T</h1><div class="tiles"><div class="tile">n</div></div>' +
+      '<h2>Still inside</h2><p>keeps the column</p></div>');
+    assert(nested.status === 0, `correctly nested doc rejected: ${nested.stderr}`);
+
+    // <script>/<style> at body level are not content and must not trip it
+    const scripts = run('scripts.html',
+      '<div class="wrap"><h1>T</h1></div><template id="x"></template>');
+    assert(scripts.status === 0, `template beside the root should pass: ${scripts.stderr}`);
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
 t('validator rejects a figure whose ink floats inside its own viewBox', () => {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'tdoc-viewbox-'));
   const page = (svg) => `<!doctype html><html><head>


### PR DESCRIPTION
A doc I generated rendered full-bleed on tdoc.dev, and every check passed on the way out.

One stray `</div>` closed `.wrap` at byte 4189 of a 37KB document. The remaining 89% became siblings of the root, so `:where(body > .wrap)` — which supplies the 720px column — stopped applying to it. Measured against the previous version at the same viewport:

| | content width at 1280px |
|---|---|
| v2 | 671px |
| v4 | **1261px** |

Nothing else was wrong. The doc had a content root, its CSS was in contract, its figures were in bounds. The nesting was the only tell, and nothing looked at it.

## The check

The parser already counted content roots at body level. It now also records the elements it finds *beside* one, and rejects them by name and count.

It fires only when a root exists. A doc with no root at all is a supported shape — the template applies the column to `body` itself through `:has()` — and its headings are the document rather than escapees. `~/tdocs/hello` is exactly that, and it was the one false positive in a sweep of every doc on this machine before that condition went in. Zero after.

`<script>`, `<style>`, `<template>` and `<noscript>` beside the root are not content and do not trip it.

## Tier

Structural, not stylistic, so it runs on both paths — beside the existing "exactly one content root" rule, which would otherwise be trivially satisfiable by a document whose root wraps only its first paragraph.

46 offline suites green; the new test covers the escaped case, the correctly nested case, and a `<template>` sibling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Xw9Mt3rV3ujnejPr41pqvz