### PR TITLE
An agent reads the source of truth, one conditional request at a time

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -532,7 +532,24 @@ comments you handled unless you reply on each one. Skipping comments
 silently is the #1 source of regression complaints.
 
 1. Read `~/tdocs/<slug>/comments.json` — filter to `status: "open"`.
-2. Read latest version's `index.html`, and re-read `$SKILL_DIR/authoring/voice.md`, `$SKILL_DIR/authoring/visuals.md` and `$SKILL_DIR/authoring/structure/components.md`.
+2. **Get the current document — remote is the source of truth, local is a
+   cache.** The local `v<n>/index.html` can be stale: a browser edit or a
+   publish from another machine creates versions your checkout never saw, and
+   an edit based on a stale copy silently discards them. One conditional
+   request settles it (`published.json` holds the base URL; skip this entirely
+   for a doc that was never published):
+
+   ```bash
+   REMOTE_SHA="$(curl -sfI "$BASE/d/<slug>/v/<n>/raw" | tr -d '\r' | sed -n 's/^etag: "\(.*\)"$/\1/Ip')"
+   LOCAL_SHA="$(node -e 'const m=require(process.argv[1]);const e=(m.versions||[]).find(v=>v.n===Number(process.argv[2]));console.log(e&&e.sha||"")' "$TDOC_DIR/<slug>/meta.json" <n>)"
+   ```
+
+   - **Match** → your local copy produced what remote holds; use it as the base.
+   - **Differ (or no local sha)** → pull the truth: `curl -sf "$BASE/d/<slug>/v/<n>/raw" -o "$TDOC_DIR/<slug>/v<n>/index.html"` and base the edit on that.
+   - **Unreachable** → use the local copy, and say so in your reply: the edit
+     is based on a possibly-stale cache.
+
+   Then re-read `$SKILL_DIR/authoring/voice.md`, `$SKILL_DIR/authoring/visuals.md` and `$SKILL_DIR/authoring/structure/components.md`.
    A regeneration writes new prose, so the contract applies here exactly as
    it does on `/tdoc new`. Prose you carry over unchanged from the previous
    version stays as it is — do not re-edit untouched sections for voice, and

