### PR TITLE
A doc created in the browser is born like one published from the CLI

### DIFF
--- a/test/create-from-scratch.test.js
+++ b/test/create-from-scratch.test.js
@@ -251,5 +251,30 @@ t('a doc created from scratch opens in edit mode, not read mode', () => {
     'edit-on-arrival must still respect canEdit, or a reader gets an editor that cannot save');
 });
 
+t('a doc created from scratch shares the CLI default: no stored access policy', () => {
+  // A CLI publish stores no `access`, so accessFromMeta falls back to the
+  // legacy defaults — public, with version history visible to anyone holding
+  // the link. Creating in the browser used to stamp the product defaults into
+  // meta instead (unlisted + owner-only history), so two docs with the same
+  // content behaved differently depending on where they were born, and a
+  // shared link silently showed one version instead of all of them.
+  const scratch = worker.slice(
+    worker.indexOf("prompt: 'Created from scratch in the browser'") - 400,
+    worker.indexOf("prompt: 'Created from scratch in the browser'") + 400,
+  );
+  assert(!/access:\s*normalizeAccess/.test(scratch),
+    'creating from scratch stamps an access policy again; a CLI publish stores none');
+
+  // The duplicate path is deliberately NOT the same: on tdoc.dev a reader may
+  // duplicate someone else's doc, and a copy carrying a public policy would
+  // republish it. hosted-oob-behavior asserts a copy defaults unlisted.
+  const duplicate = worker.slice(
+    worker.indexOf('duplicated_by: session.login') - 200,
+    worker.indexOf('duplicated_by: session.login') + 600,
+  );
+  assert(/access:\s*normalizeAccess\({}, { legacy: false }\)/.test(duplicate),
+    'a duplicate must keep its own conservative default, not inherit or drop it');
+});
+
 console.log(`\n${pass} passed, ${fail} failed`);
 process.exit(fail ? 1 : 0);

--- a/worker/worker.js
+++ b/worker/worker.js
@@ -4502,7 +4502,6 @@ export default {
         // something an author wrote.
         versions: [{ n: 1, created: now, prompt: 'Created from scratch in the browser', blank: true }],
         created_by: session.login,
-        access: normalizeAccess({}, { legacy: false }),
       };
       incoming = stampHostedOwnership(incoming, actor);
 
@@ -4609,6 +4608,11 @@ export default {
         versions: [{ n: 1, created: now, prompt: `Duplicated from ${slug} v${version}` }],
         source: { slug, version },
         duplicated_by: session.login,
+        // Deliberately NOT inherited from the source: on tdoc.dev a reader may
+        // duplicate someone else's doc, and a copy that carried a public policy
+        // would republish it. hosted-oob-behavior asserts this defaults
+        // unlisted. Creating a doc from scratch is the case that should match
+        // a CLI publish; duplicating is not.
         access: normalizeAccess({}, { legacy: false }),
       };
       incoming = stampHostedOwnership(incoming, actor);


### PR DESCRIPTION
Fixes #388.

A CLI publish stores no `access` object, so `accessFromMeta` falls back to the legacy defaults: public, with version history visible to anyone holding the link. Creating from scratch in the browser stamped the product defaults into meta instead — `unlisted`, `history_visibility: 'owner'`.

Same content, different behavior depending on where the doc was born, and nothing in the UI said so. Share a browser-made doc and the recipient sees one version where a CLI-published copy would show all of them.

## Verified end to end

Both bundles run under `wrangler dev` (miniflare KV/R2/DO), driving the real `POST /api/doc/create` route, then reading the page as an anonymous visitor:

```
before   meta.access = {"visibility":"unlisted","history_visibility":"owner",...}
         reader is given 1 of 3 versions
after    meta.access = null
         reader is given 3 of 3
```

## The change

One line: drop the stamp from the create-from-scratch path.

## Deliberately not changed

The **duplicate** path keeps `normalizeAccess({}, { legacy: false })`. On tdoc.dev a signed-in reader may duplicate someone else's doc, and a copy carrying a public policy would republish it — `hosted-oob-behavior.test.js` asserts a copy defaults unlisted. I tried inheriting the source's policy first; that test caught it, which is the right outcome.

The new test pins both halves of the asymmetry so neither drifts.

## Not included

Docs already created in the browser carry the policy in their meta, so this changes nothing for them — they need Share → Advanced, or a separate data repair.

`npm test` — **59/59 offline suites green**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)