### PR TITLE
An account gains its email key; sign-in stops being GitHub-shaped inside

### DIFF
--- a/test/account-email-groundwork.test.js
+++ b/test/account-email-groundwork.test.js
@@ -1,0 +1,191 @@
+// Phase-1 account groundwork: the email merge key, behaviorally.
+//
+// The refactor's identity rule is: account_id stays the only canonical
+// identity; a verified email is the key that routes different sign-in
+// methods to the same account. These tests pin the four properties that
+// rule depends on, against worker.js with fake bindings and a stubbed
+// GitHub (the only outbound calls the auth routes make):
+//
+//   1. sign-in never mints an account (a commenter is not a publisher, and
+//      hasUsedTdoc reads hosted-account presence as "registered");
+//   2. sign-in on an EXISTING account attaches the verified email — index
+//      written, record enriched, session carrying account_id + email;
+//   3. the index is first-writer-wins — a second account with the same
+//      verified email must not steal the key;
+//   4. the account record rewrite preserves fields it does not know about
+//      (the old fixed-shape rewrite erased anything extra on every login).
+//
+// Run with: node test/account-email-groundwork.test.js
+
+const { loadWorker, makeEnv, req, putSession } = require('./helpers/worker-harness');
+
+let pass = 0, fail = 0;
+function ok(n) { console.log(`  ✓ ${n}`); pass++; }
+function bad(n, e) { console.log(`  ✗ ${n}\n    ${e && e.message ? e.message : e}`); fail++; }
+async function t(n, fn) { try { await fn(); ok(n); } catch (e) { bad(n, e); } }
+function assert(c, m) { if (!c) throw new Error(m || 'assertion failed'); }
+
+// GitHub stand-in: the device poll exchanges a code, reads /user, and — new
+// in phase 1 — reads /user/emails. Everything else falls through to the
+// real fetch (none of these tests need it).
+const realFetch = globalThis.fetch;
+function stubGitHub({ login, emails }) {
+  globalThis.fetch = async (input, init) => {
+    const url = String(input && input.url ? input.url : input);
+    if (url.includes('github.com/login/oauth/access_token')) {
+      return Response.json({ access_token: 'gho_stub', token_type: 'bearer' });
+    }
+    if (url.includes('api.github.com/user/emails')) {
+      return Response.json(emails);
+    }
+    if (url.includes('api.github.com/user')) {
+      return Response.json({ login, avatar_url: '', name: login });
+    }
+    return realFetch(input, init);
+  };
+}
+
+async function devicePoll(worker, env) {
+  const r = await worker.fetch(req('/api/auth/device/poll', {
+    method: 'POST', body: { device_code: 'stub-device-code' },
+  }), env, {});
+  return { r, data: await r.json() };
+}
+
+function kvJson(env, key) {
+  const raw = env.META.map.get(key);
+  return raw ? JSON.parse(raw) : null;
+}
+
+function sessionFromCookie(env, r) {
+  const cookie = r.headers.get('set-cookie') || '';
+  const m = cookie.match(/tdoc_sid=([a-f0-9]+)/);
+  assert(m, `no tdoc_sid in Set-Cookie: ${cookie}`);
+  return kvJson(env, `session:${m[1]}`);
+}
+
+(async () => {
+  const mod = await loadWorker();
+  const worker = mod.default;
+  console.log('account email groundwork');
+
+  await t('sign-in never mints an account', async () => {
+    const env = makeEnv(mod.CommentsStore);
+    stubGitHub({ login: 'spectator', emails: [{ email: 'spec@example.com', primary: true, verified: true }] });
+    const { r, data } = await devicePoll(worker, env);
+    assert(data.ok === true, `poll failed: ${JSON.stringify(data)}`);
+    assert(!env.META.map.has('hosted-account:spectator'),
+      'a mere sign-in minted a hosted account — hasUsedTdoc now lies');
+    assert(!env.META.map.has('account-email:spec@example.com'),
+      'an email index exists for an account that does not');
+    const session = sessionFromCookie(env, r);
+    assert(session.email === 'spec@example.com', 'session should still carry the verified email');
+    assert(!('account_id' in session), 'session claims an account_id no account backs');
+  });
+
+  await t('sign-in on an existing account attaches the email key end to end', async () => {
+    const env = makeEnv(mod.CommentsStore);
+    env.META.map.set('hosted-account:alice', JSON.stringify({
+      account_id: 'acct_alice0000', github_login: 'alice', created: '2026-01-01T00:00:00Z',
+    }));
+    stubGitHub({
+      login: 'Alice',
+      emails: [
+        { email: 'old@example.com', primary: false, verified: true },
+        { email: 'Alice@Example.COM', primary: true, verified: true },
+      ],
+    });
+    const { r, data } = await devicePoll(worker, env);
+    assert(data.ok === true, `poll failed: ${JSON.stringify(data)}`);
+    const idx = kvJson(env, 'account-email:alice@example.com');
+    assert(idx && idx.account_id === 'acct_alice0000',
+      `index missing/wrong (primary verified email, lowercased): ${JSON.stringify(idx)}`);
+    const rec = kvJson(env, 'hosted-account:alice');
+    assert(rec.email === 'alice@example.com', `record not enriched: ${JSON.stringify(rec)}`);
+    const session = sessionFromCookie(env, r);
+    assert(session.account_id === 'acct_alice0000', 'session lacks account_id');
+    assert(session.email === 'alice@example.com', 'session lacks email');
+  });
+
+  await t('an unverified email attaches nothing', async () => {
+    const env = makeEnv(mod.CommentsStore);
+    env.META.map.set('hosted-account:mallory', JSON.stringify({
+      account_id: 'acct_mallory00', github_login: 'mallory', created: '2026-01-01T00:00:00Z',
+    }));
+    stubGitHub({ login: 'mallory', emails: [{ email: 'victim@example.com', primary: true, verified: false }] });
+    const { data } = await devicePoll(worker, env);
+    assert(data.ok === true, `poll failed: ${JSON.stringify(data)}`);
+    assert(!env.META.map.has('account-email:victim@example.com'),
+      'an UNVERIFIED address wrote the merge key — this is the account-takeover hole');
+    assert(!('email' in kvJson(env, 'hosted-account:mallory')), 'record gained an unverified email');
+  });
+
+  await t('the email index is first-writer-wins', async () => {
+    const env = makeEnv(mod.CommentsStore);
+    env.META.map.set('account-email:shared@example.com', JSON.stringify({
+      account_id: 'acct_first0000', created: '2026-01-01T00:00:00Z',
+    }));
+    env.META.map.set('hosted-account:second', JSON.stringify({
+      account_id: 'acct_second000', github_login: 'second', created: '2026-01-01T00:00:00Z',
+    }));
+    stubGitHub({ login: 'second', emails: [{ email: 'shared@example.com', primary: true, verified: true }] });
+    const { data } = await devicePoll(worker, env);
+    assert(data.ok === true, `poll failed: ${JSON.stringify(data)}`);
+    const idx = kvJson(env, 'account-email:shared@example.com');
+    assert(idx.account_id === 'acct_first0000',
+      `second account stole the key: ${JSON.stringify(idx)}`);
+    assert(!('email' in kvJson(env, 'hosted-account:second')),
+      'the losing account still claims the email on its record');
+  });
+
+  await t('token mint hands a brand-new publisher their email key', async () => {
+    // First sign-in of a future publisher: no account yet (test 1 proved none
+    // is minted), but the session carries the attested email. The mint at
+    // /api/hosted/token is where the account is born — with its key.
+    const env = makeEnv(mod.CommentsStore);
+    const cookie = await putSession(env, 'newpub');
+    const sid = cookie.split('=')[1];
+    const sess = kvJson(env, `session:${sid}`);
+    env.META.map.set(`session:${sid}`, JSON.stringify({ ...sess, email: 'newpub@example.com' }));
+    const r = await worker.fetch(req('/api/hosted/token', {
+      method: 'POST', cookie, body: { label: 'first' },
+    }), env, {});
+    const data = await r.json();
+    assert(r.status === 200 && data.ok, `mint failed: ${JSON.stringify(data)}`);
+    const rec = kvJson(env, 'hosted-account:newpub');
+    assert(rec && rec.email === 'newpub@example.com', `minted account lacks email: ${JSON.stringify(rec)}`);
+    const idx = kvJson(env, 'account-email:newpub@example.com');
+    assert(idx && idx.account_id === rec.account_id, 'index not written at mint');
+  });
+
+  await t('a client cannot smuggle an email through the mint body', async () => {
+    const env = makeEnv(mod.CommentsStore);
+    const cookie = await putSession(env, 'honest'); // session has NO email
+    const r = await worker.fetch(req('/api/hosted/token', {
+      method: 'POST', cookie, body: { label: 'x', email: 'attacker@example.com', verified_email: 'attacker@example.com' },
+    }), env, {});
+    assert(r.status === 200, `mint failed: ${r.status}`);
+    assert(!env.META.map.has('account-email:attacker@example.com'),
+      'a body-supplied email reached the merge key — it must only come from the provider');
+    assert(!('email' in kvJson(env, 'hosted-account:honest')), 'body email landed on the record');
+  });
+
+  await t('the record rewrite preserves fields it does not know about', async () => {
+    const env = makeEnv(mod.CommentsStore);
+    env.META.map.set('hosted-account:keeper', JSON.stringify({
+      account_id: 'acct_keeper000', github_login: 'keeper', created: '2026-01-01T00:00:00Z',
+      email: 'keeper@example.com', identities: [{ provider: 'google', sub: 'g-123' }],
+    }));
+    stubGitHub({ login: 'keeper', emails: [] }); // no scope yet → no email this time
+    const { data } = await devicePoll(worker, env);
+    assert(data.ok === true, `poll failed: ${JSON.stringify(data)}`);
+    const rec = kvJson(env, 'hosted-account:keeper');
+    assert(rec.email === 'keeper@example.com', `email erased by rewrite: ${JSON.stringify(rec)}`);
+    assert(Array.isArray(rec.identities) && rec.identities[0].sub === 'g-123',
+      `future fields erased by rewrite: ${JSON.stringify(rec)}`);
+  });
+
+  globalThis.fetch = realFetch;
+  console.log(`\n${pass} passed, ${fail} failed`);
+  process.exit(fail ? 1 : 0);
+})();

