### PR TITLE
A preview can show the homepage, so two of them can be compared

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -192,6 +192,31 @@ jobs:
           seed 1 test/fixtures/tdocs/sample-doc/v1/index.html
           seed 2 test/fixtures/tdocs/sample-doc/v2/index.html
 
+          # The homepage is itself a tdoc (LANDING_SLUG = tornado-doc, served
+          # at `/`). Without it a preview answers `/` with the neutral page, so
+          # anything touching site chrome — a mark, a bar control, a theme —
+          # could not be reviewed where it ships, and two homepages could not
+          # be put side by side at all. Seed the same payload production
+          # publishes: bin/tdoc-landing-release collapses the working copy's
+          # versions to a single v1 and drops the review thread, so the preview
+          # is not a 40-entry version picker over somebody's review notes.
+          node bin/tdoc-landing-release
+          LANDING_DIR=.release/tornado-doc
+          jq -n \
+            --arg slug tornado-doc \
+            --argjson version 1 \
+            --rawfile html "$LANDING_DIR/v1/index.html" \
+            --slurpfile meta "$LANDING_DIR/meta.json" \
+            '{slug:$slug, version:$version, html:$html, meta:$meta[0]}' \
+            > /tmp/tdoc-preview-landing.json
+          curl -sS --connect-timeout 10 --max-time 90 -X POST "$BASE/api/upload" \
+            -H "Authorization: Bearer $TDOC_PREVIEW_UPLOAD_TOKEN" \
+            -H "Content-Type: application/json" \
+            --data-binary @/tmp/tdoc-preview-landing.json \
+            | tee /tmp/tdoc-preview-landing-resp.json
+          jq -e '.ok == true' /tmp/tdoc-preview-landing-resp.json >/dev/null
+          echo "seeded landing"
+
       - name: Sticky preview comment
         env:
           GH_TOKEN: ${{ github.token }}
