### PR TITLE
The table cell reset is checked, not just described

### DIFF
--- a/authoring/structure/components.md
+++ b/authoring/structure/components.md
@@ -48,6 +48,12 @@ rather than a tinted band, and numbers are tabular so a column lines up.
 </div>
 ```
 
+```css
+/* The reader styles every cell as a standalone chip, and a chip survives any
+   rule that does not name the two properties making it one. Name them. */
+.wrap th, .wrap td { background: transparent; border-radius: 0; }
+```
+
 The header is a label, so it takes the style's `label-type` register rather
 than a smaller, greyer version of the body. Set at body size in the muted ink
 it reads as a quieter row instead of a different kind of row; in the label
@@ -73,11 +79,11 @@ reason: the gutters cut the columns, leaving nothing continuous to follow. A
 fill is also the worst case for this reader — dark mode is a whole-page invert,
 so a filled cell becomes a slab where a hairline only changes colour.
 
-Reset the cell's own shape, not only the parts you are changing. The reader
-styles cells as standalone chips — a fill and a corner radius of their own —
-and those survive any rule that does not name them, so a treatment that sets
-borders and padding alone comes out filled and rounded anyway. Name
-`background` and `border-radius` explicitly.
+Reset the cell's own shape, not only the parts you are changing. A rule that
+sets borders and padding alone comes out filled and rounded anyway, because the
+fill and the radius are separate properties and nothing in that rule mentions
+them. This is the one part of a table that a document cannot leave unsaid, so
+`bin/tdoc-validate-template` fails a document whose cells never name both.
 
 **Scroll wrappers** — `tdoc-table-scroll` for a table, `diagram-box` for a
 figure. Both are `overflow-x: auto`, and both need the child to have a
@@ -87,7 +93,9 @@ phone. Give a wide figure a `min-width` that keeps its smallest type around
 9px, and let it scroll.
 
 **Stat tile row** — a few numbers that carry an argument on their own. Three or
-four; a fifth is a table.
+four; a fifth is a table. It earns its place from the numbers in it, like any
+other component, so it goes where those numbers are the point rather than
+standing at the top of every document as a header band.
 
 ```html
 <div class="tiles">

--- a/bin/tdoc-validate-template
+++ b/bin/tdoc-validate-template
@@ -313,6 +313,38 @@ def check_style_accent(html, style):
             "vocabulary is not being applied" % (len(svgs), style)]
 
 
+def check_table_cells(html, styles):
+    """A cell that never names its fill or its radius inherits a chip.
+
+    The reader stamps `background` and `border-radius` onto every th and td at
+    zero specificity. Those survive a document rule that sets only borders and
+    padding, so a table written that way renders as a grid of rounded tinted
+    blocks whatever the style says. Nothing about the document reveals this —
+    it looks correct in the source and wrong on the page — which is why it is
+    checked rather than left to prose.
+
+    A document with no table has nothing to reset.
+    """
+    if not re.search(r"<table[\s>]", html, re.I):
+        return []
+    css = "\n".join(styles)
+    faults = []
+    for prop in ("background", "border-radius"):
+        # Any rule naming a cell and that property counts, in shorthand or long
+        # form: `background:` also matches `background-color:`, and a document
+        # is free to name them in one rule or several.
+        hit = re.search(
+            r"[^{}]*\b(?:th|td)\b[^{}]*\{[^}]*(?<![\w-])" + prop + r"[-\w]*\s*:",
+            css, re.I | re.S)
+        if not hit:
+            faults.append(prop)
+    if not faults:
+        return []
+    return ["a table's cells never set %s, so the reader's chip (a fill and an "
+            "8px radius on every th and td) survives - name it on th, td" %
+            " or ".join(faults)]
+
+
 def validate(path: Path, *, style: str, custom_template: bool) -> list[str]:
     html = path.read_text(encoding="utf-8")
     parser = ContractParser()
@@ -397,6 +429,10 @@ def validate(path: Path, *, style: str, custom_template: bool) -> list[str]:
     # system reaches this file through --custom-template and returned above.
     errors.extend(inset)
     errors.extend(check_style_accent(raw, style))
