### PR TITLE
Polish terminal onboarding recovery

### DIFF
--- a/bin/tdoc-publish
+++ b/bin/tdoc-publish
@@ -130,6 +130,24 @@ if [ "$SIGNIN_ONLY" = "1" ]; then
 elif [ -z "$SLUG" ]; then
   usage
 fi
+
+# Keep one canonical retry command for interruptions during hosted sign-in.
+# The sign-in-only flow has no document yet; a normal publish must preserve
+# every access flag the user chose instead of silently retrying a different
+# publish.
+if [ "$SIGNIN_ONLY" = "1" ]; then
+  RETRY_COMMAND="/tdoc publish --signin-only"
+else
+  RETRY_COMMAND="/tdoc publish"
+  [ -n "$PLATFORM_FLAG" ] && RETRY_COMMAND+=" --platform $PLATFORM_FLAG"
+  [ -n "$VISIBILITY_FLAG" ] && RETRY_COMMAND+=" --visibility $VISIBILITY_FLAG"
+  [ -n "$HISTORY_FLAG" ] && RETRY_COMMAND+=" --history $HISTORY_FLAG"
+  [ -n "$COMMENTING_FLAG" ] && RETRY_COMMAND+=" --commenting $COMMENTING_FLAG"
+  for _allow_user in ${ALLOW_USERS[@]+"${ALLOW_USERS[@]}"}; do
+    RETRY_COMMAND+=" --allow-user $_allow_user"
+  done
+  RETRY_COMMAND+=" $SLUG"
+fi
 # Validate the slug BEFORE it becomes a filesystem path or a URL query value.
 
 # Same kebab-case rule tdoc-new enforces. Without this a `..` slug escapes
@@ -266,13 +284,13 @@ EOF
 require_wrangler() {
   if ! command -v wrangler >/dev/null 2>&1; then
     fail_with_agent_prompt "wrangler is not installed" \
-      "Install Cloudflare wrangler globally so tdoc can publish: run 'npm i -g wrangler' (or 'pnpm add -g wrangler'). After it's installed, run '/tdoc publish $SLUG' again."
+      "Install Cloudflare wrangler globally so tdoc can publish: run 'npm i -g wrangler' (or 'pnpm add -g wrangler'). After it's installed, run '/tdoc publish --platform cloudflare $SLUG' again."
   fi
 }
 require_vercel() {
   if ! command -v vercel >/dev/null 2>&1; then
     fail_with_agent_prompt "the vercel CLI is not installed" \
-      "Install the Vercel CLI globally so tdoc can publish: run 'npm i -g vercel' (or 'pnpm add -g vercel'). After it's installed, run '/tdoc publish $SLUG' again."
+      "Install the Vercel CLI globally so tdoc can publish: run 'npm i -g vercel' (or 'pnpm add -g vercel'). After it's installed, run '/tdoc publish --platform vercel $SLUG' again."
   fi
 }
 
@@ -333,6 +351,11 @@ hosted_github_signin() {
   [ "$interval" -lt 5 ] && interval=5
   case "$expires" in ''|*[!0-9]*) expires=900 ;; esac
 
+  # Install the human-cancel path before printing the device instructions.
+  # A fast Ctrl-C on the first visible line must still clear #325's modal side
+  # channel and must never be reported as a GitHub denial.
+  trap 'clear_pending_signin; rm -f "$cookiejar"; echo "[tdoc] GitHub sign-in canceled. No credential was saved." >&2; echo "[tdoc] Retry: $RETRY_COMMAND" >&2; exit 130' INT
+
   # No attempt to pre-fill the code in the URL. GitHub returns no
   # verification_uri_complete, and appending ?user_code= does NOT work in
   # practice: a signed-out visitor is sent to the account chooser first and the