@@ -202,7 +227,9 @@ jobs:
           BODY=$(cat <<EOF
           <!-- tdoc-preview -->
           ### Preview
-          **Open this:** https://${PREVIEW_HOST}/d/conway-life/v/2
+          **Open this:** https://${PREVIEW_HOST}/ — the homepage, this PR's code
+          carrying the landing version in this PR's checkout.
+          **Or a document:** https://${PREVIEW_HOST}/d/conway-life/v/2
 
           This link is unique to this PR. New commits update the same URL. It is not [tdoc.dev](https://tdoc.dev).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,17 @@ file and `.claude-plugin/plugin.json`.
 
 ### Added
 
+- **PR previews serve the real homepage, and so does the comparison harness.**
+  A preview seeded only the demo doc, so its `/` answered with the neutral
+  fallback page: anything touching site chrome — a mark, a bar control, a
+  theme — could not be reviewed where it actually ships, and two versions of
+  the homepage could not be put side by side at all. `preview.yml` now seeds
+  the same payload production publishes (`bin/tdoc-landing-release`, which
+  collapses the working copy's versions to one v1 and drops the review
+  thread), and the sticky comment leads with the homepage. `test/visual/hosted-compare.mjs` seeds the same doc
+  and grows landing scenes, signed out and signed in.
+
+
 - **Home-screen icons.** Adding tdoc to a phone's home screen showed no mark:
   Add to Home Screen never reads the SVG favicon — iOS takes
   `apple-touch-icon`, Android takes the PNGs a web app manifest names — and

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -87,6 +87,11 @@ node test/visual/hosted-compare.mjs /tmp/cmp-hosted /tmp/wb-old/_worker.bundled.
 The rule for a migration or restyle: match the old chrome where it can be
 matched; where it cannot, the new one still has to look finished.
 
+Both harnesses serve the real homepage — the newest `landing/tornado-doc/vN`
+out of the checkout — so site chrome can be judged where it ships rather than
+against the neutral fallback. PR previews seed it too, so the preview's `/` is
+this branch's code carrying this branch's landing.
+
 `server/runtime/` is **committed on purpose**: skill users run
 `server/server.js` straight from the checkout and `bin/tdoc-bundle` embeds the
 same bytes into the Worker — neither runs `npm install`. The Vite output is

--- a/test/preview-workflow.test.js
+++ b/test/preview-workflow.test.js
@@ -44,7 +44,14 @@ t('uses pr-<N> alias, not the branch name', () => {
 t('sticky comment matches the #148 template', () => {
   assert(wf.includes('<!-- tdoc-preview -->'), 'must use the sticky HTML marker');
   assert(wf.includes('**Open this:**'), 'must lead with Open this');
-  assert(wf.includes('/d/conway-life/v/2'), 'Open this must be the demo doc, not the host root');
+  // The root used to be the neutral page on a preview, so the comment pointed
+  // at the demo doc instead. The preview now seeds the landing, so `/` is the
+  // real homepage and leads; the demo doc stays as the second link, because a
+  // document is where the comment layer can be exercised.
+  assert(wf.includes('**Open this:** https://${PREVIEW_HOST}/ '),
+    'Open this must be the homepage now that the preview seeds it');
+  assert(wf.includes('/d/conway-life/v/2'), 'the demo doc must still be linked');
+  assert(/seed .*landing|seeded landing/.test(wf), 'the preview must seed the landing doc');
   assert(wf.includes('It is not [tdoc.dev](https://tdoc.dev)'),
     'must say the link is not tdoc.dev');
   assert(wf.includes('issues/comments/'), 'must PATCH an existing comment rather than always POST');

--- a/test/visual/hosted-compare.mjs
+++ b/test/visual/hosted-compare.mjs
@@ -33,6 +33,27 @@ async function boot(side) {
   const meta = JSON.parse(fs.readFileSync(path.join(FIXTURE, 'meta.json'), 'utf8'));
   meta.hosted = { account_id: 'acct-alice', github_login: 'alice' };
   await env.META.put('meta:sample-doc', JSON.stringify(meta));
+  // The homepage is a tdoc of its own (LANDING_SLUG = tornado-doc, served at
+  // `/`). Seed the newest version out of the checkout so site chrome — the
+  // mark, the bar, the theme — can be compared where it actually ships,
+  // instead of against the neutral fallback page.
+  // `node bin/tdoc-landing-release` first if you want the production shape —
+  // one v1 instead of the working copy's version picker. Falls back to the
+  // newest working version so the harness runs without that step.
+  const repo = path.resolve(path.dirname(new URL(import.meta.url).pathname), '../..');
+  const release = path.join(repo, '.release/tornado-doc');
+  const working = path.join(repo, 'landing/tornado-doc');
+  let landing = null;
+  if (fs.existsSync(path.join(release, 'v1/index.html'))) {
+    landing = { n: 1, html: path.join(release, 'v1/index.html') };
+  } else if (fs.existsSync(working)) {
+    const n = Math.max(0, ...fs.readdirSync(working).map((d) => Number((d.match(/^v(\d+)$/) || [])[1]) || 0));
+    if (n) landing = { n, html: path.join(working, `v${n}`, 'index.html') };
+  }
+  if (landing) {
+    await env.META.put('meta:tornado-doc', JSON.stringify({ title: 'tornado-doc', slug: 'tornado-doc', versions: [{ n: landing.n }] }));
+    await env.DOCS.put(`docs/tornado-doc/v${landing.n}/index.html`, fs.readFileSync(landing.html, 'utf8'));
+  }
   for (const v of [1, 2]) await env.DOCS.put(`docs/sample-doc/v${v}/index.html`, fs.readFileSync(path.join(FIXTURE, `v${v}/index.html`), 'utf8'));
   const call = (pathname, init = {}, cookie) => mod.default.fetch(new Request(`https://tdoc.dev${pathname}`, { ...init, headers: { ...(init.headers || {}), ...(cookie ? { Cookie: `tdoc_sid=${cookie}` } : {}) } }), env, { waitUntil() {}, passThroughOnException() {} });
   const fixture = JSON.parse(fs.readFileSync(path.join(FIXTURE, 'comments.json'), 'utf8'));
@@ -75,6 +96,10 @@ const SCENES = [
   { name: 'h09-reader-card', as: 'bob', run: async (p) => { await click(p, '.tdoc-pin'); } },
   { name: 'h10-owner-dark-share', as: 'alice', run: async (p) => { await click(p, '#tdoc-theme-btn'); await click(p, '#tdoc-share-btn'); await settle(p, 800); } },
   { name: 'h11-me', as: 'alice', url: '/me' },
+  // The homepage, full page, signed out and signed in — the surface most
+  // chrome changes are actually judged on.
+  { name: 'h11b-landing', as: null, url: '/', full: true },
+  { name: 'h11c-landing-owner', as: 'alice', url: '/', full: true },
   { name: 'h12-anon-mobile', as: null, viewport: { width: 375, height: 812 }, run: async (p) => { await click(p, '.tdoc-fab'); await settle(p, 500); } },
 ];
 const servers = { old: await boot('old'), new: await boot('new') };
@@ -89,7 +114,7 @@ for (const scene of SCENES) {
       const r = await page.goto(servers[side].base + (scene.url || '/d/sample-doc/v/2'), { waitUntil: 'networkidle' });
       if (!scene.url) await ready(page); else await settle(page, 800);
       if (scene.run) await scene.run(page);
-      await page.screenshot({ path: path.join(OUT, `${scene.name}-${side}.png`) });
+      await page.screenshot({ path: path.join(OUT, `${scene.name}-${side}.png`), fullPage: Boolean(scene.full) });
       row[side] = (r.status() !== 200 ? `HTTP ${r.status()} ` : '') + (errors.length ? 'errors: ' + errors.join(' | ') : 'ok');
     } catch (e) { row[side] = 'FAILED: ' + String(e).split('\n')[0]; try { await page.screenshot({ path: path.join(OUT, `${scene.name}-${side}.png`) }); } catch {} }
     await ctx.close();


### PR DESCRIPTION
A PR preview seeded only the demo doc, so its `/` answered with the **neutral fallback page**. Anything that touches site chrome — a mark, a bar control, a theme — could not be reviewed where it actually ships, and two versions of the homepage could not be put side by side at all.

- `preview.yml` seeds the homepage with **the same payload production publishes**: `bin/tdoc-landing-release` collapses the working copy's versions to a single `v1` and drops the review thread, so a preview is not a 44-entry version picker over somebody's review notes.
- The sticky comment leads with the homepage; the demo doc stays as the second link, because a document is where the comment layer can be exercised. Its test asserted the opposite — that the link must not be the host root — which was right only while the root *was* the neutral page.
- `test/visual/hosted-compare.mjs` seeds the same doc (preferring `.release` when built) and grows landing scenes, signed out and signed in, so **any two builds can be compared on the homepage locally**, without a deploy:

```bash
git worktree add /tmp/tdoc-main origin/main
SKILL_DIR=/tmp/tdoc-main OUT_DIR=/tmp/wb-old node bin/tdoc-bundle
SKILL_DIR=$PWD           OUT_DIR=/tmp/wb-new node bin/tdoc-bundle
node bin/tdoc-landing-release
node test/visual/hosted-compare.mjs /tmp/cmp /tmp/wb-old/_worker.bundled.js /tmp/wb-new/_worker.bundled.js
# → /tmp/cmp/h11b-landing.png is the homepage, old | new
```

The idea is not new: #200 did this and was closed during unrelated triage of a publish 401, before the React shell landed.

`npm test` green; verified the harness renders the real landing with full chrome.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DTsAHQ7Xmdghu9jStyx3WY