### PR TITLE
A click in blank space dismisses instead of commenting on a neighbour

### DIFF
--- a/server/frame-probe.js
+++ b/server/frame-probe.js
@@ -141,6 +141,20 @@
     while (end < value.length && isWord(value.charAt(end))) end++;
     return { start: start, end: end };
   }
+  // caretPositionFromPoint answers with the NEAREST caret, not the one under the
+  // pointer: a click in a margin, in the gap between blocks, or below the last
+  // line still resolves into the closest text node. Commenting on a word the
+  // pointer was never over is how a click meant to dismiss a card opened a
+  // different one, and how blank space 30px under a paragraph could select a
+  // word inside a <pre>. A click is on a word or it is not — no proximity.
+  function pointOverRange(range, x, y) {
+    var rects = range.getClientRects();
+    for (var i = 0; i < rects.length; i++) {
+      var r = rects[i];
+      if (x >= r.left && x <= r.right && y >= r.top && y <= r.bottom) return true;
+    }
+    return false;
+  }
   function reportPointSelection(event) {
     if (interactionMode !== 'comment' || event.button !== 0) return;
     if (event.target && event.target.closest && event.target.closest('a,button,input,textarea,select,summary,[contenteditable],.tdoc-comment-pill')) return;
@@ -155,6 +169,9 @@
       range.setStart(point.node, bounds.start); range.setEnd(point.node, bounds.end);
       var text = range.toString().trim();
       if (!text) return;
+      // Clicked past the text, not on it: leave the click to the clear path so
+      // it dismisses whatever is open instead of commenting on a neighbour.
+      if (!pointOverRange(range, event.clientX, event.clientY)) return;
       if (current) { current.removeAllRanges(); current.addRange(range); }
       event.preventDefault(); event.stopPropagation();
       postTextSelection(range, text);

--- a/test/browser-editing.test.js
+++ b/test/browser-editing.test.js
@@ -123,6 +123,54 @@ async function chooseMode(page, label) {
         'Comment artifact pill retained an outline around the solid icon');
     });
 
+    await test('a click in blank space dismisses instead of commenting on the nearest word', async () => {
+      // caretPositionFromPoint answers with the NEAREST caret, so a click in a
+      // margin or below the last line used to select a word the pointer was
+      // never over — dismissing a card and opening a different one.
+      const box = await page.locator('.tdoc-doc-frame').boundingBox();
+      const geometry = await frame.evaluate(() => {
+        const paragraph = document.querySelector('#editable-paragraph');
+        const rect = paragraph.getBoundingClientRect();
+        const word = document.createRange();
+        word.setStart(paragraph.firstChild, 0);
+        word.setEnd(paragraph.firstChild, 4);
+        const wordRect = word.getBoundingClientRect();
+        return {
+          left: rect.left, right: rect.right, top: rect.top, bottom: rect.bottom,
+          onWord: { x: wordRect.left + wordRect.width / 2, y: wordRect.top + wordRect.height / 2 },
+        };
+      });
+      const selectionText = () => frame.evaluate(() => {
+        const selection = window.getSelection();
+        return selection && !selection.isCollapsed ? selection.toString() : null;
+      });
+      const clickAt = async (x, y) => {
+        await frame.evaluate(() => window.getSelection().removeAllRanges());
+        await page.mouse.click(box.x + x, box.y + y);
+        await page.waitForTimeout(150);
+      };
+
+      const blankPoints = [
+        ['above the first line', geometry.left + 40, geometry.top - 6],
+        ['below the last line', geometry.left + 40, geometry.bottom + 6],
+        ['in the left margin', geometry.left - 16, geometry.top + 8],
+        ['past the end of a short line', geometry.right - 20, geometry.top + 12],
+      ];
+      for (const [where, x, y] of blankPoints) {
+        await clickAt(x, y);
+        const stray = await selectionText();
+        assert(!stray, `a click ${where} selected ${JSON.stringify(stray)}`);
+      }
+
+      await clickAt(geometry.onWord.x, geometry.onWord.y);
+      assert(await selectionText(), 'a click on the word itself stopped selecting it');
+
+      // That last click opened the composer on purpose. Leave the page as this
+      // test found it, or the suite's later modes inherit an open popup.
+      await page.locator('.tdoc-popup button.x').click();
+      await frame.evaluate(() => window.getSelection().removeAllRanges());
+    });
+
     await test('Read mode opens existing anchors but does not create a comment selection', async () => {
       await chooseMode(page, 'Read');
       await selectParagraph(frame);


### PR DESCRIPTION
Fixes #376.

`caretPositionFromPoint` answers with the **nearest** caret, not the one under the pointer. `reportPointSelection` took that at face value, so a click in a margin, in the gap between blocks, or below the last line resolved into the closest text node — and `wordBounds` expanded a word the pointer was never over.

Measured on a doc with anchored comments, before the change:

| clicked | selected |
|---|---|
| 1px above the first line | `"one"` |
| 1px below the last line | `"browser"` |
| the left margin | `"This"` |
| 30px below the paragraph, pure whitespace | `"Live"` — inside a `<pre>`, which `ATOMIC` treats as untouchable |

The two handlers were working against each other: `mousedown` clears the shell's open UI, and the `click` that followed immediately re-selected a stray word. The card you meant to close closed, and something else opened — and when the snapped word carried an anchor, that anchor's card is what opened. That is the reported symptom: clicking away to dismiss a comment opens a different one.

## The change

`pointOverRange` checks the point against the word range's own client rects and bails when it is outside, letting the click fall through to the clear path it was always meant to take. No padding, no proximity: a click is on a word or it is not.

17 lines in `server/frame-probe.js`, entirely inside the comment-mode branch.

`anchorIdAtPoint` keeps its deliberate ±2px hit slop on anchor rects — that is a touch-target affordance, and far too small to explain any of the rows above.

## Tests

New case in the gated browser suite covering four blank-space points plus the control (a click on the word itself must still select it).

- `npm test` — **57/57 offline suites green**
- `browser-editing.test.js` — **9 passed / 3 failed**

Those 3 failures are **pre-existing on `origin/main`**: running pristine `origin/main` in the same worktree gives 8 passed / 3 failed. This branch takes it to 9/3 — the new case is the one that went green. (They are `Edit mode keeps changes in a recoverable draft`, `stale Save shows a conflict`, and `mobile editor chrome fits without horizontal overflow`; the first failing cascades into the other two.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)