--- a/bin/tdoc-publish
+++ b/bin/tdoc-publish
@@ -1201,7 +1201,11 @@ upload_version() {
   # Tier-1 client visibility: the server records which client produced each
   # version. This is the observability that does not depend on the client's
   # own (repeatedly silently-broken) self-update machinery.
-  TDOC_CLIENT_VERSION="$(cat "$SKILL_DIR/VERSION" 2>/dev/null || echo unknown)"
+  # The checkout sha, not the VERSION file: VERSION has said 0.9.0 since the
+  # beginning, so it cannot distinguish any two clients in the wild. The sha
+  # answers the question observability exists for — "which exact skill code
+  # produced this version?"
+  TDOC_CLIENT_VERSION="$(git -C "$SKILL_DIR" rev-parse --short=12 HEAD 2>/dev/null || cat "$SKILL_DIR/VERSION" 2>/dev/null || echo unknown)"
   resp="$(curl -sS --connect-timeout 10 --max-time 120 -X POST "$UPLOAD_BASE/api/upload" \
     -H "Authorization: Bearer $TOKEN" \
     -H "X-Tdoc-Client: $TDOC_CLIENT_VERSION" \
@@ -1213,6 +1217,24 @@ upload_version() {
   _sz="$(printf '%s' "$resp" | json_get size)"
   if [ "$ok" = "true" ]; then
     local merged
+    # The server returns the sha of the EXACT stored bytes (post-bake,
+    # post-aid-stamp). Recording it on the local version entry gives a later
+    # edit a one-request answer to "has remote moved since I published?" —
+    # the local FILE hashes differently (it is the pre-stamp form), so the
+    # recorded sha, not a recomputed one, is the comparison key.
+    local up_sha
+    up_sha="$(printf '%s' "$resp" | json_get sha)"
+    if [ -n "$up_sha" ] && [ "$up_sha" != "null" ]; then
+      node -e '
+        const fs = require("fs");
+        const [metaPath, n, sha] = process.argv.slice(1);
+        try {
+          const m = JSON.parse(fs.readFileSync(metaPath, "utf8"));
+          const entry = (m.versions || []).find((v) => Number(v.n) === Number(n));
+          if (entry) { entry.sha = sha; fs.writeFileSync(metaPath, JSON.stringify(m, null, 2) + "\n"); }
+        } catch {}
+      ' "$META_FILE" "$v" "$up_sha" 2>/dev/null || true
+    fi
     merged="$(printf '%s' "$resp" | json_get mergedComments)"; merged="${merged:-0}"
     if [ "$merged" != "0" ] && [ "$merged" != "null" ]; then
       echo "[tdoc] v$v uploaded (${_sz:-?} bytes, +$merged local comment(s) merged)"

--- a/skills/tdoc/SKILL.md
+++ b/skills/tdoc/SKILL.md
@@ -532,7 +532,24 @@ comments you handled unless you reply on each one. Skipping comments
 silently is the #1 source of regression complaints.
 
 1. Read `~/tdocs/<slug>/comments.json` — filter to `status: "open"`.
-2. Read latest version's `index.html`, and re-read `$SKILL_DIR/authoring/voice.md`, `$SKILL_DIR/authoring/visuals.md` and `$SKILL_DIR/authoring/structure/components.md`.
+2. **Get the current document — remote is the source of truth, local is a
+   cache.** The local `v<n>/index.html` can be stale: a browser edit or a
+   publish from another machine creates versions your checkout never saw, and
+   an edit based on a stale copy silently discards them. One conditional
+   request settles it (`published.json` holds the base URL; skip this entirely
+   for a doc that was never published):
+
+   ```bash
+   REMOTE_SHA="$(curl -sfI "$BASE/d/<slug>/v/<n>/raw" | tr -d '\r' | sed -n 's/^etag: "\(.*\)"$/\1/Ip')"
+   LOCAL_SHA="$(node -e 'const m=require(process.argv[1]);const e=(m.versions||[]).find(v=>v.n===Number(process.argv[2]));console.log(e&&e.sha||"")' "$TDOC_DIR/<slug>/meta.json" <n>)"
+   ```
+
+   - **Match** → your local copy produced what remote holds; use it as the base.
+   - **Differ (or no local sha)** → pull the truth: `curl -sf "$BASE/d/<slug>/v/<n>/raw" -o "$TDOC_DIR/<slug>/v<n>/index.html"` and base the edit on that.
+   - **Unreachable** → use the local copy, and say so in your reply: the edit
+     is based on a possibly-stale cache.
+
+   Then re-read `$SKILL_DIR/authoring/voice.md`, `$SKILL_DIR/authoring/visuals.md` and `$SKILL_DIR/authoring/structure/components.md`.
    A regeneration writes new prose, so the contract applies here exactly as
    it does on `/tdoc new`. Prose you carry over unchanged from the previous
    version stays as it is — do not re-edit untouched sections for voice, and

--- a/test/write-invariants.test.js
+++ b/test/write-invariants.test.js
@@ -259,6 +259,66 @@ const DOC = '<!doctype html><html><head><meta name="viewport" content="width=dev
     assert(meta.versions.find((v) => v.n === 2), 'backfill must not drop other version entries');
   });
 