--- a/test/create-from-scratch.test.js
+++ b/test/create-from-scratch.test.js
@@ -134,7 +134,7 @@ t('the worker create route claims a slug, charges quota, and writes v1', () => {
   for (const needle of [
     "json({ error: 'sign_in_required' }, { status: 401 })",
     'hostedAccountCopiesEnabled(env, req)',
-    'hostedAccountForGithub(env, session.login)',
+    'hostedAccountForGithub(env, session.login, session && session.email)',
     'countHostedDocs(env, actor.account_id, limit)',
     "kind: 'claim_owner'",
     'blankDocHtml()',

--- a/test/hosted-oob.test.js
+++ b/test/hosted-oob.test.js
@@ -48,7 +48,11 @@ t('Worker exposes provider-gated hosted token bootstrap', () => {
 });
 
 t('CLI mint and Duplicate share one hosted-account registry', () => {
-  const acctStart = worker.indexOf('async function hostedAccountForGithub');
+  // The legacy hosted-github: read moved into lookupHostedAccount, the
+  // read-only resolver hostedAccountForGithub now delegates to — slice from
+  // there so the invariant (one registry, legacy records still readable)
+  // is checked where it now lives.
+  const acctStart = worker.indexOf('async function lookupHostedAccount');
   const acct = worker.slice(acctStart, worker.indexOf('async function sourceHasWidgets'));
   const issue = worker.slice(
     worker.indexOf('async function issueHostedToken'),
@@ -57,7 +61,7 @@ t('CLI mint and Duplicate share one hosted-account registry', () => {
   assert(acct.includes('hosted-account:'), 'canonical account key is hosted-account:<login>');
   assert(acct.includes('hosted-github:'), 'must still read leftover hosted-github records');
   assert(!acct.includes("source: 'duplicate'"), 'must not mint a second registry just for Duplicate');
-  assert(issue.includes('hostedAccountForGithub(env, github_login)'),
+  assert(issue.includes('hostedAccountForGithub(env, github_login, verifiedEmail)'),
     'token mint must reuse hostedAccountForGithub');
   assert(!issue.includes('hosted-github:'), 'token mint must not write a second registry');
 });

--- a/test/run.js
+++ b/test/run.js
@@ -31,6 +31,7 @@ const OFFLINE = [
   'runtime-provenance.test.js', // release provenance + content-hash redeploy
   'hosted-oob.test.js',       // hosted token bootstrap + scoped writes
   'hosted-oob-behavior.test.js', // hosted token ownership behavior with fake bindings
+  'account-email-groundwork.test.js', // phase-1 identity: email merge key, no mint-on-signin, field-preserving rewrite
   'duplicate-download.test.js', // #146 Duplicate vs Download chrome + route contract
   'deploy-tdoc-dev.test.js',  // tdoc.dev hosted CD: main-only, not BYOK
   'oldver-strip.test.js',     // old-version banner predicate

--- a/vercel/api/tdoc.js
+++ b/vercel/api/tdoc.js
@@ -66,6 +66,11 @@ async function buildEnv() {
       // Same public GitHub Device Flow app as Cloudflare (shared/github-oauth.js).
       // Device flow has no redirect URI, so it works from any host.
       GITHUB_CLIENT_ID: process.env.GITHUB_CLIENT_ID || githubOauth.GITHUB_CLIENT_ID,
+      // Absent → webAuth stays false and the device flow carries sign-in,
+      // exactly as before. This line existing is what makes the web redirect
+      // flow POSSIBLE on Vercel — it was silently impossible: the worker
+      // gates on env.GITHUB_CLIENT_SECRET and the map never passed it.
+      GITHUB_CLIENT_SECRET: process.env.GITHUB_CLIENT_SECRET || '',
       TDOC_DEBUG: process.env.TDOC_DEBUG || '',
     },
   };

--- a/worker/worker.js
+++ b/worker/worker.js
@@ -2589,6 +2589,40 @@ async function ghPost(path, formObj) {
   if (!Object.keys(out).length) return { error: 'gh_empty', error_description: `status=${r.status} ct=${ct}` };
   return out;
 }
+// The merge key's gatekeeper. Loose on purpose — the provider already proved
+// deliverability; this only guards KV key hygiene (no spaces/control chars,
+// exactly one @, bounded length) and canonicalizes case.
+function normalizeEmail(email) {
+  const v = String(email || '').trim().toLowerCase();
+  if (v.length > 254) return null;
+  if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(v)) return null;
+  return v;
+}
+
+// The signed-in user's verified email, or null. Requires the user:email
+// scope; a token minted before the scope widened gets [] or 403 here, and
+// null is the correct answer — the account simply gains its email key on a
+// later sign-in (migration is lazy by design).
+async function ghVerifiedEmail(token) {
+  try {
+    const r = await fetch('https://api.github.com/user/emails', {
+      headers: {
+        'Accept': 'application/vnd.github+json',
+        'Authorization': `Bearer ${token}`,
+        'User-Agent': 'tdoc-worker',
+      },
+    });
+    if (!r.ok) return null;
+    const list = await r.json();
+    if (!Array.isArray(list)) return null;
+    const hit = list.find((e) => e && e.primary && e.verified && typeof e.email === 'string')
+      || list.find((e) => e && e.verified && typeof e.email === 'string');
+    return hit ? normalizeEmail(hit.email) : null;
+  } catch {
+    return null;
+  }
+}
+
 async function ghUser(token) {
   const r = await fetch('https://api.github.com/user', {
     headers: {
@@ -2834,34 +2868,63 @@ function syncDocumentTitle(html, title) {
     .replace(/<title\b[^>]*>[\s\S]*?<\/title>/i, () => `<title>${safe}</title>`);
 }
 
-async function hostedAccountForGithub(env, login) {
+// Read-only twin of hostedAccountForGithub: resolves an existing account and
+// never mints one. Sign-in goes through THIS — a commenter is not a
+// publisher, and hasUsedTdoc treats hosted-account presence as "has
+// registered", so minting on sign-in would both fill KV with spectator
+// accounts and make every second commenter read as an established user.
+async function lookupHostedAccount(env, login) {
+  const norm = normalizeGithubLogin(login);
+  if (!norm || !env || !env.META) return null;
+  for (const key of [`hosted-account:${norm}`, `hosted-github:${norm}`]) {
+    try {
+      const rec = JSON.parse(await env.META.get(key));
+      if (rec && typeof rec.account_id === 'string' && rec.account_id) return rec;
+    } catch {}
+  }
+  return null;
+}
+
+async function hostedAccountForGithub(env, login, verifiedEmail = null) {
   const norm = normalizeGithubLogin(login);
   if (!norm || !env || !env.META) return null;
   const primary = `hosted-account:${norm}`;
-  const legacy = `hosted-github:${norm}`;
-  let rec = null;
-  try {
-    const raw = await env.META.get(primary);
-    if (raw) rec = JSON.parse(raw);
-  } catch {}
-  if (!(rec && typeof rec.account_id === 'string' && rec.account_id)) {
-    try {
-      const raw = await env.META.get(legacy);
-      if (raw) rec = JSON.parse(raw);
-    } catch {}
-  }
-  if (!(rec && typeof rec.account_id === 'string' && rec.account_id)) {
+  let rec = await lookupHostedAccount(env, login);
+  if (!rec) {
     rec = {
       account_id: `acct_${rand(12)}`,
       github_login: norm,
       created: new Date().toISOString(),
     };
   } else {
+    // Spread first: the record is about to grow fields this function does not
+    // know about (email today, linked identities later), and the old
+    // fixed-three-field rewrite silently dropped anything extra on every
+    // sign-in — data written once and erased on next login.
     rec = {
+      ...rec,
       account_id: rec.account_id,
       github_login: norm,
       created: rec.created || new Date().toISOString(),
     };
+  }
+  // The email merge key. First writer wins: if the index already names a
+  // DIFFERENT account, this account does not get the key — silently stealing
+  // it would hand one user's future sign-ins to another's docs. Verified-only
+  // is enforced upstream (callers pass what the provider attested, nothing
+  // user-typed).
+  const email = normalizeEmail(verifiedEmail);
+  if (email && rec.email !== email) {
+    const key = `account-email:${email}`;
+    let existing = null;
+    try { existing = JSON.parse(await env.META.get(key)); } catch {}
+    if (!existing || !existing.account_id || existing.account_id === rec.account_id) {
+      await env.META.put(key, JSON.stringify({
+        account_id: rec.account_id,
+        created: (existing && existing.created) || new Date().toISOString(),
+      }));
+      rec.email = email;
+    }
   }
   await env.META.put(primary, JSON.stringify(rec));
   return rec;
@@ -2876,12 +2939,12 @@ async function sourceHasWidgets(env, slug, version) {
   }
 }
 
-async function issueHostedToken(env, body = {}) {
+async function issueHostedToken(env, body = {}, verifiedEmail = null) {
   const github_login = normalizeGithubLogin(body.login);
   if (!github_login) {
     return { error: 'sign_in_required', status: 401 };
   }
-  const account = await hostedAccountForGithub(env, github_login);
+  const account = await hostedAccountForGithub(env, github_login, verifiedEmail);
   if (!account) return { error: 'sign_in_required', status: 401 };
   const token = `tdoc_${rand(24)}`;
   const tokenHash = await sha256Hex(token);
@@ -4122,12 +4185,21 @@ export default {
         }
         const user = await ghUser(r.access_token);
         if (!user.login) return authStatusResponse('GitHub returned no account.', { error: true, status: 500 });
+        // The only moment the GitHub token exists is now, so the verified
+        // email is read now; it is the merge key that routes every sign-in
+        // method to one account. Resolve-don't-mint: sign-in must not create
+        // hosted accounts (see lookupHostedAccount).
+        const email = await ghVerifiedEmail(r.access_token);
+        const existing = await lookupHostedAccount(env, user.login);
+        const account = existing ? await hostedAccountForGithub(env, user.login, email) : null;
         const sid = rand(24);
         const session = {
           login: user.login,
           avatar_url: user.avatar_url,
           name: user.name || user.login,
           created: new Date().toISOString(),
+          ...(account ? { account_id: account.account_id } : {}),
+          ...(email ? { email } : {}),
         };
         await env.META.put(`session:${sid}`, JSON.stringify(session), { expirationTtl: 60 * 60 * 24 * 30 });
         return redirectTo(ret, [
@@ -4449,7 +4521,7 @@ export default {
         }
         // Not a precondition — this mints the account on first use. A null here
         // means the account store itself is unreachable.
-        const acct = await hostedAccountForGithub(env, session.login);
+        const acct = await hostedAccountForGithub(env, session.login, session && session.email);
         if (!acct) return json({ error: 'hosted_account_unavailable' }, { status: 503 });
         actor = { kind: 'hosted', account_id: acct.account_id, github_login: acct.github_login };
       }
@@ -4553,7 +4625,7 @@ export default {
 
       let actor = { kind: 'owner_session' };
       if (!ownerCopy) {
-        const acct = await hostedAccountForGithub(env, session.login);
+        const acct = await hostedAccountForGithub(env, session.login, session && session.email);
         if (!acct) return json({ error: 'account_copy_unavailable' }, { status: 403 });
         actor = { kind: 'hosted', account_id: acct.account_id, github_login: acct.github_login };
       }
@@ -4656,7 +4728,7 @@ export default {
       const gh = new URL('https://github.com/login/oauth/authorize');
       gh.searchParams.set('client_id', env.GITHUB_CLIENT_ID);
       gh.searchParams.set('redirect_uri', `${url.origin}/auth/github/callback`);
-      gh.searchParams.set('scope', 'read:user');
+      gh.searchParams.set('scope', 'read:user user:email');
       gh.searchParams.set('state', nonce);
       return redirectTo(gh.toString(), [
         `tdoc_oauth=${nonce}; Path=/; HttpOnly; Secure; SameSite=Lax; Max-Age=600`,
@@ -4667,7 +4739,7 @@ export default {
       try {
         const r = await ghPost('/login/device/code', {
           client_id: env.GITHUB_CLIENT_ID,
-          scope: 'read:user',
+          scope: 'read:user user:email',
         });
         if (r.error) return json({ error: r.error, message: r.error_description }, { status: 400 });
         return json({
@@ -4711,16 +4783,22 @@ export default {
         const user = await ghUser(r.access_token);
         debug(env, '[poll] gh /user response keys:', Object.keys(user).join(','), 'login:', user.login || 'none');
         if (!user.login) return json({ error: 'no_user', message: user.message || 'GitHub /user returned no login' }, { status: 500 });
+        const email = await ghVerifiedEmail(r.access_token);
+        const existing = await lookupHostedAccount(env, user.login);
+        const account = existing ? await hostedAccountForGithub(env, user.login, email) : null;
         const sid = rand(24);
         // Store only the identity we actually use. The GitHub access token is
         // intentionally NOT persisted: nothing downstream reads session.token,
-        // and keeping a read:user token at rest for 30 days is needless
-        // exposure (data minimization).
+        // and keeping a token at rest for 30 days is needless exposure. The
+        // verified email IS stored: it is the merge key (and what email-based
+        // invites will match), attested by the provider, not user-typed.
         const session = {
           login: user.login,
           avatar_url: user.avatar_url,
           name: user.name || user.login,
           created: new Date().toISOString(),
+          ...(account ? { account_id: account.account_id } : {}),
+          ...(email ? { email } : {}),
         };
         // 30 day TTL
         await env.META.put(`session:${sid}`, JSON.stringify(session), { expirationTtl: 60 * 60 * 24 * 30 });
@@ -4929,7 +5007,11 @@ export default {
       }, { status: 401 });
       let body = {};
       try { body = await req.json(); } catch {}
-      const issued = await issueHostedToken(env, { ...body, login });
+      // session.email is the provider-attested address captured at sign-in —
+      // passed as its own argument so nothing in the client-controlled body
+      // can pose as it. This is what gives a brand-new publisher their email
+      // merge key at the moment their account is minted.
+      const issued = await issueHostedToken(env, { ...body, login }, session && session.email);
       if (issued.error) return json({ error: issued.error }, { status: issued.status || 401 });
       return json({
         ok: true,


### PR DESCRIPTION
Phase 1 of the provider-independent auth refactor — all groundwork, **nothing user-visible**. Design doc (D1/D2 decided, D3 confirmed in review): https://tdoc.dev/d/tdoc-auth-refactor/v/3

## The identity rule this implements

`account_id` stays the **only canonical identity**; a **verified email** is the merge key that routes different sign-in methods to the same account.

## What changed

- **Scope**: both OAuth flows request `user:email` alongside `read:user`; sign-in (the one moment the GitHub token exists) reads the verified primary address via `/user/emails`. Old tokens without the scope get `null` — the account gains its key on a later sign-in; migration stays lazy.
- **KV**: account records grow an `email` field; new index `account-email:<email>` → `account_id`. **Verified only** (an unverified address from any provider is an account-takeover hole) and **first-writer-wins** (a second account with the same verified email must not steal the key).
- **Sign-in never mints**: new read-only `lookupHostedAccount` resolves; `hostedAccountForGithub` still mints, but only publish-side callers reach it. A commenter is not a publisher, and `hasUsedTdoc` reads `hosted-account:` presence as "registered" — minting on sign-in would make every second commenter look established.
- **New publishers still get their key at birth**: the session carries the attested email, and `/api/hosted/token` threads it into the mint **as its own trusted argument** — a body-supplied `email` is ignored (test-pinned).
- **The rewrite no longer erases**: `hostedAccountForGithub` used to rebuild a fixed three-field record on every sign-in, silently dropping anything extra — which would have deleted the email key the moment it was written. It now spreads the existing record first.
- **Sessions carry `account_id` + `email`** — what phase 2 (`/activate` confirm page) and D2 (email invites matching `session.email`) will read.
- **Vercel hole fixed**: the env map never passed `GITHUB_CLIENT_SECRET`, so webAuth was silently impossible there. One passthrough line; absent → device-flow-only, exactly as before.

## Verification

`test/account-email-groundwork.test.js` — behavioral, against worker.js with fake bindings + stubbed GitHub:

- sign-in never mints an account ✓
- existing account: index written, record enriched, session carries both ✓
- unverified email attaches nothing ✓
- first-writer-wins on the index ✓
- token mint hands a brand-new publisher their key ✓
- client cannot smuggle an email through the mint body ✓
- record rewrite preserves unknown fields ✓

Full offline suite: **61/61 green**. Two static-pattern assertions in `hosted-oob.test.js` / `create-from-scratch.test.js` updated to the new call shapes; their invariants are unchanged.

## What this deliberately does not do

No `/activate`, no pairing endpoints, no Google, no reading of the email index anywhere — phase 2. Nothing in this PR changes what any user sees.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013Eow4sjmakK5n7JkFVhqDh