### PR TITLE
The table header rule is structural, not another typographic signal

### DIFF
--- a/authoring/structure/components.md
+++ b/authoring/structure/components.md
@@ -51,8 +51,15 @@ rather than a tinted band, and numbers are tabular so a column lines up.
 The header is a label, so it takes the style's `label-type` register rather
 than a smaller, greyer version of the body. Set at body size in the muted ink
 it reads as a quieter row instead of a different kind of row; in the label
-register it is unmistakable at a glance, whatever its size. Give it its own
-rule, a step stronger than the row rules under it.
+register it is unmistakable at a glance, whatever its size.
+
+Under it goes a rule in `ink`, heavier than the hairlines between rows. That
+separation is structural rather than typographic, which is why it is worth
+spending: the register already carries every typographic signal available —
+case, tracking, size, face — so making the header bolder or darker competes
+with the body text on an axis that is used up. A rule does not. A hairline in
+the same weight as the row rules below is not a header rule at all; the eye
+reads the header as one more row.
 
 **Square corners.** No radius on the table and none on its cells. A rounded
 card competes with the figures around it, and a radius on the cells is worse

--- a/authoring/style/default.md
+++ b/authoring/style/default.md
@@ -87,7 +87,7 @@ white with one pastel accent, and it draws any figure the content asks for.
 | Accent fill | Pink `fill:#f7d7d1 stroke:#e0a99e`, text `#b3503c`; or blue `fill:#dde7f9 stroke:#a9c0ee`, text `#26407a` |
 | Textured variant | Dot over the pink for a live state; diagonal hatch over the blue for a transformed one |
 | Stacked bar | Blue shades `#c4d4f5` / `#d4e0f8` / `#e8eefb` with `#a9c0ee` strokes and mono labels; a hatched segment marks a transformed part, a dashed baseline marks a limit |
-| Table | `rule` hairline border, square corners; row rules in `rule`; header in `label-type` — uppercase mono, `muted` — over its own `rule`; no fill |
+| Table | `rule` hairline border, square corners; row rules in `rule`; header in `label-type` — uppercase mono, `muted` — over a rule in `ink`; no fill |
 
 Solid pastel is the base and the texture is the *variant*, not the fill. Put
 the colour inside the pattern tile so the texture reads on top of it rather

--- a/authoring/style/editorial.md
+++ b/authoring/style/editorial.md
@@ -91,7 +91,7 @@ is a pointer, not a decoration, and it lands on one element.
 | Accent fill | `fill:#eef1fb stroke:#3a55f4`, text `#2200ff` |
 | Textured variant | Hatch in `#3a55f4` over the same fill; the green `#4ba181` is reserved for a positive outcome and never used as a second accent |
 | Stacked bar | Blues `#eef1fb` / `#dbe3fa` / `#c3d0f6` with `#b3bdc9` strokes |
-| Table | `rule` hairline border, square corners; row rules in `rule`; header in `label-type` sans, `muted`, over its own `rule`; no fill |
+| Table | `rule` hairline border, square corners; row rules in `rule`; header in `label-type` sans, `muted`, over a rule in `ink`; no fill |
 
 The underline that marks a term in prose has no figure equivalent. Inside a
 drawing, emphasis is the accent fill.

--- a/authoring/style/paper.md
+++ b/authoring/style/paper.md
@@ -92,7 +92,7 @@ only saturated thing on the page and it stays rationed.
 | Accent fill | `fill:#f4e3dc stroke:#e3c4b6`, text `#c15f3c` |
 | Textured variant | Sparse dot in `#e3c4b6` over the same fill |
 | Stacked bar | Paper tints `#f4efe7` / `#ece5d8` / `#dcd3c4` with `#c9bfae` strokes |
-| Table | `rule` hairline border, square corners; row rules in `rule`; header in `label-type` small-caps, `muted`, over its own `rule`; no fill |
+| Table | `rule` hairline border, square corners; row rules in `rule`; header in `label-type` small-caps, `muted`, over a rule in `ink`; no fill |
 
 Figure labels are the body sans, not the display serif — the serif is for
 headings, and inside a drawing it turns decorative.

--- a/authoring/style/technical.md
+++ b/authoring/style/technical.md
@@ -131,7 +131,7 @@ the single thing the figure is about.
 | Accent fill | `fill:#fff5f3 stroke:#ff4b2e`, text `#ff4b2e` — **one node per figure** |
 | Textured variant | Diagonal hatch in `#ff4b2e` at 35% over the same fill |
 | Stacked bar | Greys `#f0f0f0` / `#e5e5e5` / `#d4d4d4` with `#a3a3a3` strokes; the segment under discussion takes the accent |
-| Table | `rule` hairline border, square corners; row rules in `rule`; header in `label-type` mono, `muted`, over its own `rule`; figures tabular; no fill |
+| Table | `rule` hairline border, square corners; row rules in `rule`; header in `label-type` mono, `muted`, over a rule in `ink`; figures tabular; no fill |
 
 Metric labels are mono here, including inside figures — a number set in the
 body sans reads as prose and gets skimmed.


### PR DESCRIPTION
The contract said the header sits over a rule "a step stronger than the row rules under it", and the treatment shipped that as `#d4d4d4` against `#e5e5e5` — 17 points of luminance apart, at the same 1px weight. That is not a step; the header read as one more row.

It is now a rule in `ink`, heavier than the hairlines between rows.

## Why the rule and not the type

The label register already spends every typographic axis available — case, tracking, size, face. Making the header bolder or darker adds nothing, because it competes with the body text on axes that are used up. A rule is a structural signal, so it stacks with the register rather than against it, and it costs one token that all four styles already declare.

| | header rule vs row rule |
|---|---|
| before | 17 luminance, same weight |
| after | 212 luminance, 2px against 1px |

Measured on the published page: 169 points between the darkest and lightest rule in the table.

## Considered and not taken

Moving the header outside the card reads strongest of the options, but it changes what the component *is* rather than how it looks — `components.md` defines a table as one bordered card with the header inside it. That is a structure-layer edit that all four styles would have to follow, so it belongs in a separate component ("a table with a legend"), not in a treatment change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Xw9Mt3rV3ujnejPr41pqvz