### PR TITLE
The document hero settles at one scale across all four styles

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -244,7 +244,7 @@ voice is being preserved when the agent is the one writing.
 
 `style/default.md` is the stark sans style: pure white, pure black, one clean
 sans everywhere (open Inter, standing in for the proprietary OpenAI Sans), an
-oversized tight-tracked headline, near-zero color, and a full technical-diagram
+tight-tracked headline, near-zero color, and a full technical-diagram
 vocabulary (thin frames, mono pill labels, numbered containers, solid/dashed
 arrows, one accent per figure, dot/hatch textured fills). The OpenAI-index
 aesthetic, done with open fonts — no brand assets, a look not an identity.

--- a/authoring/style/README.md
+++ b/authoring/style/README.md
@@ -9,7 +9,7 @@ trusts it.
 
 | Entry | When it applies |
 |---|---|
-| `default.md` | **When a doc selects nothing.** Stark sans — pure white/black, one sans, oversized tight-tracked headline, OpenAI-style diagram vocabulary (frames, mono labels, dot/hatch textures). OpenAI-index aesthetic via open fonts (no brand assets). |
+| `default.md` | **When a doc selects nothing.** Stark sans — pure white/black, one sans, tight-tracked headline, OpenAI-style diagram vocabulary (frames, mono labels, dot/hatch textures). OpenAI-index aesthetic via open fonts (no brand assets). |
 | `technical.md` | When named. Cold engineering-blog register — mono, neutral greys, one sparing red-orange accent. From `judgmentlabs.ai`. |
 | `editorial.md` | When named. Long-read essay — warm paper, serif body, electric-blue accent, colored inline underlines. From `cognition.com`. The one entry that overrides typography (ground + body font only). |
 | `paper.md` | When named. Warm serif long-read — off-white paper, open serif display + humanist sans, clay accent. Anthropic-blog aesthetic via open fonts (no brand assets). |

--- a/authoring/style/default.md
+++ b/authoring/style/default.md
@@ -1,8 +1,8 @@
 # default — the stark sans style (applied when a doc selects nothing)
 
 **This is the house default: every doc that names no style gets it.** A cold,
-spare register: pure white, pure black, one clean sans everywhere, an
-oversized headline with tight tracking, and almost no color. The aesthetic of
+spare register: pure white, pure black, one clean sans everywhere, a
+tightly-tracked headline, and almost no color. The aesthetic of
 the OpenAI research index, approximated with **open fonts** — the real page
 uses OpenAI's proprietary OpenAI Sans, which is not ours to ship.
 
@@ -27,8 +27,9 @@ Measured against the live page, then substituted:
 **One sans, no serif, no warmth.** Everything is the same geometric-humanist
 sans. The register comes from scale and restraint, not from type contrast.
 
-**An oversized headline with tight tracking.** h1 is large (≈56px) with
-negative letter-spacing (`-.03em`). That single move is most of the look. h1
+**A tightly-tracked headline.** h1 runs `clamp(28px,3.6vw,36px)` — 36px on a
+desktop, easing to 28px on a phone — with negative letter-spacing (`-.03em`).
+The tracking, not the size, is most of the look. h1
 and h2 set their family explicitly (the overlay colors/styles headings).
 
 **Near-zero color.** Black on white. Links are black dimmed to ~60%, not a
