### PR TITLE
fix: update the active agent skill checkout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -203,6 +203,14 @@ file and `.claude-plugin/plugin.json`.
   different agent's installation and leave the active one stale. The default
   now comes from the updater script's own directory while an explicit
   `SKILL_DIR` override continues to work. [#332](https://github.com/tornado-doc/tdoc/pull/332).
+- **Automatic updates select the active agent's installation.** The skill's
+  preamble still searched Claude, Codex, and shared installations in one fixed
+  order before it invoked the updater. On a machine with multiple agents,
+  Codex could therefore invoke Claude's updater even though each updater now
+  correctly modifies itself. Resolution is host-aware, falls back to the
+  shared `~/.agents` checkout, and still honors `TDOC_SKILL_DIR` first. The
+  resolved checkout is also passed explicitly to the updater so installations
+  old enough to predate #332 can bootstrap onto the fixed behavior.
 - **The first doc goes to tdoc.dev, privately, instead of ending at
   localhost.** The recipe told the agent to build the page, open it locally and
   ask before publishing — which recreated exactly the failure the localhost

--- a/SKILL.md
+++ b/SKILL.md
@@ -186,15 +186,33 @@ Server runs at `http://localhost:7878` (override with `TDOC_PORT`) and serves:
 
 ```bash
 TDOC_DIR="${TDOC_DIR:-$HOME/tdocs}"
-# Resolve the skill dir for whichever host installed it: Claude Code
-# (~/.claude/skills/tdoc) or Codex (~/.codex/skills/tdoc). Honor an explicit
-# TDOC_SKILL_DIR override if set. Claude's location is checked first, so its
-# behavior is unchanged.
-SKILL_DIR="${TDOC_SKILL_DIR:-}"
-[ -z "$SKILL_DIR" ] && for d in "$HOME/.claude/skills/tdoc" "$HOME/.codex/skills/tdoc"; do
-  [ -f "$d/SKILL.md" ] && SKILL_DIR="$d" && break
-done
-SKILL_DIR="${SKILL_DIR:-$HOME/.claude/skills/tdoc}"
+# Resolve the checkout for the agent that is running this skill. Multiple
+# agents can be installed on one machine, so a fixed cross-host order can
+# update Claude's checkout while Codex is using a different one (or vice
+# versa). An explicit override remains authoritative.
+tdoc_resolve_skill_dir() {
+  if [ -n "${TDOC_SKILL_DIR:-}" ]; then
+    printf '%s\n' "$TDOC_SKILL_DIR"
+    return
+  fi
+  if [ -n "${CLAUDE_CODE:-}${CLAUDE_SESSION_ID:-}${CLAUDECODE:-}${CLAUDE_CODE_ENTRYPOINT:-}${CLAUDE_CODE_SSE_PORT:-}" ]; then
+    for d in "$HOME/.claude/skills/tdoc" "$HOME/.agents/skills/tdoc" "$HOME/.codex/skills/tdoc"; do
+      [ -f "$d/SKILL.md" ] && { printf '%s\n' "$d"; return; }
+    done
+    printf '%s\n' "$HOME/.claude/skills/tdoc"
+  elif [ -n "${CODEX_SESSION_ID:-}${CODEX_CLI:-}${OPENAI_CODEX:-}${CODEX_HOME:-}${CODEX_SHELL:-}" ]; then
+    for d in "$HOME/.codex/skills/tdoc" "$HOME/.agents/skills/tdoc" "$HOME/.claude/skills/tdoc"; do
+      [ -f "$d/SKILL.md" ] && { printf '%s\n' "$d"; return; }
+    done
+    printf '%s\n' "$HOME/.codex/skills/tdoc"
+  else
+    for d in "$HOME/.agents/skills/tdoc" "$HOME/.claude/skills/tdoc" "$HOME/.codex/skills/tdoc"; do
+      [ -f "$d/SKILL.md" ] && { printf '%s\n' "$d"; return; }
+    done
+    printf '%s\n' "$HOME/.agents/skills/tdoc"
+  fi
+}
+SKILL_DIR="$(tdoc_resolve_skill_dir)"
 mkdir -p "$TDOC_DIR"
 
 # Check server is running. Identity-check the body — 200 alone is not proof
@@ -234,7 +252,8 @@ Three files are required reading before you write doc HTML, on every
 | `$SKILL_DIR/authoring/style/<picked>.md` | what those parts look like | Yes — you pick the entry that fits the content. |
 
 `$SKILL_DIR` is the installed skill directory resolved in "Setup check"
-above (`~/.claude/skills/tdoc`, or `~/.codex/skills/tdoc` under Codex) —
+above (`~/.claude/skills/tdoc`, `~/.codex/skills/tdoc`, or the shared
+`~/.agents/skills/tdoc`) —
 **not** the current working directory, which is the user's project.
 
 `voice.md` carries tdoc's adaptation of the vendored `no-ai-slop` rule set
@@ -1245,12 +1264,29 @@ fi
 # A self-update that depends on an install step is a self-update that does not
 # exist. Note this is a different directory from the TDOC_DIR above, which is
 # the docs root (~/tdocs) — hence the distinct name.
-TDOC_SKILL_ROOT="${TDOC_SKILL_DIR:-}"
-if [ -z "$TDOC_SKILL_ROOT" ]; then
-  for _d in "$HOME/.claude/skills/tdoc" "$HOME/.codex/skills/tdoc" "$HOME/.agents/skills/tdoc"; do
-    [ -f "$_d/SKILL.md" ] && TDOC_SKILL_ROOT="$_d" && break
-  done
-fi
+tdoc_resolve_skill_dir() {
+  if [ -n "${TDOC_SKILL_DIR:-}" ]; then
+    printf '%s\n' "$TDOC_SKILL_DIR"
+    return
+  fi
+  if [ -n "${CLAUDE_CODE:-}${CLAUDE_SESSION_ID:-}${CLAUDECODE:-}${CLAUDE_CODE_ENTRYPOINT:-}${CLAUDE_CODE_SSE_PORT:-}" ]; then
+    for _d in "$HOME/.claude/skills/tdoc" "$HOME/.agents/skills/tdoc" "$HOME/.codex/skills/tdoc"; do
+      [ -f "$_d/SKILL.md" ] && { printf '%s\n' "$_d"; return; }
+    done
+    printf '%s\n' "$HOME/.claude/skills/tdoc"
+  elif [ -n "${CODEX_SESSION_ID:-}${CODEX_CLI:-}${OPENAI_CODEX:-}${CODEX_HOME:-}${CODEX_SHELL:-}" ]; then
+    for _d in "$HOME/.codex/skills/tdoc" "$HOME/.agents/skills/tdoc" "$HOME/.claude/skills/tdoc"; do
+      [ -f "$_d/SKILL.md" ] && { printf '%s\n' "$_d"; return; }
+    done
+    printf '%s\n' "$HOME/.codex/skills/tdoc"
+  else
+    for _d in "$HOME/.agents/skills/tdoc" "$HOME/.claude/skills/tdoc" "$HOME/.codex/skills/tdoc"; do
+      [ -f "$_d/SKILL.md" ] && { printf '%s\n' "$_d"; return; }
+    done
+    printf '%s\n' "$HOME/.agents/skills/tdoc"
+  fi
+}
+TDOC_SKILL_ROOT="$(tdoc_resolve_skill_dir)"
 
 # Resolve installed version, trying multiple sources in order:
 #   1. VERSION file (if maintained, like gstack)
@@ -1280,7 +1316,9 @@ fi
 # the installed script actually knows.
 if [ -z "${TDOC_SKIP_UPDATE_CHECK:-}" ] && [ -x "$TDOC_SKILL_ROOT/bin/tdoc-update" ] \
    && grep -q -- '--auto)' "$TDOC_SKILL_ROOT/bin/tdoc-update" 2>/dev/null; then
-  "$TDOC_SKILL_ROOT/bin/tdoc-update" --auto 2>&1 || true
+  # Pass the resolved checkout explicitly so versions older than #332, whose
+  # internal default was ~/.claude, can still bootstrap the correct install.
+  SKILL_DIR="$TDOC_SKILL_ROOT" "$TDOC_SKILL_ROOT/bin/tdoc-update" --auto 2>&1 || true
 fi
 
 if [ -x "$TDOC_SKILL_ROOT/bin/tdoc-update-nag" ]; then

--- a/skills/tdoc/SKILL.md
+++ b/skills/tdoc/SKILL.md
@@ -186,15 +186,33 @@ Server runs at `http://localhost:7878` (override with `TDOC_PORT`) and serves:
 
 ```bash
 TDOC_DIR="${TDOC_DIR:-$HOME/tdocs}"
-# Resolve the skill dir for whichever host installed it: Claude Code
-# (~/.claude/skills/tdoc) or Codex (~/.codex/skills/tdoc). Honor an explicit
-# TDOC_SKILL_DIR override if set. Claude's location is checked first, so its
-# behavior is unchanged.
-SKILL_DIR="${TDOC_SKILL_DIR:-}"
-[ -z "$SKILL_DIR" ] && for d in "$HOME/.claude/skills/tdoc" "$HOME/.codex/skills/tdoc"; do
-  [ -f "$d/SKILL.md" ] && SKILL_DIR="$d" && break
-done
-SKILL_DIR="${SKILL_DIR:-$HOME/.claude/skills/tdoc}"
+# Resolve the checkout for the agent that is running this skill. Multiple
+# agents can be installed on one machine, so a fixed cross-host order can
+# update Claude's checkout while Codex is using a different one (or vice
+# versa). An explicit override remains authoritative.
+tdoc_resolve_skill_dir() {
+  if [ -n "${TDOC_SKILL_DIR:-}" ]; then
+    printf '%s\n' "$TDOC_SKILL_DIR"
+    return
+  fi
+  if [ -n "${CLAUDE_CODE:-}${CLAUDE_SESSION_ID:-}${CLAUDECODE:-}${CLAUDE_CODE_ENTRYPOINT:-}${CLAUDE_CODE_SSE_PORT:-}" ]; then
+    for d in "$HOME/.claude/skills/tdoc" "$HOME/.agents/skills/tdoc" "$HOME/.codex/skills/tdoc"; do
+      [ -f "$d/SKILL.md" ] && { printf '%s\n' "$d"; return; }
+    done
+    printf '%s\n' "$HOME/.claude/skills/tdoc"
+  elif [ -n "${CODEX_SESSION_ID:-}${CODEX_CLI:-}${OPENAI_CODEX:-}${CODEX_HOME:-}${CODEX_SHELL:-}" ]; then
+    for d in "$HOME/.codex/skills/tdoc" "$HOME/.agents/skills/tdoc" "$HOME/.claude/skills/tdoc"; do
+      [ -f "$d/SKILL.md" ] && { printf '%s\n' "$d"; return; }
+    done
+    printf '%s\n' "$HOME/.codex/skills/tdoc"
+  else
+    for d in "$HOME/.agents/skills/tdoc" "$HOME/.claude/skills/tdoc" "$HOME/.codex/skills/tdoc"; do
+      [ -f "$d/SKILL.md" ] && { printf '%s\n' "$d"; return; }
+    done
+    printf '%s\n' "$HOME/.agents/skills/tdoc"
+  fi
+}
+SKILL_DIR="$(tdoc_resolve_skill_dir)"
 mkdir -p "$TDOC_DIR"
 
 # Check server is running. Identity-check the body — 200 alone is not proof
@@ -234,7 +252,8 @@ Three files are required reading before you write doc HTML, on every
 | `$SKILL_DIR/authoring/style/<picked>.md` | what those parts look like | Yes — you pick the entry that fits the content. |
 
 `$SKILL_DIR` is the installed skill directory resolved in "Setup check"
-above (`~/.claude/skills/tdoc`, or `~/.codex/skills/tdoc` under Codex) —
+above (`~/.claude/skills/tdoc`, `~/.codex/skills/tdoc`, or the shared
+`~/.agents/skills/tdoc`) —
 **not** the current working directory, which is the user's project.
 
 `voice.md` carries tdoc's adaptation of the vendored `no-ai-slop` rule set
@@ -1245,12 +1264,29 @@ fi
 # A self-update that depends on an install step is a self-update that does not
 # exist. Note this is a different directory from the TDOC_DIR above, which is
 # the docs root (~/tdocs) — hence the distinct name.
-TDOC_SKILL_ROOT="${TDOC_SKILL_DIR:-}"
-if [ -z "$TDOC_SKILL_ROOT" ]; then
-  for _d in "$HOME/.claude/skills/tdoc" "$HOME/.codex/skills/tdoc" "$HOME/.agents/skills/tdoc"; do
-    [ -f "$_d/SKILL.md" ] && TDOC_SKILL_ROOT="$_d" && break
-  done
-fi
+tdoc_resolve_skill_dir() {
+  if [ -n "${TDOC_SKILL_DIR:-}" ]; then
+    printf '%s\n' "$TDOC_SKILL_DIR"
+    return
+  fi
+  if [ -n "${CLAUDE_CODE:-}${CLAUDE_SESSION_ID:-}${CLAUDECODE:-}${CLAUDE_CODE_ENTRYPOINT:-}${CLAUDE_CODE_SSE_PORT:-}" ]; then
+    for _d in "$HOME/.claude/skills/tdoc" "$HOME/.agents/skills/tdoc" "$HOME/.codex/skills/tdoc"; do
+      [ -f "$_d/SKILL.md" ] && { printf '%s\n' "$_d"; return; }
+    done
+    printf '%s\n' "$HOME/.claude/skills/tdoc"
+  elif [ -n "${CODEX_SESSION_ID:-}${CODEX_CLI:-}${OPENAI_CODEX:-}${CODEX_HOME:-}${CODEX_SHELL:-}" ]; then
+    for _d in "$HOME/.codex/skills/tdoc" "$HOME/.agents/skills/tdoc" "$HOME/.claude/skills/tdoc"; do
+      [ -f "$_d/SKILL.md" ] && { printf '%s\n' "$_d"; return; }
+    done
+    printf '%s\n' "$HOME/.codex/skills/tdoc"
+  else
+    for _d in "$HOME/.agents/skills/tdoc" "$HOME/.claude/skills/tdoc" "$HOME/.codex/skills/tdoc"; do
+      [ -f "$_d/SKILL.md" ] && { printf '%s\n' "$_d"; return; }
+    done
+    printf '%s\n' "$HOME/.agents/skills/tdoc"
+  fi
+}
+TDOC_SKILL_ROOT="$(tdoc_resolve_skill_dir)"
 
 # Resolve installed version, trying multiple sources in order:
 #   1. VERSION file (if maintained, like gstack)
@@ -1280,7 +1316,9 @@ fi
 # the installed script actually knows.
 if [ -z "${TDOC_SKIP_UPDATE_CHECK:-}" ] && [ -x "$TDOC_SKILL_ROOT/bin/tdoc-update" ] \
    && grep -q -- '--auto)' "$TDOC_SKILL_ROOT/bin/tdoc-update" 2>/dev/null; then
-  "$TDOC_SKILL_ROOT/bin/tdoc-update" --auto 2>&1 || true
+  # Pass the resolved checkout explicitly so versions older than #332, whose
+  # internal default was ~/.claude, can still bootstrap the correct install.
+  SKILL_DIR="$TDOC_SKILL_ROOT" "$TDOC_SKILL_ROOT/bin/tdoc-update" --auto 2>&1 || true
 fi
 
 if [ -x "$TDOC_SKILL_ROOT/bin/tdoc-update-nag" ]; then

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -1187,6 +1187,8 @@ t('SKILL.md resolves its own directory at runtime, not at install time', () => {
   assert(/TDOC_SKILL_ROOT=/.test(skill), 'no runtime resolution of the skill directory');
   assert(/tdoc-update" --auto/.test(skill) || /tdoc-update" --auto/.test(skill.replace(/\n\s*/g, ' ')),
     'the automatic update call is gone');
+  assert(/SKILL_DIR="\$TDOC_SKILL_ROOT"\s+"\$TDOC_SKILL_ROOT\/bin\/tdoc-update" --auto/.test(skill),
+    'the preamble does not pin old updaters to the resolved active checkout');
 
   // And the guard must actually pass against a real checkout.
   const root = path.join(__dirname, '..');
@@ -1196,6 +1198,58 @@ t('SKILL.md resolves its own directory at runtime, not at install time', () => {
     { encoding: 'utf8', timeout: 10000 });
   assert(probe.stdout.trim() === 'ok',
     'the resolved directory does not satisfy the update guard');
+});
+
+t('SKILL.md resolves the checkout for the active agent host', () => {
+  const skill = fs.readFileSync(path.join(__dirname, '..', 'SKILL.md'), 'utf8');
+  const resolvers = skill.match(/tdoc_resolve_skill_dir\(\) \{[\s\S]*?\n\}/g) || [];
+  assert(resolvers.length === 2,
+    `expected setup + telemetry resolvers, found ${resolvers.length}`);
+
+  const home = fs.mkdtempSync(path.join(os.tmpdir(), 'tdoc-agent-roots-'));
+  const roots = {
+    claude: path.join(home, '.claude', 'skills', 'tdoc'),
+    codex: path.join(home, '.codex', 'skills', 'tdoc'),
+    agents: path.join(home, '.agents', 'skills', 'tdoc'),
+  };
+  for (const root of Object.values(roots)) {
+    fs.mkdirSync(root, { recursive: true });
+    fs.writeFileSync(path.join(root, 'SKILL.md'), 'fixture\n');
+  }
+
+  const resolve = (source, extraEnv = {}) => {
+    const r = spawnSync('bash', ['-c', `${source}\ntdoc_resolve_skill_dir`], {
+      env: { HOME: home, PATH: process.env.PATH || '/usr/bin:/bin', ...extraEnv },
+      encoding: 'utf8',
+      timeout: 10000,
+    });
+    assert(r.status === 0, `resolver failed: ${r.stderr}`);
+    return r.stdout.trim();
+  };
+
+  try {
+    for (const resolver of resolvers) {
+      assert(resolve(resolver, { CODEX_SESSION_ID: 'codex-test' }) === roots.codex,
+        'Codex did not prefer its Codex-specific installation');
+      assert(resolve(resolver, { CLAUDECODE: '1' }) === roots.claude,
+        'Claude did not prefer its Claude-specific installation');
+      assert(resolve(resolver) === roots.agents,
+        'an unknown/shared host did not prefer the shared .agents installation');
+
+      fs.unlinkSync(path.join(roots.codex, 'SKILL.md'));
+      assert(resolve(resolver, { CODEX_SESSION_ID: 'codex-test' }) === roots.agents,
+        'Codex did not fall back to the shared .agents installation');
+      fs.writeFileSync(path.join(roots.codex, 'SKILL.md'), 'fixture\n');
+
+      const override = path.join(home, 'explicit-tdoc');
+      assert(resolve(resolver, {
+        CODEX_SESSION_ID: 'codex-test',
+        TDOC_SKILL_DIR: override,
+      }) === override, 'TDOC_SKILL_DIR no longer overrides host detection');
+    }
+  } finally {
+    fs.rmSync(home, { recursive: true, force: true });
+  }
 });
 
 


### PR DESCRIPTION
## Summary

- make tdoc skill-directory resolution aware of the active agent host
- prefer Codex, Claude, or shared .agents installs in the matching order
- preserve TDOC_SKILL_DIR as the authoritative override
- pass the resolved SKILL_DIR into tdoc-update so pre-#332 installations bootstrap the correct checkout
- cover both setup and telemetry resolver copies with executable regression tests

## Why #332 was not sufficient

#332 made each updater modify its own checkout, but the SKILL.md preamble still chose which updater to invoke using a fixed Claude-first order. On a machine where Codex loaded ~/.agents/skills/tdoc and ~/.claude/skills/tdoc also existed, the preamble invoked Claude’s updater.

There is also a bootstrap edge: a checkout older than #332 still has the old updater default. Passing SKILL_DIR explicitly is required for that old updater to update the selected checkout on its first fixed run.

## Verification

- node test/cli.test.js — 74 passed, 0 failed
- npm test — all 49 default suites green
- SKILL.md and skills/tdoc/SKILL.md are byte-identical
- git diff --check clean
- isolated dual-install E2E from pre-#332 commit 2f93abe:
  - Codex resolved ~/.agents/skills/tdoc
  - .agents advanced to origin/main 4594c36
  - parallel .claude remained at 2f93abe

## Existing work checked

No open PR overlaps this resolver/update path. This follows merged PRs #268 and #332 rather than replacing or reverting them.