+    # The cell reset is a house-style rule: tdoc tables are ruled, never filled.
+    # A caller bringing its own design system returned above with the other
+    # house checks, so this only judges documents tdoc itself authored.
+    errors.extend(check_table_cells(raw, parser.styles))
 
     return errors
 

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -123,6 +123,44 @@ t('chat-driven new and edit flows require host validation', () => {
     '/tdoc edit must validate every generated version');
 });
 
+// The reader stamps `background` and `border-radius` onto every th and td at
+// zero specificity, so a table that names neither renders as a grid of rounded
+// tinted chips no matter what the style says. That failure is invisible in the
+// source, which is why the validator checks it instead of leaving it to prose.
+// The contract is "name it", not "make it transparent": a heat-map cell that
+// deliberately sets a fill is a choice, and only silence inherits a chip.
+t('a table whose cells never name background or radius is rejected', () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'tdoc-cells-'));
+  const write = (css, body) => {
+    const f = path.join(dir, 'c' + Math.abs(css.length + body.length) + '.html');
+    fs.writeFileSync(f, `<!doctype html><html><head>
+      <meta name="viewport" content="width=device-width, initial-scale=1">
+      <style>body { background: #fff; } ${css}</style>
+      </head><body><div class="wrap"><h1>T</h1>${body}</div></body></html>`);
+    return spawnSync(path.join(BIN, 'tdoc-validate-template'), [f], { encoding: 'utf8' });
+  };
+  const TABLE = '<table><tr><th>a</th></tr><tr><td>b</td></tr></table>';
+  try {
+    const bare = write('.wrap th, .wrap td { border-bottom:1px solid #eee; padding:8px; }', TABLE);
+    assert(/reader's chip/.test(bare.stdout + bare.stderr),
+      'a table setting only borders and padding must be rejected');
+
+    const reset = write('.wrap th, .wrap td { background:transparent; border-radius:0; border-bottom:1px solid #eee; }', TABLE);
+    assert(!/reader's chip/.test(reset.stdout + reset.stderr),
+      'naming both properties must satisfy the check');
+
+    // A deliberate fill is a choice the author made and can see; it passes.
+    const chosen = write('.wrap th, .wrap td { background:#fafafa; border-radius:4px; }', TABLE);
+    assert(!/reader's chip/.test(chosen.stdout + chosen.stderr),
+      'a deliberately filled cell is a choice, not an inherited chip');
+
+    // A document with no table has nothing to reset.
+    const notable = write('.wrap p { margin:0 }', '<p>no table here</p>');
+    assert(!/reader's chip/.test(notable.stdout + notable.stderr),
+      'a document with no table must not be asked to reset cells');
+  } finally { fs.rmSync(dir, { recursive: true, force: true }); }
+});
+
 t('tdoc default-template validator accepts scoped widget CSS', () => {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'tdoc-template-'));
   try {


### PR DESCRIPTION
Fixes #317.

`components.md` has said to name `background` and `border-radius` on cells
since the table treatment landed. Of the 37 local documents containing a table,
**30 inherit the chip anyway** — the guidance was a paragraph beside a code
example showing only markup, and an agent building a table copies the example.

Two changes:

1. The example carries the reset, so copying it produces a correct table.
2. `bin/tdoc-validate-template` fails a document whose cells name neither
   property. SKILL.md already mandates validation before publishing, so this is
   reached on every generation.

**The contract is "name it", not "make it transparent."** A heat-map cell that
deliberately sets a fill is a choice its author can see; only silence inherits
something nobody picked. Verified against the local corpus — the 7 documents
that name both pass, including `customer-group-copilot`, whose verdict cells
are deliberately coloured (`td.y { background:#f7d7d1 }`).

### Deliberately not a reader.css fix

#282 put this in the injected layer and #284 reverted it: that layer is being
retired, and the direction is that the agent writes the treatment into each
document. `server/reader.css` is untouched here — a validator check is the
same guarantee on the layer that is staying.

### Also

Constrains where a stat tile row goes — it earns its place from the numbers in
it, like any other component, rather than standing at the top of every document
as a header band.

### Verification

- Reproduced the failure by injecting `reader.css` ahead of the document's own
  `<style>`, as the server does, and reading computed styles: `rgb(240,240,238)`
  with an `8px` radius on every cell.
- New test covers all four cases: bare rule rejected, reset accepted, deliberate
  fill accepted, no-table document not asked to reset.
- 47 offline suites green. `components.md` still carries zero hex colours.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Xw9Mt3rV3ujnejPr41pqvz