@@ -387,12 +410,12 @@ hosted_github_signin() {
   echo "        $user_code" >&2
   echo "" >&2
   [ "${opened:-0}" = "1" ] && echo "[tdoc] (If nothing opened: $uri )" >&2
-  echo "[tdoc] Then click Authorize. I'll carry on by myself — nothing to do here." >&2
-  echo "[tdoc] Waiting for GitHub approval…" >&2
+  echo "[tdoc] After you click Authorize, I'll continue here." >&2
   # From here the code exists and nothing else will print it. Hand it to the
   # side channel before the first sleep, so a modal polling for it sees the
   # code on its next tick rather than after the whole flow resolves.
   write_pending_signin "$user_code" "$uri" "$expires" "${opened:-0}"
+  echo "[tdoc] Waiting for GitHub approval…" >&2
   local waited=0 err
   while [ "$waited" -lt "$expires" ]; do
     sleep "$interval"
@@ -406,6 +429,7 @@ hosted_github_signin() {
       _who="$(printf '%s' "$payload" | json_get identity.login)"
       echo "[tdoc] Signed in as ${_who:-github user}" >&2
       clear_pending_signin
+      trap - INT
       return 0
     fi
     err="$(printf '%s' "$payload" | json_get error)"

--- a/test/onboarding-terminal-recovery.test.js
+++ b/test/onboarding-terminal-recovery.test.js
@@ -1,0 +1,177 @@
+// Terminal onboarding recovery regressions.
+//
+// Runs the real tdoc-publish script with an isolated HOME. Provider tests use
+// a PATH that deliberately lacks the selected CLI; cancellation tests use a
+// local GitHub-device-flow stand-in and send SIGINT to the publish process.
+
+const fs = require('fs');
+const http = require('http');
+const net = require('net');
+const os = require('os');
+const path = require('path');
+const { spawn, spawnSync } = require('child_process');
+
+const PUBLISH = path.join(__dirname, '..', 'bin', 'tdoc-publish');
+let pass = 0, fail = 0;
+function ok(name) { console.log(`  ✓ ${name}`); pass++; }
+function bad(name, err) { console.log(`  ✗ ${name}\n    ${err}`); fail++; }
+async function t(name, fn) { try { await fn(); ok(name); } catch (e) { bad(name, e.message); } }
+function assert(condition, message) { if (!condition) throw new Error(message); }
+
+function isolatedHome(slug = 'recovery-doc') {
+  const home = fs.mkdtempSync(path.join(os.tmpdir(), 'tdoc-terminal-recovery-'));
+  const docs = path.join(home, 'tdocs');
+  fs.mkdirSync(path.join(docs, slug), { recursive: true });
+  return { home, docs, slug };
+}
+
+function pathWithoutProvider(home) {
+  const bin = path.join(home, 'bin');
+  fs.mkdirSync(bin, { recursive: true });
+  fs.symlinkSync(process.execPath, path.join(bin, 'node'));
+  fs.symlinkSync('/bin/bash', path.join(bin, 'bash'));
+  // The missing-provider branch only checks for jq; it does not invoke it.
+  fs.writeFileSync(path.join(bin, 'jq'), '#!/bin/sh\nexit 0\n', { mode: 0o755 });
+  return `${bin}:/usr/bin:/bin`;
+}
+
+function freePort() {
+  return new Promise((resolve, reject) => {
+    const server = net.createServer();
+    server.listen(0, '127.0.0.1', () => {
+      const port = server.address().port;
+      server.close(() => resolve(port));
+    });
+    server.on('error', reject);
+  });
+}
+
+function startDeviceServer(port) {
+  const server = http.createServer((req, res) => {
+    res.setHeader('content-type', 'application/json');
+    if (req.url === '/api/auth/device/start') {
+      return res.end(JSON.stringify({
+        user_code: 'ABCD-1234',
+        device_code: 'device-token',
+        verification_uri: 'https://github.com/login/device',
+        interval: 5,
+        expires_in: 900,
+      }));
+    }
+    if (req.url === '/api/auth/device/poll') {
+      return res.end(JSON.stringify({ error: 'authorization_pending' }));
+    }
+    res.statusCode = 404;
+    res.end('{}');
+  });
+  return new Promise((resolve, reject) => {
+    server.listen(port, '127.0.0.1', () => resolve(server));
+    server.on('error', reject);
+  });
+}
+
+function cancelPublish(args, expectedRetry, port, slug = 'recovery-doc') {
+  return new Promise((resolve, reject) => {
+    const fixture = isolatedHome(slug);
+    const pending = path.join(fixture.home, '.tdoc', 'pending-signin.json');
+    const config = path.join(fixture.home, '.tdoc', 'published.json');
+    let stderr = '';
+    let interrupted = false;
+    const child = spawn(PUBLISH, args, {
+      detached: true,
+      env: {
+        ...process.env,
+        HOME: fixture.home,
+        TDOC_DIR: fixture.docs,
+        TDOC_HOSTED_BASE: `http://127.0.0.1:${port}`,
+        TDOC_NO_BROWSER: '1',
+        TDOC_SKIP_UPDATE_CHECK: '1',
+        TDOC_PLATFORM: '',
+      },
+      stdio: ['ignore', 'ignore', 'pipe'],
+    });
+    const timer = setTimeout(() => {
+      try { process.kill(-child.pid, 'SIGKILL'); } catch {}
+      reject(new Error(`publish did not reach device wait; stderr:\n${stderr}`));
+    }, 15000);
+    child.stderr.on('data', (chunk) => {
+      stderr += chunk;
+      if (!interrupted && stderr.includes('Waiting for GitHub approval')) {
+        interrupted = true;
+        process.kill(-child.pid, 'SIGINT');
+      }
+    });
+    child.on('error', reject);
+    child.on('close', (code, signal) => {
+      clearTimeout(timer);
+      try {
+        assert(interrupted, `publish exited before SIGINT; code=${code} signal=${signal}\n${stderr}`);
+        assert(code === 130, `SIGINT should exit 130, got code=${code} signal=${signal}\n${stderr}`);
+        assert(stderr.includes('GitHub sign-in canceled. No credential was saved.'),
+          `cancel state was not explicit:\n${stderr}`);
+        assert(stderr.includes(`[tdoc] Retry: ${expectedRetry}`),
+          `retry command did not preserve the invocation:\n${stderr}`);
+        assert(!/denied/i.test(stderr), `SIGINT was mislabeled as denied:\n${stderr}`);
+        assert(!fs.existsSync(pending), 'pending-signin.json survived cancellation');
+        assert(!fs.existsSync(config), 'a publish credential was saved after cancellation');
+        resolve();
+      } catch (error) {
+        reject(error);
+      } finally {
+        fs.rmSync(fixture.home, { recursive: true, force: true });
+      }
+    });
+  });
+}
+
+(async () => {
+  console.log('terminal onboarding recovery');
+
+  for (const provider of ['cloudflare', 'vercel']) {
+    await t(`missing ${provider} CLI preserves --platform in retry`, () => {
+      const fixture = isolatedHome();
+      try {
+        const result = spawnSync(PUBLISH, ['--platform', provider, fixture.slug], {
+          env: {
+            ...process.env,
+            HOME: fixture.home,
+            TDOC_DIR: fixture.docs,
+            PATH: pathWithoutProvider(fixture.home),
+            TDOC_SKIP_UPDATE_CHECK: '1',
+            TDOC_PLATFORM: '',
+          },
+          encoding: 'utf8',
+          timeout: 20000,
+        });
+        assert(result.status === 1, `expected exit 1, got ${result.status}: ${result.stderr}`);
+        const retry = `/tdoc publish --platform ${provider} ${fixture.slug}`;
+        assert(result.stderr.includes(retry), `missing exact retry ${retry}:\n${result.stderr}`);
+      } finally {
+        fs.rmSync(fixture.home, { recursive: true, force: true });
+      }
+    });
+  }
+
+  const port = await freePort();
+  const server = await startDeviceServer(port);
+  try {
+    await t('SIGINT during sign-in-only clears state and prints its exact retry', () =>
+      cancelPublish(['--signin-only'], '/tdoc publish --signin-only', port, 'signin'));
+
+    const flags = [
+      '--platform', 'hosted', '--visibility', 'private', '--history', 'owner',
+      '--commenting', 'owner', '--allow-user', 'octocat', 'recovery-doc',
+    ];
+    await t('SIGINT during publish preserves the current slug and flags', () =>
+      cancelPublish(
+        flags,
+        '/tdoc publish --platform hosted --visibility private --history owner --commenting owner --allow-user octocat recovery-doc',
+        port,
+      ));
+  } finally {
+    await new Promise((resolve) => server.close(resolve));
+  }
+
+  console.log(`\n${pass} passed, ${fail} failed`);
+  process.exit(fail ? 1 : 0);
+})();

--- a/test/run.js
+++ b/test/run.js
@@ -63,6 +63,7 @@ const OFFLINE = [
   'vercel-shim.test.js',      // vercel storage shims (KV/R2 contract, rewrite URL)
   'api.test.js',              // hermetic: spawns its own server in a temp dir
   'publish-signin.test.js',   // device code reaches the publish modal (expiry/pid/slug guards)
+  'onboarding-terminal-recovery.test.js', // provider retry flags + honest SIGINT recovery
 ];
 
 // Require network (live Cloudflare) or a browser (playwright). Not run in the


### PR DESCRIPTION
## Scope

Terminal onboarding only. Preserves the selected Cloudflare/Vercel platform when the CLI is missing, makes device-flow cancellation explicit and safe, and clarifies that publish resumes after authorization.

No landing-page changes. No reader/template changes.

## Verification

- `node test/onboarding-terminal-recovery.test.js` — 4/4
- `node test/cli.test.js` — 70/70
- `node test/publish-signin.test.js` — 9/9
- `node test/onboarding.test.js` — 16/16
- `npm test` — 49/49
- Independent exact-head audit: CLEAN (`70a5427d8f72f7702c6886319a043540e8169906`)

## Manual UX audit

Terminal output and recovery paths were exercised at the exact head. This PR intentionally excludes the real GitHub authorization acceptance test, which remains a post-merge human gate.