### PR TITLE
The worker keeps its logs

### DIFF
--- a/test/no-drift.test.js
+++ b/test/no-drift.test.js
@@ -74,6 +74,11 @@ t('GITHUB_CLIENT_ID has a single SoT (shared/github-oauth.js)', () => {
   assert(read('shared/github-oauth.js').includes(id), 'SoT module missing its own id');
   assert(!read('vercel/api/tdoc.js').includes('Ov23liZ1UAGOchvKPmlS'),
     'vercel still hardcodes the retired personal OAuth client id');
+  assert(template.includes('[observability]') && /enabled\s*=\s*true/.test(template),
+    'wrangler.toml.template must keep Workers Logs on — without it a live 500 can only be chased by reproducing it');
+  const preview = read('worker/wrangler.preview.toml.template');
+  assert(preview.includes('[observability]') && /enabled\s*=\s*true/.test(preview),
+    'the preview worker needs logs too — PR previews are where a break is cheapest to catch');
   assert(!template.includes('Ov23liZ1UAGOchvKPmlS'),
     'wrangler.toml.template still hardcodes the retired personal OAuth client id');
   assert(read('bin/tdoc-publish').includes('shared/github-oauth.js'),

--- a/worker/wrangler.preview.toml.template
+++ b/worker/wrangler.preview.toml.template
@@ -14,6 +14,16 @@ compatibility_date = "2025-01-01"
 workers_dev = true
 preview_urls = true
 
+# Workers Logs: persisted, searchable invocation logs in the Cloudflare
+# dashboard (Workers > tdoc > Logs), with sampled traces. Without this the
+# only view into a live worker is `wrangler tail`, which shows nothing that
+# happened before you attached — so a 500 reported after the fact could only
+# be chased by reproducing it. head_sampling_rate = 1 keeps every invocation;
+# lower it if request volume ever makes the included quota the binding cost.
+[observability]
+enabled = true
+head_sampling_rate = 1
+
 [[r2_buckets]]
 binding = "DOCS"
 bucket_name = "tdoc-preview-docs"

--- a/worker/wrangler.toml.template
+++ b/worker/wrangler.toml.template
@@ -3,6 +3,16 @@ main = "_worker.bundled.js"
 compatibility_date = "2025-01-01"
 workers_dev = true
 
+# Workers Logs: persisted, searchable invocation logs in the Cloudflare
+# dashboard (Workers > tdoc > Logs), with sampled traces. Without this the
+# only view into a live worker is `wrangler tail`, which shows nothing that
+# happened before you attached — so a 500 reported after the fact could only
+# be chased by reproducing it. head_sampling_rate = 1 keeps every invocation;
+# lower it if request volume ever makes the included quota the binding cost.
+[observability]
+enabled = true
+head_sampling_rate = 1
+
 [[r2_buckets]]
 binding = "DOCS"
 bucket_name = "tdoc-docs"


### PR DESCRIPTION
Two lines of config that retire the project's worst debugging loop.

## Why

`wrangler tail` only shows what happens **while you are attached**. A 500 reported after the fact can only be chased by reproducing it — which is exactly how the loop for this project became "hit `/api/runtime` for the deployed sha, then tail and hope it happens again."

Workers Logs gives the dashboard (Workers → tdoc → Logs) persisted, searchable invocation logs with sampled traces. Nothing to install, no vendor, no code change.

```toml
[observability]
enabled = true
head_sampling_rate = 1
```

`head_sampling_rate = 1` keeps every invocation; the inline comment says where to turn it down if request volume ever makes the included quota the binding cost.

## Both templates, on purpose

| Template | Who materializes it |
|---|---|
| `wrangler.toml.template` | tdoc.dev CD (`deploy-tdoc-dev.yml`, `publish-landing.yml`) **and** every BYOK self-hoster via `bin/tdoc-publish` |
| `wrangler.preview.toml.template` | the PR preview worker — where a break is cheapest to catch |

So self-hosters get the same visibility into their own workers without doing anything.

## Verification

- Both templates parsed as TOML with placeholders substituted, asserting `observability.enabled === true` in position
- Pinned in `test/no-drift.test.js` so a future template edit cannot quietly turn logging back off
- Full offline suite: **67/67 green**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013Eow4sjmakK5n7JkFVhqDh