@@ -43,7 +44,7 @@ hue. Reserve any real color for a chart that genuinely needs it.
 ```css
 body { background:#fff; }
 .wrap { font-family:"Inter",system-ui,-apple-system,sans-serif; color:#0a0a0a; font-size:17px; line-height:1.65; }
-.wrap h1 { font-family:"Inter",system-ui,sans-serif; font-weight:600; font-size:clamp(38px,6vw,56px); letter-spacing:-.03em; line-height:1.05; color:#0a0a0a; }
+.wrap h1 { font-family:"Inter",system-ui,sans-serif; font-weight:600; font-size:clamp(28px,3.6vw,36px); letter-spacing:-.03em; line-height:1.05; color:#0a0a0a; }
 .wrap h2 { font-family:"Inter",system-ui,sans-serif; font-weight:600; letter-spacing:-.015em; color:#0a0a0a; margin-top:40px; }
 .wrap a  { color:rgba(10,10,10,.6); text-decoration:none; border-bottom:1px solid rgba(10,10,10,.2); }
 /* a hairline-ruled note — no fill, just a rule */

--- a/authoring/style/editorial.md
+++ b/authoring/style/editorial.md
@@ -43,7 +43,7 @@ overlay's heading rule wins and it comes out sans.
 ```css
 body { background:#f7f6f5; }
 .wrap { font-family:"Iowan Old Style", Georgia, "Times New Roman", serif; color:#000; }
-.wrap h1 { font-family:"Iowan Old Style", Georgia, serif; font-weight:300; letter-spacing:-.02em; }
+.wrap h1 { font-family:"Iowan Old Style", Georgia, serif; font-weight:300; font-size:clamp(28px,3.6vw,36px); letter-spacing:-.02em; }
 .wrap h2 { font-family:system-ui,-apple-system,"Segoe UI",sans-serif; font-weight:500; }
 .wrap a  { color:#2200ff; text-decoration:none; border-bottom:2px solid #2200ff; }
 

--- a/authoring/style/paper.md
+++ b/authoring/style/paper.md
@@ -46,7 +46,7 @@ No second hue.
 ```css
 body { background:#faf9f5; }
 .wrap { font-family:"Inter",system-ui,-apple-system,sans-serif; color:#141413; font-size:19px; line-height:1.65; }
-.wrap h1 { font-family:"Fraunces","Newsreader",Georgia,serif; font-weight:500; letter-spacing:-.005em; color:#141413; }
+.wrap h1 { font-family:"Fraunces","Newsreader",Georgia,serif; font-weight:500; font-size:clamp(28px,3.6vw,36px); letter-spacing:-.005em; color:#141413; }
 .wrap h2 { font-family:"Fraunces","Newsreader",Georgia,serif; font-weight:500; color:#141413; }
 .wrap h3 { font-family:"Fraunces","Newsreader",Georgia,serif; font-weight:500; }
 .wrap a  { color:#c15f3c; text-decoration:none; border-bottom:1px solid #e3c4b6; }

--- a/authoring/style/technical.md
+++ b/authoring/style/technical.md
@@ -68,7 +68,7 @@ mono  ui-monospace, "SF Mono", Menlo, monospace   (theirs is "DM Mono")
    Dark is the overlay's invert of everything below. */
 body  { background:#fff; }
 .wrap { color:rgba(10,10,10,.92); font:16px/1.62 system-ui,-apple-system,"Segoe UI",Roboto,sans-serif; }
-.wrap h1 { color:#0a0a0a; font-size:36px; font-weight:500; letter-spacing:-.9px; line-height:1.25; }
+.wrap h1 { color:#0a0a0a; font-size:clamp(28px,3.6vw,36px); font-weight:500; letter-spacing:-.9px; line-height:1.25; }
 .wrap h2 { color:#0a0a0a; font-size:24px; font-weight:500; margin-top:34px; }
 .muted   { color:#737373; }
 .wrap a  { color:#737373; text-decoration:underline; }

--- a/server/reader.css
+++ b/server/reader.css
@@ -38,7 +38,7 @@
     text-rendering: optimizeLegibility;
     -webkit-font-smoothing: antialiased;
   }
-  :where(body h1) { font-family: var(--td-font-display); font-size: 38px; line-height: 1.15; font-weight: 700; letter-spacing: -0.02em; margin: 0 0 20px; color: var(--td-heading); }
+  :where(body h1) { font-family: var(--td-font-display); font-size: clamp(28px, 3.6vw, 36px); line-height: 1.15; font-weight: 700; letter-spacing: -0.02em; margin: 0 0 20px; color: var(--td-heading); }
   :where(body h2) { font-family: var(--td-font-display); font-size: 27px; line-height: 1.25; font-weight: 700; letter-spacing: -0.01em; margin: 44px 0 14px; color: var(--td-heading); padding-bottom: 6px; border-bottom: 1px solid var(--td-h2-rule); }
   :where(body h3) { font-family: var(--td-font-display); font-size: 21px; line-height: 1.35; font-weight: 700; margin: 32px 0 10px; color: var(--td-heading); }
   :where(body h4) { font-size: 17px; font-weight: 700; margin: 22px 0 6px; color: var(--td-heading); }

--- a/skills/tdoc/SKILL.md
+++ b/skills/tdoc/SKILL.md
@@ -244,7 +244,7 @@ voice is being preserved when the agent is the one writing.
 
 `style/default.md` is the stark sans style: pure white, pure black, one clean
 sans everywhere (open Inter, standing in for the proprietary OpenAI Sans), an
-oversized tight-tracked headline, near-zero color, and a full technical-diagram
+tight-tracked headline, near-zero color, and a full technical-diagram
 vocabulary (thin frames, mono pill labels, numbered containers, solid/dashed
 arrows, one accent per figure, dot/hatch textured fills). The OpenAI-index
 aesthetic, done with open fonts — no brand assets, a look not an identity.


### PR DESCRIPTION
Fixes #306.

All four style files now declare `font-size: clamp(28px,3.6vw,36px)` for
`.wrap h1` — 36px on a desktop, easing to 28px on a phone.

`paper` and `editorial` declare it outright instead of falling through to
`server/reader.css`, so they no longer depend on the injection layer #284
is retiring. `reader.css` keeps a matching value, but only as a safety net.

Prose moved with the CSS: `default.md` said "h1 is large (≈56px)", which an
agent reads and writes back into the document. Corrected there, plus the two
other places that advertised an "oversized" headline. `skills/tdoc/SKILL.md`
re-synced (`cli.test.js` and `agent-md.test.js` both enforce that mirror).

Consistent with the #294 layering: an h1's size is treatment, so it belongs
in `style/`, not `structure/`. `components.md` is unchanged and still
carries zero sizes and zero colours.

**Verified in Chrome** (devtools MCP, computed styles not screenshots):

| viewport | computed `h1` | lines | overflow-x |
|---|---|---|---|
| 1280px | 36px (2.12x body) | 1 | none |
| 500px | 28px — clamp floor holds | 1 | none |

46 offline suites green.

**Expected side effect:** regenerating a doc written before this moves its
hero, because `check_style_contract` flags the old value as a contradiction.
That is the contract working, not a regression — confirmed against the
`tdoc-visual-vocabulary` doc, which reports
`'.wrap h1' sets font-size: clamp(38px,6vw,56px) - the 'default' style says clamp(28px,3.6vw,36px)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Xw9Mt3rV3ujnejPr41pqvz