### PR TITLE
The sign-in stderr now knows its reader is an agent

### DIFF
--- a/bin/tdoc-publish
+++ b/bin/tdoc-publish
@@ -437,9 +437,10 @@ hosted_github_signin() {
   # they already got that tab once, and if they are mid-approval a second tab
   # would land on top of the page they are typing into.
   echo "[tdoc] Resuming the GitHub sign-in from the previous run — the code is still valid." >&2
-  echo "[tdoc] If you already clicked Authorize, there is nothing more to do." >&2
-  echo "[tdoc] Otherwise open: $uri" >&2
-  echo "[tdoc] and enter this code:" >&2
+  echo "[tdoc] If the human already clicked Authorize, there is nothing more to do." >&2
+  echo "[tdoc] Otherwise, agent: give the human this URL — do not open it yourself:" >&2
+  echo "[tdoc]   $uri" >&2
+  echo "[tdoc] where they enter this code:" >&2
   echo "" >&2
   echo "        $user_code" >&2
   echo "" >&2
@@ -490,7 +491,16 @@ hosted_github_signin() {
     echo "[tdoc] A GitHub page just opened in your browser." >&2
     echo "[tdoc] Enter this code there (it is only shown here):" >&2
   else
-    echo "[tdoc] Open this page in your browser to finish signing in:" >&2
+    # This branch's reader is usually an AGENT, not the human: auto-open only
+    # fails where there is no desktop (cloud sandbox, SSH, CI), and there the
+    # human never sees this terminal. "Open this page in your browser" read as
+    # an instruction to the agent — watched live in ChatGPT: it opened the
+    # URL in its own cloud browser, whose session is not the human's, and hit
+    # a login wall. Address the agent first, and say whose browser counts.
+    echo "[tdoc] Agent: relay the URL and code below to the human, then wait here." >&2
+    echo "[tdoc] Do NOT open the URL in your own browser — your browser is not signed" >&2
+    echo "[tdoc] in as them, and the approval only counts from THEIR browser." >&2
+    echo "[tdoc] Ask the human to open:" >&2
     echo "[tdoc]   $uri" >&2
     echo "[tdoc] and enter this code:" >&2
   fi
@@ -498,7 +508,7 @@ hosted_github_signin() {
   echo "        $user_code" >&2
   echo "" >&2
   [ "${opened:-0}" = "1" ] && echo "[tdoc] (If nothing opened: $uri )" >&2
-  echo "[tdoc] After you click Authorize, I'll continue here." >&2
+  echo "[tdoc] Once it's approved, I'll continue here on my own." >&2
   fi
   # From here the code exists and nothing else will print it. Hand it to the
   # side channel before the first sleep, so a modal polling for it sees the

--- a/test/resume-signin.test.js
+++ b/test/resume-signin.test.js
@@ -145,6 +145,11 @@ function runSigninOnly(home, port) {
     try {
       assert(code === 0, `expected exit 0, got ${code}:\n${stderr}`);
       assert(stderr.includes('Resuming the GitHub sign-in'), `no resume message:\n${stderr}`);
+      // The reader of this stderr is usually an agent. It must be told, in
+      // words, not to complete the approval in its own browser — a ChatGPT
+      // session was watched doing exactly that off the old wording.
+      assert(stderr.includes('do not open it yourself'),
+        `resume message lost its agent instruction:\n${stderr}`);
       assert(stderr.includes('RSME-4321'), `resumed code not shown again:\n${stderr}`);
       assert(hits.start === 0, `device/start was called ${hits.start}x on resume`);
       assert(hits.lastPolledCode === 'resumable-device-code',
@@ -168,6 +173,13 @@ function runSigninOnly(home, port) {
       assert(!stderr.includes('Resuming'), `resumed an expired code:\n${stderr}`);
       assert(hits.start === 1, `device/start called ${hits.start}x, expected 1`);
       assert(hits.lastPolledCode === 'fresh-device-code', 'did not poll the fresh code');
+      // Fresh-code path, no auto-open (TDOC_NO_BROWSER=1): the exact branch a
+      // cloud agent reads. The agent line and whose-browser-counts line must
+      // both be there.
+      assert(stderr.includes('Agent: relay the URL and code'),
+        `fresh sign-in lost its agent-first instruction:\n${stderr}`);
+      assert(stderr.includes('THEIR browser'),
+        `fresh sign-in no longer says whose browser counts:\n${stderr}`);
     } finally {
       fs.rmSync(home, { recursive: true, force: true });
     }


### PR DESCRIPTION
## The bug, watched live

In the branch where auto-open fails — cloud sandbox, SSH, CI, i.e. wherever there is no desktop — the sign-in stderr said:

```
[tdoc] Open this page in your browser to finish signing in:
```

That sentence is addressed to a human, but its actual reader there is almost always an **agent** (the human never sees the terminal in ChatGPT/Codex). A ChatGPT session was watched taking it literally: it opened `github.com/login/device` in its **own cloud browser**, whose session is not the human's, and hit a login wall — a dead-end detour on every first publish. The correct instruction ("print the code and the URL and wait for them") existed only in FIRST-DOC.md, which a returning session has no reason to have loaded. stderr is the one text guaranteed to be in front of the agent at the moment it decides.

## The fix

Say it on stderr, agent first:

```
[tdoc] Agent: relay the URL and code below to the human, then wait here.
[tdoc] Do NOT open the URL in your own browser — your browser is not signed
[tdoc] in as them, and the approval only counts from THEIR browser.
[tdoc] Ask the human to open:
[tdoc]   https://github.com/login/device
[tdoc] and enter this code:

        WXYZ-1234
```

Same treatment for the resume branch (`agent: give the human this URL — do not open it yourself`), and the trailing "After you click Authorize" — ambiguous the same way — becomes "Once it's approved, I'll continue here on my own", which reads right for either audience. The auto-opened desktop branch is untouched.

## Why this is worth doing before the provider refactor

The wording belongs to the relay-a-code mechanism, not to GitHub: when `/activate` replaces the GitHub device page, **only the URL in these lines changes**. Everything written here is inherited by the pairing flow as-is.

## Verification

- Both branches' agent lines pinned in `test/resume-signin.test.js` (fresh path and resume path)
- Full offline suite: 57/57 green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013Eow4sjmakK5n7JkFVhqDh