### PR TITLE
Tables are square, and the header takes the label register

### DIFF
--- a/authoring/structure/components.md
+++ b/authoring/structure/components.md
@@ -48,22 +48,29 @@ rather than a tinted band, and numbers are tabular so a column lines up.
 </div>
 ```
 
-The shape matters more than it looks. Filling every cell and spacing them apart
-turns a table into a pile of blocks: the gutters cut the columns, so the eye has
-no continuous edge to scan down, and rounded corners multiply with every row.
-Fills are also the worst case for this reader — dark mode is a whole-page
-invert, so a filled cell becomes a slab where a hairline only changes colour.
+The header is a label, so it takes the style's `label-type` register rather
+than a smaller, greyer version of the body. Set at body size in the muted ink
+it reads as a quieter row instead of a different kind of row; in the label
+register it is unmistakable at a glance, whatever its size. Give it its own
+rule, a step stronger than the row rules under it.
 
-Rounding a table needs `border-collapse: separate` with `border-spacing: 0` and
-`overflow: hidden` to clip; `collapse` will not round.
+**Square corners.** No radius on the table and none on its cells. A rounded
+card competes with the figures around it, and a radius on the cells is worse
+than decorative: under `border-collapse: separate` each cell is its own box, so
+a rounded one truncates the row rule at both ends and two of those meeting in
+the middle read as a break in the line rather than a continuous edge to scan
+down.
+
+Filling every cell and spacing them apart has the same effect for a different
+reason: the gutters cut the columns, leaving nothing continuous to follow. A
+fill is also the worst case for this reader — dark mode is a whole-page invert,
+so a filled cell becomes a slab where a hairline only changes colour.
 
 Reset the cell's own shape, not only the parts you are changing. The reader
 styles cells as standalone chips — a fill and a corner radius of their own —
-and those survive any rule that does not name them. A treatment that sets
-borders and padding alone comes out filled; one that also clears the fill but
-leaves the radius comes out with row rules that curve away at every cell
-boundary instead of crossing the table. Set `background` and `border-radius`
-on the cell explicitly; the card carries the radius, the cells do not.
+and those survive any rule that does not name them, so a treatment that sets
+borders and padding alone comes out filled and rounded anyway. Name
+`background` and `border-radius` explicitly.
 
 **Scroll wrappers** — `tdoc-table-scroll` for a table, `diagram-box` for a
 figure. Both are `overflow-x: auto`, and both need the child to have a

--- a/authoring/style/default.md
+++ b/authoring/style/default.md
@@ -87,7 +87,7 @@ white with one pastel accent, and it draws any figure the content asks for.
 | Accent fill | Pink `fill:#f7d7d1 stroke:#e0a99e`, text `#b3503c`; or blue `fill:#dde7f9 stroke:#a9c0ee`, text `#26407a` |
 | Textured variant | Dot over the pink for a live state; diagonal hatch over the blue for a transformed one |
 | Stacked bar | Blue shades `#c4d4f5` / `#d4e0f8` / `#e8eefb` with `#a9c0ee` strokes and mono labels; a hatched segment marks a transformed part, a dashed baseline marks a limit |
-| Table | `rule` hairline border, `rx:12` card; row rules in `rule`; header in `muted`, normal case, no fill |
+| Table | `rule` hairline border, square corners; row rules in `rule`; header in `label-type` — uppercase mono, `muted` — over its own `rule`; no fill |
 
 Solid pastel is the base and the texture is the *variant*, not the fill. Put
 the colour inside the pattern tile so the texture reads on top of it rather

--- a/authoring/style/editorial.md
+++ b/authoring/style/editorial.md
@@ -91,7 +91,7 @@ is a pointer, not a decoration, and it lands on one element.
 | Accent fill | `fill:#eef1fb stroke:#3a55f4`, text `#2200ff` |
 | Textured variant | Hatch in `#3a55f4` over the same fill; the green `#4ba181` is reserved for a positive outcome and never used as a second accent |
 | Stacked bar | Blues `#eef1fb` / `#dbe3fa` / `#c3d0f6` with `#b3bdc9` strokes |
-| Table | `rule` hairline border, `rx:10` card; row rules in `rule`; header serif in `muted`, no fill |
+| Table | `rule` hairline border, square corners; row rules in `rule`; header in `label-type` sans, `muted`, over its own `rule`; no fill |
 
 The underline that marks a term in prose has no figure equivalent. Inside a
 drawing, emphasis is the accent fill.

--- a/authoring/style/paper.md
+++ b/authoring/style/paper.md
@@ -92,7 +92,7 @@ only saturated thing on the page and it stays rationed.
 | Accent fill | `fill:#f4e3dc stroke:#e3c4b6`, text `#c15f3c` |
 | Textured variant | Sparse dot in `#e3c4b6` over the same fill |
 | Stacked bar | Paper tints `#f4efe7` / `#ece5d8` / `#dcd3c4` with `#c9bfae` strokes |
-| Table | `rule` hairline border, `rx:6` card; row rules in `rule`; header small-caps in `muted`, no fill |
+| Table | `rule` hairline border, square corners; row rules in `rule`; header in `label-type` small-caps, `muted`, over its own `rule`; no fill |
 
 Figure labels are the body sans, not the display serif — the serif is for
 headings, and inside a drawing it turns decorative.

--- a/authoring/style/technical.md
+++ b/authoring/style/technical.md
@@ -131,7 +131,7 @@ the single thing the figure is about.
 | Accent fill | `fill:#fff5f3 stroke:#ff4b2e`, text `#ff4b2e` — **one node per figure** |
 | Textured variant | Diagonal hatch in `#ff4b2e` at 35% over the same fill |
 | Stacked bar | Greys `#f0f0f0` / `#e5e5e5` / `#d4d4d4` with `#a3a3a3` strokes; the segment under discussion takes the accent |
-| Table | `rule` hairline border, square corners; row rules in `rule`; header mono in `muted`; figures tabular |
+| Table | `rule` hairline border, square corners; row rules in `rule`; header in `label-type` mono, `muted`, over its own `rule`; figures tabular; no fill |
 
 Metric labels are mono here, including inside figures — a number set in the
 body sans reads as prose and gets skimmed.


### PR DESCRIPTION
Two things about the table treatment from #300.

## Square corners

The radius is gone from the contract and from all four styles. A rounded card competes with the figures around it, and on the cells it was worse than decorative — that was the break in the row rules #301 chased: under `border-collapse: separate` each cell is its own box, so a rounded one truncates the rule at both ends and two of those meeting in the middle read as a gap rather than a continuous edge.

`default`, `paper` and `editorial` carried `rx:12`, `rx:6` and `rx:10`; all four now say square corners, which is what `technical` already said.

## A header that reads as a header

It was set at `13.5px` in the muted ink — smaller and greyer than the body, so it read as a *quieter* row rather than a *different kind* of row.

It now takes the style's `label-type` token, which every entry already declares, over its own rule a step stronger than the row rules beneath it. A table header is a label, so this is the token doing the job it exists for rather than a new rule invented for tables. Uppercase and letterspaced, it separates at a glance whatever its size — where weight and colour alone have to compete with the body text next to them.

## Verified on the published page

- row rules cross the full table with **0 gaps**
- the top-left corner pixel is border-coloured, not white — square, not rounded
- no `border-radius` in the served table CSS

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Xw9Mt3rV3ujnejPr41pqvz