+  await t('/raw returns stored bytes as text/plain with the sha as ETag', async () => {
+    const env = makeEnv(mod.CommentsStore);
+    const a = await issue(worker, env);
+    await worker.fetch(req('/api/upload', {
+      method: 'POST', token: a.token,
+      body: { slug: 'r1', version: 1, html: DOC, meta: { title: 'r1', slug: 'r1', versions: [{ n: 1 }] } },
+    }), env, {});
+    const r = await worker.fetch(req('/d/r1/v/1/raw'), env, {});
+    assert(r.status === 200, `raw ${r.status}`);
+    // NEVER text/html: author HTML on the shared origin outside the sandboxed
+    // /frame would be stored XSS.
+    assert((r.headers.get('content-type') || '').startsWith('text/plain'), `raw content-type: ${r.headers.get('content-type')}`);
+    assert(r.headers.get('x-content-type-options') === 'nosniff', 'raw lacks nosniff');
+    const body = await r.text();
+    const stored = await (await env.DOCS.get('docs/r1/v1/index.html')).text();
+    assert(body === stored, 'raw body is not the exact stored bytes');
+    const meta = JSON.parse(await env.META.get('meta:r1'));
+    const sha = meta.versions.find((v) => v.n === 1).sha;
+    assert(r.headers.get('etag') === `"${sha}"`, `etag ${r.headers.get('etag')} != version sha ${sha}`);
+  });
+
+  await t('/raw honors If-None-Match with 304 and no body', async () => {
+    const env = makeEnv(mod.CommentsStore);
+    const a = await issue(worker, env);
+    await worker.fetch(req('/api/upload', {
+      method: 'POST', token: a.token,
+      body: { slug: 'r2', version: 1, html: DOC, meta: { title: 'r2', slug: 'r2', versions: [{ n: 1 }] } },
+    }), env, {});
+    const first = await worker.fetch(req('/d/r2/v/1/raw'), env, {});
+    const etag = first.headers.get('etag');
+    const second = await worker.fetch(req('/d/r2/v/1/raw', { headers: { 'If-None-Match': etag } }), env, {});
+    assert(second.status === 304, `expected 304, got ${second.status}`);
+    assert((await second.text()) === '', '304 must carry no body');
+  });
+
+  await t('/raw computes an ETag for pre-existing storage with no recorded sha', async () => {
+    const env = makeEnv(mod.CommentsStore);
+    // Seed unbaked legacy bytes directly, meta without sha — the population
+    // written before prepareDocVersion existed.
+    await env.DOCS.put('docs/r3/v1/index.html', DOC);
+    await env.META.put('meta:r3', JSON.stringify({ title: 'r3', slug: 'r3', versions: [{ n: 1 }] }));
+    const r = await worker.fetch(req('/d/r3/v/1/raw'), env, {});
+    assert(r.status === 200, `raw ${r.status}`);
+    assert(/^"[0-9a-f]{16}"$/.test(r.headers.get('etag') || ''), `legacy etag: ${r.headers.get('etag')}`);
+    assert((await r.text()) === DOC, 'legacy raw must return the stored bytes untouched — /raw never bakes');
+  });
+
+  await t('/raw is access-gated like every other doc read', async () => {
+    const env = makeEnv(mod.CommentsStore);
+    const a = await issue(worker, env);
+    await worker.fetch(req('/api/upload', {
+      method: 'POST', token: a.token,
+      body: { slug: 'r4', version: 1, html: DOC, meta: { title: 'r4', slug: 'r4', versions: [{ n: 1 }], access: { visibility: 'private' } } },
+    }), env, {});
+    const anon = await worker.fetch(req('/d/r4/v/1/raw'), env, {});
+    assert(anon.status === 401 || anon.status === 403, `anonymous read of a private doc must be denied, got ${anon.status}`);
+    const owner = await worker.fetch(req('/d/r4/v/1/raw', { token: a.token }), env, {});
+    assert(owner.status === 200, `owner token read failed: ${owner.status}`);
+  });
+
   console.log(`\n${pass} passed, ${fail} failed`);
   process.exit(fail ? 1 : 0);
 })().catch((e) => { console.error(e); process.exit(1); });

