### PR TITLE
Table cells have to reset their own shape, not only the parts being changed

### DIFF
--- a/authoring/structure/components.md
+++ b/authoring/structure/components.md
@@ -55,9 +55,15 @@ Fills are also the worst case for this reader — dark mode is a whole-page
 invert, so a filled cell becomes a slab where a hairline only changes colour.
 
 Rounding a table needs `border-collapse: separate` with `border-spacing: 0` and
-`overflow: hidden` to clip; `collapse` will not round. Clear the cell fill
-explicitly — the reader supplies one, and a rule that sets only borders and
-padding leaves it in place, so the card comes out filled anyway.
+`overflow: hidden` to clip; `collapse` will not round.
+
+Reset the cell's own shape, not only the parts you are changing. The reader
+styles cells as standalone chips — a fill and a corner radius of their own —
+and those survive any rule that does not name them. A treatment that sets
+borders and padding alone comes out filled; one that also clears the fill but
+leaves the radius comes out with row rules that curve away at every cell
+boundary instead of crossing the table. Set `background` and `border-radius`
+on the cell explicitly; the card carries the radius, the cells do not.
 
 **Scroll wrappers** — `tdoc-table-scroll` for a table, `diagram-box` for a
 figure. Both are `overflow-x: auto`, and both need the child to have a


### PR DESCRIPTION
The ruled-card table shipped with row rules that stop at the column boundary and curve away instead of crossing the table.

Same class of miss as the fill in #300, one property along. The reader styles cells as standalone chips — a fill *and* a corner radius of their own — and both survive any rule that does not name them. #300 added `background: transparent` and stopped there, so `border-radius: 8px` stayed on every cell. Under `border-collapse: separate` each cell is its own box, so a `border-bottom` on it gets rounded off at both ends, and two rounded ends meeting in the middle read as a break in the rule.

Measured on a two-column table, counting gaps along a row rule:

| | gaps in the rule |
|---|---|
| cells keep `border-radius: 8px` | **3** |
| cells set `border-radius: 0` | 0 |

`components.md` now says to reset the cell's shape rather than the parts being changed, and names both properties. The card carries the radius; the cells do not.

Verified on the published page: every row rule crosses the full 665px table with zero gaps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Xw9Mt3rV3ujnejPr41pqvz