### PR TITLE
Storing a document version becomes one function

### DIFF
--- a/bin/tdoc-bake
+++ b/bin/tdoc-bake
@@ -43,7 +43,10 @@ function templateStamp(css) {
 }
 
 function hasBlock(html) {
-  return html.includes('id="tdoc-reader"');
+  // Tag match, not substring: a document whose prose quotes id="tdoc-reader"
+  // in a code sample must still be baked. Mirrors hasReaderBlock() in
+  // worker/worker.js.
+  return /<style[^>]*\bid="tdoc-reader"/i.test(html);
 }
 
 // Returns true when the file was changed.

--- a/bin/tdoc-publish
+++ b/bin/tdoc-publish
@@ -1198,8 +1198,13 @@ upload_version() {
   payload_file="$(mktemp -t tdoc-upload.XXXXXX)"
   printf '%s' "$payload" > "$payload_file"
   local resp
+  # Tier-1 client visibility: the server records which client produced each
+  # version. This is the observability that does not depend on the client's
+  # own (repeatedly silently-broken) self-update machinery.
+  TDOC_CLIENT_VERSION="$(cat "$SKILL_DIR/VERSION" 2>/dev/null || echo unknown)"
   resp="$(curl -sS --connect-timeout 10 --max-time 120 -X POST "$UPLOAD_BASE/api/upload" \
     -H "Authorization: Bearer $TOKEN" \
+    -H "X-Tdoc-Client: $TDOC_CLIENT_VERSION" \
     -H "Content-Type: application/json" \
     --data-binary @"$payload_file")" || { rm -f "$payload_file"; echo "[tdoc] v$v upload: network error/timeout" >&2; return 1; }
   rm -f "$payload_file"

--- a/server/server.js
+++ b/server/server.js
@@ -789,7 +789,10 @@ const server = http.createServer(async (req, res) => {
       // Roman. The proxy is unnecessary: the template is :where()
       // zero-specificity throughout, so a document that does style itself
       // wins every property it declares and is unaffected by the injection.
-      if (!body.includes('id="tdoc-reader"')) {
+      // Tag match, not substring: a doc whose PROSE quotes id="tdoc-reader"
+      // (tdoc's own design docs do) must still receive the template. Mirrors
+      // hasReaderBlock() in worker.js.
+      if (!/<style[^>]*\bid="tdoc-reader"/i.test(body)) {
         const rcss = readerCss();
         if (rcss) {
           const rtag = `<style id="tdoc-reader">${rcss}</style>`;

--- a/test/bake-reader.test.js
+++ b/test/bake-reader.test.js
@@ -106,7 +106,9 @@ try {
     const src = fs.readFileSync(path.join(ROOT, 'worker', 'worker.js'), 'utf8');
     const fn = src.slice(src.indexOf('function injectReaderCss'));
     const body = fn.slice(0, fn.indexOf('\n}'));
-    if (!body.includes("html.includes('id=\"tdoc-reader\"')")) {
+    // The guard is the shared tag-matching test (a substring check
+    // false-positives on prose that quotes the id).
+    if (!body.includes('hasReaderBlock(html)')) {
       throw new Error('injectReaderCss has no presence guard — downloads get two reader blocks');
     }
   });

--- a/test/duplicate-download.test.js
+++ b/test/duplicate-download.test.js
@@ -80,7 +80,9 @@ t('POST /api/doc/duplicate is session-gated, snapshot-only, no comment copy', ()
   assert(dupRoute.includes('sourceHasWidgets'), 'must refuse island-bearing docs');
   assert(!dupRoute.includes('mutateComments'), 'v1 duplicate must not copy comment threads');
   assert(!dupRoute.includes('readComments'), 'v1 duplicate must not snapshot comments');
-  assert(dupRoute.includes('stampAids'), 'copied HTML must be aid-stamped');
+  // prepareDocVersion is the single home for stored-document invariants:
+  // it aid-stamps AND bakes the reading template AND records the content sha.
+  assert(dupRoute.includes('prepareDocVersion'), 'copied HTML must go through prepareDocVersion (aids + bake + sha)');
   assert(dupRoute.includes('hostedAccountForGithub'), 'duplicate must reuse the hosted account registry');
   assert(dupRoute.includes('quota_docs'), 'duplicate must share the hosted doc quota');
   assert(dupRoute.includes('quota_upload_bytes'), 'duplicate must share the hosted upload-size cap');

--- a/test/run.js
+++ b/test/run.js
@@ -51,6 +51,7 @@ const OFFLINE = [
   'worker-shell.test.js',     // step7 worker shell parity: /frame route, CSP, bundled builders
   'bake-reader.test.js',      // tdoc-new bakes the reader template → self-contained docs (shell)
   'dark-invert-parity.test.js', // the shell's dark invert and the frame's copy must not drift
+  'write-invariants.test.js',  // every server write path bakes, stamps aids, records sha
   'comment-upload.test.js',   // local→worker comment merge (non-destructive)
   'comment-ops.test.js',      // #34 DO-serialized mutation ops
   'notifications.test.js',    // inbox aggregation + Reddit recipients

--- a/test/write-invariants.test.js
+++ b/test/write-invariants.test.js
@@ -1,0 +1,223 @@
+// Every server path that stores a document version goes through
+// prepareDocVersion(): bake the reading template, stamp aids, hash the exact
+// stored bytes. This suite exercises the three writers — /api/upload, the
+// browser Save inside the Durable Object, and duplicate — through the real
+// fetch handler against fake bindings, and asserts the invariants landed in
+// R2 and in the version entries. Widgets are asserted NOT baked: they are
+// sandboxed islands, and the reading template does not belong in them.
+//
+// Why this exists: the browser Save path (#329) shipped without baking, which
+// is exactly what happens when "store a version" is not a function anyone can
+// be routed through. The harness mirrors hosted-oob-behavior.test.js.
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const crypto = require('crypto');
+
+let pass = 0, fail = 0;
+function ok(n) { console.log(`  ✓ ${n}`); pass++; }
+function bad(n, e) { console.log(`  ✗ ${n}\n    ${e && e.stack ? e.stack.split('\n').slice(0, 3).join('\n    ') : e}`); fail++; }
+async function t(n, fn) { try { await fn(); ok(n); } catch (e) { bad(n, e); } }
+function assert(cond, msg) { if (!cond) throw new Error(msg || 'assertion failed'); }
+
+class FakeKV {
+  constructor() { this.map = new Map(); }
+  async get(k) { return this.map.has(k) ? this.map.get(k) : null; }
+  async put(k, v) { this.map.set(k, String(v)); }
+  async delete(k) { this.map.delete(k); }
+  async list({ prefix = '' } = {}) {
+    return { keys: [...this.map.keys()].filter((k) => k.startsWith(prefix)).map((name) => ({ name })), list_complete: true };
+  }
+}
+class FakeR2 {
+  constructor() { this.map = new Map(); }
+  async get(k) {
+    if (!this.map.has(k)) return null;
+    const v = this.map.get(k);
+    return { text: async () => v, body: v };
+  }
+  async put(k, v) { this.map.set(k, String(v)); }
+  async head(k) { return this.map.has(k) ? { key: k } : null; }
+  async delete(k) { const ks = Array.isArray(k) ? k : [k]; for (const one of ks) this.map.delete(one); }
+  async list({ prefix = '', cursor } = {}) {
+    return { objects: [...this.map.keys()].filter((k) => k.startsWith(prefix)).map((key) => ({ key })), truncated: false, cursor: undefined };
+  }
+}
+class FakeStorage {
+  constructor() { this.map = new Map(); }
+  async get(k) { return this.map.has(k) ? this.map.get(k) : undefined; }
+  async put(k, v) { this.map.set(k, v); }
+  async delete(k) { this.map.delete(k); }
+  async transaction(fn) { await fn(this); }
+}
+class FakeDurableNamespace {
+  constructor(env, StoreClass) { this.env = env; this.StoreClass = StoreClass; this.states = new Map(); }
+  idFromName(name) { return name; }
+  get(id) {
+    if (!this.states.has(id)) this.states.set(id, { storage: new FakeStorage() });
+    const state = this.states.get(id);
+    const { StoreClass, env } = this;
+    return {
+      fetch: async (url, init = {}) => {
+        const store = new StoreClass(state, env);
+        return store.fetch(new Request(url, init));
+      },
+    };
+  }
+}
+
+async function loadWorker() {
+  const root = path.join(__dirname, '..');
+  let src = fs.readFileSync(path.join(root, 'worker', 'worker.js'), 'utf8');
+  const readerCss = fs.readFileSync(path.join(root, 'server', 'reader.css'), 'utf8');
+  src = src.replace(/const READER_CSS = `__TDOC_READER_CSS__`;/, 'const READER_CSS = ' + JSON.stringify(readerCss) + ';');
+  const tmp = path.join(os.tmpdir(), `tdoc-wi-${Date.now()}-${Math.random().toString(16).slice(2)}.mjs`);
+  fs.writeFileSync(tmp, src);
+  const mod = await import(`file://${tmp}`);
+  try { fs.unlinkSync(tmp); } catch {}
+  return mod;
+}
+
+function makeEnv(StoreClass) {
+  const env = { META: new FakeKV(), DOCS: new FakeR2(), TDOC_HOSTED_REGISTRATION: '1' };
+  env.COMMENTS = new FakeDurableNamespace(env, StoreClass);
+  return env;
+}
+
+function req(pathname, { method = 'GET', token = '', body = null, cookie = '', headers = {} } = {}) {
+  return new Request(`https://tdoc.dev${pathname}`, {
+    method,
+    headers: {
+      ...(token ? { Authorization: `Bearer ${token}` } : {}),
+      ...(cookie ? { Cookie: `tdoc_sid=${cookie}` } : {}),
+      ...(body ? { 'Content-Type': 'application/json' } : {}),
+      ...headers,
+    },
+    body: body ? JSON.stringify(body) : undefined,
+  });
+}
+
+async function putSession(env, login) {
+  const sid = crypto.randomBytes(16).toString('hex');
+  await env.META.put(`session:${sid}`, JSON.stringify({ login, avatar_url: '', created: new Date().toISOString() }));
+  return sid;
+}
+
+async function issue(worker, env, login = 'alice') {
+  const cookie = await putSession(env, login);
+  const r = await worker.fetch(req('/api/hosted/token', { method: 'POST', cookie, body: { label: login } }), env, {});
+  const data = await r.json();
+  assert(r.status === 200 && data.token, `token issue failed ${r.status}: ${JSON.stringify(data)}`);
+  return { ...data, cookie, login };
+}
+
+// A host document that follows the authoring contract: no font of its own, a
+// responsive breakpoint — the exact shape the old fallback starved.
+const DOC = '<!doctype html><html><head><meta name="viewport" content="width=device-width, initial-scale=1">'
+  + '<title>t</title><style>body{background:#fff}@media (max-width:520px){.x{padding:4px}}</style>'
+  + '</head><body><div class="wrap"><h1>T</h1><p>hi</p></div></body></html>';
+
+(async () => {
+  console.log('server write invariants (upload / browser save / duplicate)\n');
+  const mod = await loadWorker();
+  const worker = mod.default;
+
+  await t('upload: stored bytes carry the baked, generation-stamped template', async () => {
+    const env = makeEnv(mod.CommentsStore);
+    const a = await issue(worker, env);
+    const r = await worker.fetch(req('/api/upload', {
+      method: 'POST', token: a.token, headers: { 'X-Tdoc-Client': '0.9.0' },
+      body: { slug: 'd1', version: 1, html: DOC, meta: { title: 'd1', slug: 'd1', versions: [{ n: 1 }] } },
+    }), env, {});
+    assert(r.status === 200, `upload ${r.status}: ${await r.text()}`);
+    const stored = await (await env.DOCS.get('docs/d1/v1/index.html')).text();
+    assert(/id="tdoc-reader" data-tdoc-template="[0-9a-f]{8}"/.test(stored), 'stored doc lacks the stamped template');
+    assert((stored.match(/id="tdoc-reader"/g) || []).length === 1, 'template baked more than once');
+  });
+
+  await t('upload: version entry records sha of the stored bytes and the client', async () => {
+    const env = makeEnv(mod.CommentsStore);
+    const a = await issue(worker, env);
+    await worker.fetch(req('/api/upload', {
+      method: 'POST', token: a.token, headers: { 'X-Tdoc-Client': '0.9.0' },
+      body: { slug: 'd2', version: 1, html: DOC, meta: { title: 'd2', slug: 'd2', versions: [{ n: 1 }] } },
+    }), env, {});
+    const meta = JSON.parse(await env.META.get('meta:d2'));
+    const entry = meta.versions.find((v) => v.n === 1);
+    assert(entry && /^[0-9a-f]{16}$/.test(entry.sha || ''), `version entry has no sha: ${JSON.stringify(entry)}`);
+    assert(entry.client === '0.9.0', `version entry has no client: ${JSON.stringify(entry)}`);
+    const stored = await (await env.DOCS.get('docs/d2/v1/index.html')).text();
+    const expect = crypto.createHash('sha256').update(stored).digest('hex').slice(0, 16);
+    assert(entry.sha === expect, 'sha does not match the stored bytes');
+  });
+
+  await t('upload: an already-baked document is not double-baked and keeps a stable sha', async () => {
+    const env = makeEnv(mod.CommentsStore);
+    const a = await issue(worker, env);
+    const prebaked = DOC.replace('</head>', '<style id="tdoc-reader">:where(body){font-size:17px}</style></head>');
+    const r = await worker.fetch(req('/api/upload', {
+      method: 'POST', token: a.token,
+      body: { slug: 'd3', version: 1, html: prebaked, meta: { title: 'd3', slug: 'd3', versions: [{ n: 1 }] } },
+    }), env, {});
+    assert(r.status === 200, `upload ${r.status}`);
+    const stored = await (await env.DOCS.get('docs/d3/v1/index.html')).text();
+    assert((stored.match(/id="tdoc-reader"/g) || []).length === 1, 'pre-baked doc gained a second template');
+  });
+
+  await t('browser Save (DO path) bakes and records sha — the #329 gap', async () => {
+    const env = makeEnv(mod.CommentsStore);
+    const a = await issue(worker, env);
+    await worker.fetch(req('/api/upload', {
+      method: 'POST', token: a.token,
+      body: { slug: 'd4', version: 1, html: DOC, meta: { title: 'd4', slug: 'd4', versions: [{ n: 1 }] } },
+    }), env, {});
+    const save = await worker.fetch(req('/api/doc/versions', {
+      method: 'POST', cookie: a.cookie,
+      body: { slug: 'd4', baseVersion: 1, html: DOC.replace('<p>hi</p>', '<p>edited in browser</p>') },
+    }), env, {});
+    assert(save.status === 200, `save ${save.status}: ${await save.text()}`);
+    const stored = await (await env.DOCS.get('docs/d4/v2/index.html')).text();
+    assert(stored.includes('edited in browser'), 'save did not store the edit');
+    assert(/id="tdoc-reader" data-tdoc-template="[0-9a-f]{8}"/.test(stored), 'browser-saved version lacks the template');
+    const meta = JSON.parse(await env.META.get('meta:d4'));
+    const entry = meta.versions.find((v) => v.n === 2);
+    assert(entry && /^[0-9a-f]{16}$/.test(entry.sha || ''), `browser-saved entry has no sha: ${JSON.stringify(entry)}`);
+  });
+
+  await t('duplicate bakes the copy and records sha', async () => {
+    const env = makeEnv(mod.CommentsStore);
+    const a = await issue(worker, env);
+    // Seed an UNBAKED stored doc directly — the pre-migration population.
+    await env.DOCS.put('docs/src/v1/index.html', DOC);
+    await env.META.put('meta:src', JSON.stringify({ title: 'src', slug: 'src', versions: [{ n: 1 }], hosted: { account_id: a.account_id, github_login: a.login } }));
+    const r = await worker.fetch(req('/api/doc/duplicate', {
+      method: 'POST', cookie: a.cookie, body: { slug: 'src', version: 1 },
+    }), env, {});
+    const dupText = await r.text();
+    assert(r.status === 200, `duplicate ${r.status}: ${dupText}`);
+    const dup = JSON.parse(dupText);
+    const newSlug = dup.slug || dup.newSlug;
+    assert(newSlug, `duplicate response has no slug: ${JSON.stringify(dup)}`);
+    const stored = await (await env.DOCS.get(`docs/${newSlug}/v1/index.html`)).text();
+    assert(stored.includes('id="tdoc-reader"'), 'duplicated copy lacks the template');
+    const meta = JSON.parse(await env.META.get(`meta:${newSlug}`));
+    assert(/^[0-9a-f]{16}$/.test((meta.versions[0] || {}).sha || ''), 'duplicated entry has no sha');
+  });
+
+  await t('widgets are NOT baked — the template does not belong in an island', async () => {
+    const env = makeEnv(mod.CommentsStore);
+    const a = await issue(worker, env);
+    const widget = '<!doctype html><html><head><title>w</title></head><body><script>1</script></body></html>';
+    const r = await worker.fetch(req('/api/upload', {
+      method: 'POST', token: a.token,
+      body: { slug: 'd5', version: 1, html: DOC, widgets: { calc: widget }, meta: { title: 'd5', slug: 'd5', versions: [{ n: 1 }] } },
+    }), env, {});
+    assert(r.status === 200, `upload ${r.status}: ${await r.text()}`);
+    const w = await env.DOCS.get('docs/d5/v1/widgets/calc.html');
+    assert(w, 'widget not stored');
+    assert(!(await w.text()).includes('id="tdoc-reader"'), 'widget was baked — reading template leaked into an island');
+  });
+
+  console.log(`\n${pass} passed, ${fail} failed`);
+  process.exit(fail ? 1 : 0);
+})().catch((e) => { console.error(e); process.exit(1); });

--- a/test/write-invariants.test.js
+++ b/test/write-invariants.test.js
@@ -218,6 +218,47 @@ const DOC = '<!doctype html><html><head><meta name="viewport" content="width=dev
     assert(!(await w.text()).includes('id="tdoc-reader"'), 'widget was baked — reading template leaked into an island');
   });
 
+  await t('a doc whose PROSE quotes id="tdoc-reader" is still baked', async () => {
+    // The check is a tag match, not a substring: tdoc's own design docs quote
+    // the id in code samples, and a substring check would skip baking them.
+    const env = makeEnv(mod.CommentsStore);
+    const a = await issue(worker, env);
+    const quoting = DOC.replace('<p>hi</p>', '<p>Never write your own <code>id="tdoc-reader"</code> block.</p>');
+    await worker.fetch(req('/api/upload', {
+      method: 'POST', token: a.token,
+      body: { slug: 'q1', version: 1, html: quoting, meta: { title: 'q1', slug: 'q1', versions: [{ n: 1 }] } },
+    }), env, {});
+    const stored = await (await env.DOCS.get('docs/q1/v1/index.html')).text();
+    assert(/<style[^>]*id="tdoc-reader"/.test(stored), 'prose mention suppressed the bake');
+    assert((stored.match(/<style[^>]*id="tdoc-reader"/g) || []).length === 1, 'expected exactly one real block');
+  });
+
+  await t('history backfill refreshes the version entry sha', async () => {
+    // Re-uploading an old version stores freshly-prepared bytes; the recorded
+    // sha must follow them or /raw serves a stale ETag.
+    const env = makeEnv(mod.CommentsStore);
+    const a = await issue(worker, env);
+    for (const v of [1, 2]) {
+      await worker.fetch(req('/api/upload', {
+        method: 'POST', token: a.token,
+        body: { slug: 'bf', version: v, html: DOC.replace('<p>hi</p>', `<p>v${v}</p>`), meta: { title: 'bf', slug: 'bf', versions: [{ n: 1 }, { n: 2 }].slice(0, v) } },
+      }), env, {});
+    }
+    const meta0 = JSON.parse(await env.META.get('meta:bf'));
+    meta0.versions.find((v) => v.n === 1).sha = 'deadbeefdeadbeef';
+    await env.META.put('meta:bf', JSON.stringify(meta0));
+    await worker.fetch(req('/api/upload', {
+      method: 'POST', token: a.token,
+      body: { slug: 'bf', version: 1, html: DOC.replace('<p>hi</p>', '<p>v1</p>'), meta: { title: 'bf', slug: 'bf', versions: [{ n: 1 }, { n: 2 }] } },
+    }), env, {});
+    const meta = JSON.parse(await env.META.get('meta:bf'));
+    const sha = meta.versions.find((v) => v.n === 1).sha;
+    const stored = await (await env.DOCS.get('docs/bf/v1/index.html')).text();
+    const expect = crypto.createHash('sha256').update(stored).digest('hex').slice(0, 16);
+    assert(sha === expect, `backfill left a stale sha: ${sha} != ${expect}`);
+    assert(meta.versions.find((v) => v.n === 2), 'backfill must not drop other version entries');
+  });
+
   console.log(`\n${pass} passed, ${fail} failed`);
   process.exit(fail ? 1 : 0);
 })().catch((e) => { console.error(e); process.exit(1); });

--- a/worker/worker.js
+++ b/worker/worker.js
@@ -1486,6 +1486,37 @@ function forceWidgetSandbox(html) {
 function readerCssSource() {
   return (typeof READER_CSS === 'string' && READER_CSS.indexOf('__TDOC_') !== 0) ? READER_CSS : '';
 }
+// The document-content invariants, in ONE place. Every path that stores a
+// version of a document — /api/upload, the browser Save inside the Durable
+// Object, and duplicate — goes through this. It exists because there used to
+// be no function named "store a version": each writer assembled the invariants
+// itself, which is how the browser Save path shipped without baking and how
+// nobody ever recorded a content hash (there was nowhere to put it).
+//
+// What it guarantees about the stored bytes:
+//   1. The reading template is baked in, stamped with its generation
+//      (data-tdoc-template), so the file is self-contained however old the
+//      client that produced it. No-op when the document already carries the
+//      block, and when this worker is unbundled (tests on raw worker.js).
+//   2. Artifact aids are stamped (comment anchor identity).
+//   3. `sha` is the hash of the EXACT bytes stored — what a client compares
+//      against to know whether its local copy is current.
+// Widget HTML must NOT come through here: widgets are sandboxed islands with
+// their own CSP, and the reading template does not belong in them.
+async function prepareDocVersion(rawHtml) {
+  let html = String(rawHtml);
+  const css = readerCssSource();
+  if (css && !html.includes('id="tdoc-reader"')) {
+    const stamp = (await sha256Hex(css)).slice(0, 8);
+    const tag = `<style id="tdoc-reader" data-tdoc-template="${stamp}">${css}</style>\n`;
+    // Callback so a `$` in the template stays literal.
+    html = /<\/head>/i.test(html) ? html.replace(/<\/head>/i, () => `${tag}</head>`) : tag + html;
+  }
+  const stamped = stampAids(html);
+  const sha = (await sha256Hex(stamped.html)).slice(0, 16);
+  return { html: stamped.html, aids: stamped.aids, sha };
+}
+
 function injectReaderCss(html, css) {
   if (!css) return html;
   // Documents have been self-contained since creation-time baking landed, so
@@ -3245,7 +3276,7 @@ export class CommentsStore {
       const widgetFrom = `/d/${slug}/v/${op.baseVersion}/widget/`;
       const widgetTo = `/d/${slug}/v/${reservation.next}/widget/`;
       const rewritten = String(op.html).split(widgetFrom).join(widgetTo);
-      const stamped = stampAids(rewritten);
+      const stamped = await prepareDocVersion(rewritten);
       await this._copyVersionWidgets(slug, op.baseVersion, reservation.next);
       const key = `docs/${slug}/v${reservation.next}/index.html`;
       await this.env.DOCS.put(key, stamped.html, {
@@ -3262,6 +3293,7 @@ export class CommentsStore {
         created: now,
         prompt: 'Browser edit',
         source: 'browser',
+        sha: stamped.sha,
         ...(op.actorLogin ? { author: op.actorLogin } : {}),
       });
       versions.sort((a, b) => Number(a.n) - Number(b.n));
@@ -3917,7 +3949,8 @@ export default {
       };
       incoming = stampHostedOwnership(incoming, actor);
 
-      const { html: stampedHtml } = stampAids(rawHtml);
+      const { html: stampedHtml, sha: dupSha } = await prepareDocVersion(rawHtml);
+      incoming.versions[0].sha = dupSha;
       const r2Key = `docs/${newSlug}/v1/index.html`;
       try {
         await env.DOCS.put(r2Key, stampedHtml, {
@@ -4583,7 +4616,12 @@ export default {
       // data-tdoc-aid. The SAME artifact in a different version has the
       // SAME aid — so a comment anchored by aid resolves identity-first
       // and cannot drift onto a different artifact.
-      const { html: stampedHtml, aids } = stampAids(doc);
+      const { html: stampedHtml, aids, sha: uploadSha } = await prepareDocVersion(doc);
+      // Tier-1 client visibility: the server is the only place guaranteed to
+      // see every publish, so the version entry records which client produced
+      // it. The self-update machinery has failed silently in seven distinct
+      // ways; this is the observability that does not depend on it.
+      const clientVersion = (req.headers.get('x-tdoc-client') || '').slice(0, 64) || null;
       const r2Key = `docs/${slug}/v${verNum}/index.html`;
       const incomingLatest = latestVersionNumber(incoming);
       const writesLatestMeta = !!incoming && (incomingLatest === 0 || verNum === incomingLatest);
@@ -4676,6 +4714,11 @@ export default {
           if (!versionByNumber.has(verNum)) {
             versionByNumber.set(verNum, { n: verNum, created: new Date().toISOString() });
           }
+          // The entry for the version whose bytes this request just stored
+          // records the hash of those bytes and the client that sent them.
+          const storedEntry = { ...versionByNumber.get(verNum), sha: uploadSha };
+          if (clientVersion) storedEntry.client = clientVersion;
+          versionByNumber.set(verNum, storedEntry);
           const mergedVersions = [...versionByNumber.values()]
             .filter((item) => Number.isInteger(Number(item && item.n)) && Number(item.n) > 0)
             .sort((a, b) => Number(a.n) - Number(b.n));
@@ -4729,7 +4772,10 @@ export default {
       } catch (e) {
         console.error('[upload] comment merge/reconcile failed (non-fatal):', e.message);
       }
-      return json({ ok: true, url: `/d/${slug}/v/${verNum}`, size: verify.size, aids: aids.length, mergedComments: mergedLocal });
+      // `sha` is the hash of the exact stored bytes (post-bake, post-stamp). The
+      // client records it so a later edit can ask "has remote moved since I
+      // published?" with one HEAD request instead of re-downloading the doc.
+      return json({ ok: true, url: `/d/${slug}/v/${verNum}`, size: verify.size, aids: aids.length, sha: uploadSha, mergedComments: mergedLocal });
     }
 
     // ---- admin access mutation ----

--- a/worker/worker.js
+++ b/worker/worker.js
@@ -1486,6 +1486,17 @@ function forceWidgetSandbox(html) {
 function readerCssSource() {
   return (typeof READER_CSS === 'string' && READER_CSS.indexOf('__TDOC_') !== 0) ? READER_CSS : '';
 }
+// Whether the document CARRIES the baked reading template — as an actual
+// <style> tag, not as prose. A substring check false-positives on any document
+// whose text discusses the mechanism (tdoc's own design docs quote
+// id="tdoc-reader" in code samples), and a false positive here means an
+// unbaked document is skipped. Every bake/skip decision uses this one test so
+// the write side and the read side cannot disagree.
+const READER_BLOCK_RE = /<style[^>]*\bid="tdoc-reader"/i;
+function hasReaderBlock(html) {
+  return READER_BLOCK_RE.test(html);
+}
+
 // The document-content invariants, in ONE place. Every path that stores a
 // version of a document — /api/upload, the browser Save inside the Durable
 // Object, and duplicate — goes through this. It exists because there used to
@@ -1506,7 +1517,7 @@ function readerCssSource() {
 async function prepareDocVersion(rawHtml) {
   let html = String(rawHtml);
   const css = readerCssSource();
-  if (css && !html.includes('id="tdoc-reader"')) {
+  if (css && !hasReaderBlock(html)) {
     const stamp = (await sha256Hex(css)).slice(0, 8);
     const tag = `<style id="tdoc-reader" data-tdoc-template="${stamp}">${css}</style>\n`;
     // Callback so a `$` in the template stays literal.
@@ -1522,7 +1533,7 @@ function injectReaderCss(html, css) {
   // Documents have been self-contained since creation-time baking landed, so
   // most already carry the block. Stamping a second copy is 8KB of duplicate
   // CSS and a duplicate id in every downloaded file.
-  if (html.includes('id="tdoc-reader"')) return html;
+  if (hasReaderBlock(html)) return html;
   const tag = `<style id="tdoc-reader">${css}</style>\n`;
   if (/<\/head>/i.test(html)) return html.replace(/<\/head>/i, () => `${tag}</head>`);
   return tag + html;
@@ -3707,7 +3718,7 @@ export default {
         // max-width" proxy starved the documents that followed the contract,
         // and :where() zero-specificity makes the injection harmless to a
         // document that styles itself.
-        if (!body.includes('id="tdoc-reader"')) {
+        if (!hasReaderBlock(body)) {
           const rcss = (typeof READER_CSS === 'string' && READER_CSS.indexOf('__TDOC_') !== 0) ? READER_CSS : '';
           if (rcss) {
             const rtag = `<style id="tdoc-reader">${rcss}</style>`;
@@ -4739,6 +4750,26 @@ export default {
           // repairs the cursor from META; never report this committed version
           // as failed and invite an unsafe retry.
           console.error('[upload] version cursor finalize failed (recoverable):', e.message || String(e));
+        }
+      } else {
+        // History backfill (re-uploading v1..vN-1) stores freshly-prepared
+        // bytes but skips the latest-meta merge above — without this, the
+        // entry keeps a sha for bytes that no longer exist, and /raw serves a
+        // stale ETag after a reader-template generation change. Refresh just
+        // this entry; touch nothing else in meta.
+        try {
+          const currentMeta = await loadDocMeta(env, slug);
+          const entry = (Array.isArray(currentMeta && currentMeta.versions) ? currentMeta.versions : [])
+            .find((v) => Number(v.n) === verNum);
+          if (entry && (entry.sha !== uploadSha || (clientVersion && entry.client !== clientVersion))) {
+            entry.sha = uploadSha;
+            if (clientVersion) entry.client = clientVersion;
+            await env.META.put(`meta:${slug}`, JSON.stringify(currentMeta));
+          }
+        } catch (e) {
+          // The bytes are stored and correct; a stale recorded sha costs at
+          // worst one spurious /raw re-download. Never fail the upload for it.
+          console.error('[upload] backfill sha refresh failed (recoverable):', e.message || String(e));
         }
       }
       // Reconcile existing open comments against the new artifact set:


### PR DESCRIPTION
> Follow-up to #326, which fixed the read side (the render fallback no longer guesses). This is the write side: the server stops depending on the client having done the right thing.
>
> Context and the full RCA, as a tdoc: [文档的样式从哪来](https://tdoc.dev/d/tdoc-styling-map/v/7) — §10 (the three axes) and §13–15 (the self-update chronicle, the performance accounting, the client-version posture) are the sections this PR implements.

## The gap

The worker had no function named "store a version". Three paths stored documents, each assembling the invariants itself:

| writer | aid stamp | bake | sha |
|---|---|---|---|
| `/api/upload` | ✓ | ✗ | ✗ |
| browser Save (DO, #329) | ✓ | ✗ | ✗ |
| duplicate | ✓ | ✗ | ✗ |

So a version saved in the browser landed in R2 without the reading template — self-containment depended on which client produced the bytes, and the client's self-update machinery has failed silently in seven distinct ways across five generations (#116 → #248 → #268 → #332 → #334). Correctness cannot ride on that.

## The fix

`prepareDocVersion()` — every document write goes through it:

1. **Bake** the reading template, generation-stamped (`data-tdoc-template="<sha8>"`). No-op when the block is already there, and on the unbundled worker. Storage becomes self-contained regardless of client version; the render fallback (#326) keeps covering pre-existing storage and new writes never need it.
2. **Stamp aids**, as before.
3. **Hash the exact stored bytes.** Version entries record `sha`; the upload response returns it. This is what the next PR's read-side gating compares against (one HEAD instead of re-downloading).

Widgets deliberately do **not** come through it — they are sandboxed islands, and the template does not belong in them. A test pins that.

Plus tier-1 client visibility: `tdoc-publish` sends `X-Tdoc-Client`, the version entry records it. First time the wild version distribution is observable — at the one place guaranteed to see every publish.

## Performance

Bake cost moves to write time (once per version). The read path gains nothing and loses nothing: its per-request work is unchanged (R2 GET + probe injection dominate; the fallback's presence check is a microsecond substring scan that now almost never fires positive).

## Verification

- New `write-invariants.test.js`: all three writers through the real fetch handler against fake bindings — baked + stamped + `sha` recorded; pre-baked doc not double-baked; widgets not baked; `X-Tdoc-Client` recorded.
- 51/51 offline suites green.
- `duplicate-download.test.js`'s source assertion upgraded from `stampAids` to `prepareDocVersion`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QzKU7be6FRLRjpgJcfWsH5