--- a/worker/worker.js
+++ b/worker/worker.js
@@ -3696,6 +3696,46 @@ export default {
     // shell embeds. Gated on Sec-Fetch-Dest: iframe like widgets, so it can never
     // be loaded top-level — only inside the shell. Access-gated identically to
     // the doc view. Only our nonced probe runs inside; author JS stays inert.
+    // ---- raw stored bytes (agent read path) ----
+    // The document's stored bytes, exactly as R2 holds them. This is how an
+    // agent reads the source of truth before an edit, instead of trusting a
+    // possibly-stale local copy (AGENTS.md line one vs the old /tdoc edit
+    // step 2, which read local and faithfully imitated a 26-byte stale file).
+    //
+    // Served as text/plain with nosniff, NEVER text/html: author HTML on this
+    // shared origin outside the sandboxed /frame would be stored XSS. Access
+    // is the same gate as every other doc read. ETag is the sha of the stored
+    // bytes (recorded at write by prepareDocVersion; computed here for
+    // pre-existing storage), so a client that already holds the current copy
+    // pays one conditional request and gets 304, no body.
+    const rawMatch = p.match(/^\/d\/([^/]+)\/v\/(\d+)\/raw\/?$/);
+    if (rawMatch && (method === 'GET' || method === 'HEAD')) {
+      const [, slug, vStr] = rawMatch;
+      if (!isValidSlug(slug)) return text('invalid slug', { status: 400 });
+      const gate = await enforceDocAccess(env, req, slug, Number(vStr));
+      if (!gate.ok) return gate.response;
+      const obj = await env.DOCS.get(`docs/${slug}/v${vStr}/index.html`);
+      if (!obj) return text(`Not found: ${slug} v${vStr}`, { status: 404 });
+      const body = await obj.text();
+      const meta = gate.meta || await loadDocMeta(env, slug);
+      const entry = (Array.isArray(meta && meta.versions) ? meta.versions : []).find((v) => Number(v.n) === Number(vStr));
+      const sha = (entry && typeof entry.sha === 'string' && /^[0-9a-f]{16}$/.test(entry.sha))
+        ? entry.sha
+        : (await sha256Hex(body)).slice(0, 16);
+      const etag = `"${sha}"`;
+      const headers = {
+        'Content-Type': 'text/plain; charset=utf-8',
+        'X-Content-Type-Options': 'nosniff',
+        'Cache-Control': 'no-cache',
+        'ETag': etag,
+      };
+      const inm = req.headers.get('if-none-match');
+      if (inm && inm.split(',').map((s2) => s2.trim()).includes(etag)) {
+        return new Response(null, { status: 304, headers });
+      }
+      return new Response(method === 'HEAD' ? null : body, { status: 200, headers });
+    }
+
     const frameMatch = p.match(/^\/d\/([^/]+)\/v\/(\d+)\/frame\/?$/);
     if (frameMatch && (method === 'GET' || method === 'HEAD')) {
       const [, slug, vStr] = frameMatch;


### PR DESCRIPTION
> Stacked on #341 (needs its `sha`). Read side of the same design: [文档的样式从哪来 §11](https://tdoc.dev/d/tdoc-styling-map/v/7).

## The gap

`AGENTS.md` line one: remote storage is the source of truth. The `/tdoc edit` procedure: "read the latest version's `index.html`" — the local disposable copy. `tdoc-pull` already conceded this mismatch for comments; HTML had no equivalent. `tdoc-next` showed the cost: remote v2 carried the baked template, local v2 was 26 bytes, and the editing agent faithfully imitated the stale file.

## The handshake

```
publish   →  upload response returns sha of the stored bytes
          →  tdoc-publish records it on the local meta.json version entry
edit      →  HEAD /d/<slug>/v/<n>/raw  →  ETag
             match     → local copy produced what remote holds; use it (zero bytes)
             differ    → GET /raw, base the edit on the truth
             unreachable → use local, and say so in the reply
```

The recorded sha, not a recomputed one, is the comparison key — the local file hashes differently by design (it is the pre-stamp, pre-bake form).

## `/raw` security shape

Author HTML on the shared origin outside the sandboxed `/frame` would be stored XSS, so:
- `Content-Type: text/plain` + `nosniff`, never `text/html`
- same `enforceDocAccess` gate as every other doc read (test: anonymous read of a private doc denied, owner token passes)
- `/raw` never bakes — it reports the truth, it does not improve it (test pins legacy bytes returned untouched)

## Also

`X-Tdoc-Client` now carries the skill checkout's **git sha** — the `VERSION` file has said `0.9.0` since the beginning and cannot distinguish any two clients in the wild. This is the observability that attributes a broken published doc to the exact skill code that produced it.

## Verification

Four new tests in `write-invariants.test.js` (raw bytes/ETag/content-type; 304 with no body; computed ETag for legacy storage; access gating). 51/51 offline suites green; `cli.test.js` 76/76.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QzKU7be6FRLRjpgJcfWsH5