### PR TITLE
An invite adds a name and changes nothing else

### DIFF
--- a/test/mentions.test.js
+++ b/test/mentions.test.js
@@ -60,6 +60,14 @@ vm.runInContext([
   fn(src, 'positionalRecipient'),
   fn(src, 'inboxRecipients'),
   fn(src, 'inboxGroupKey'),
+  constLine(src, 'ACCESS_VISIBILITIES'),
+  constLine(src, 'ACCESS_COMMENTING'),
+  constLine(src, 'ACCESS_HISTORY'),
+  constLine(src, 'ACCESS_PATCH_FIELDS'),
+  fn(src, 'normalizeAccess'),
+  fn(src, 'accessFromMeta'),
+  fn(src, 'validateAccessWrite'),
+  fn(src, 'applyAccessPatch'),
 ].join('\n\n'), box);
 
 // The shell's pure half is an ES module; strip the export keyword and run the
@@ -254,6 +262,41 @@ t('the local server parses mentions the same way as the worker', () => {
     assert(norm(fn(src, name)) === norm(fn(serverSrc, name)),
       `${name} has DRIFTED between worker.js and server.js`);
   }
+});
+
+// ── an invite may not re-baseline the doc's policy ─────────────────
+
+// A doc published without an access object reads as public with public
+// history. applyAccessPatch deliberately switches such a doc to the product
+// defaults, which is right when the owner is editing the Share panel and wrong
+// when the write is a side effect of posting a comment: shared links silently
+// lost their version history, and the doc silently left public.
+t('@-inviting on a doc with no stored access leaves the rest of the policy alone', () => {
+  const meta = { slug: 'legacy-doc', title: 'Legacy' };
+  const access = box.accessFromMeta(meta);
+  assert(access.visibility === 'public', `precondition: ${access.visibility}`);
+  assert(access.history_visibility === 'public', `precondition: ${access.history_visibility}`);
+
+  const patched = box.applyAccessPatch(meta, {
+    visibility: access.visibility,
+    commenting: access.commenting,
+    history_visibility: access.history_visibility,
+    allowed_users: access.allowed_users.concat(['bochen']),
+  });
+  assert(!patched.error, `patch rejected: ${patched.error}`);
+  assert(patched.access.visibility === 'public',
+    `an invite made the doc ${patched.access.visibility}`);
+  assert(patched.access.history_visibility === 'public',
+    `an invite hid version history from readers (${patched.access.history_visibility})`);
+  assert(patched.access.allowed_users.join() === 'bochen', 'the invitee was not added');
+});
+
+t('the bare allowed_users patch is the shape that broke it', () => {
+  // Guards the diagnosis, not the product: if applyAccessPatch ever stops
+  // re-baselining, this flips and the workaround above can be simplified.
+  const bare = box.applyAccessPatch({ slug: 'legacy-doc' }, { allowed_users: ['bochen'] });
+  assert(bare.access.history_visibility === 'owner',
+    'applyAccessPatch no longer re-baselines; revisit the invite call site');
 });
 
 // ── who has actually used tdoc ───────────────────────────────────────────

--- a/worker/worker.js
+++ b/worker/worker.js
@@ -5022,7 +5022,17 @@ export default {
       // An invite is a meta write, so it happens before the comment lands: a
       // notification whose link 403s is worse than no notification.
       if (outcome.invited.length) {
+        // Send back every field, not just the one being widened.
+        // applyAccessPatch re-baselines a doc that has no stored access to the
+        // product defaults (unlisted + owner-only history) — correct when the
+        // owner is deliberately editing the Share panel, wrong here, where the
+        // policy write is a side effect of posting a comment. Passing the
+        // effective policy through makes the re-baseline a no-op, so an invite
+        // adds a name and changes nothing else.
         const patched = applyAccessPatch(meta, {
+          visibility: access.visibility,
+          commenting: access.commenting,
+          history_visibility: access.history_visibility,
           allowed_users: access.allowed_users.concat(outcome.invited),
         });
         if (patched.error) return json(patched, { status: 400 });


### PR DESCRIPTION
Fixes #385. Regression from #348, merged yesterday.

A doc published without an `access` object — every CLI-published doc — reads as public with public version history. `applyAccessPatch` deliberately re-baselines such a doc to the product defaults on its first policy write. That is right when the owner is editing the Share panel, and it used to be the only caller.

#348's @mention-as-invite calls the same function to widen `allowed_users`, as a side effect of posting a comment:

```
before:  {"visibility":"public",   "history_visibility":"public"}
after:   {"visibility":"unlisted", "history_visibility":"owner"}
```

An owner who @mentioned someone not already on the doc silently took the doc out of public and hid every earlier version from anyone holding the share link.

## The change

The invite passes the doc's effective policy through, so the re-baseline is a no-op — an invite adds a name and changes nothing else. Share panel behavior is untouched.

One call site in `worker/worker.js`. No new defaults, no new options, no behavior added.

## Tests

- the invite leaves visibility and history alone on a doc with no stored access
- the bare `allowed_users` patch still re-baselines — guards the diagnosis, so this call site can be simplified if `applyAccessPatch` ever changes

`npm test` — **58/58 offline suites green**, mentions 33/33.

## Not included

Docs already rewritten by the bug keep their stamped policy; this only stops new ones. Repairing those is a data question, not a code one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)