### PR TITLE
A cell class that narrows type has to be sitting on something short

### DIFF
--- a/authoring/structure/components.md
+++ b/authoring/structure/components.md
@@ -85,6 +85,27 @@ fill and the radius are separate properties and nothing in that rule mentions
 them. This is the one part of a table that a document cannot leave unsaid, so
 `bin/tdoc-validate-template` fails a document whose cells never name both.
 
+**Tabular is a numeral feature, not a smaller face.** A column of figures lines
+up because the figures are tabular, and that costs nothing:
+
+```css
+.num { font-variant-numeric: tabular-nums; }
+```
+
+Buying the same alignment with a smaller size or a monospaced family costs two
+things instead. The column ends up set differently from the ones beside it, so
+the type changes size mid-row for no reason the reader can see; and a
+monospaced family carries no CJK, so Chinese in that column falls back and
+renders as the same typeface at two sizes, one column apart.
+
+The class also has to sit on what it describes. `.num` on a `<td>` holding a
+sentence is a claim about that cell that is not true — and if it carries
+`white-space: nowrap`, the sentence can never break and the table takes a width
+no viewport can give it, pushing the whole page sideways. Put the class on the
+numerals (`<span class="num">$1.4B</span>`), not on the cell that contains them.
+`bin/tdoc-validate-template` fails a cell class that narrows type or forbids
+wrapping while sitting on prose, on the custom-template path too.
+
 **Scroll wrappers** — `tdoc-table-scroll` for a table, `diagram-box` for a
 figure. Both are `overflow-x: auto`.
 

--- a/bin/tdoc-validate-template
+++ b/bin/tdoc-validate-template
@@ -11,6 +11,7 @@ from __future__ import annotations
 import argparse
 import re
 import sys
+from html import unescape
 from html.parser import HTMLParser
 from pathlib import Path
 
@@ -345,6 +346,219 @@ def check_table_cells(html, styles):
             " or ".join(faults)]
 
 
+# A cell that refuses to wrap is a promise about its own length. Past this
+# many characters it is prose, and the promise is a table that cannot fit.
+CELL_PROSE_LIMIT = 32
+
+
+# A rule styling generated content is not styling the cell.
+PSEUDO_ELEMENT = re.compile(r"::|:(?:before|after|first-line|first-letter)\b", re.I)
+
+
+def _cell_target(selector):
+    """What a rule finally styles: (classes worn by that element, its tag).
+
+    Only the last compound counts. `.tablewrap td.lbl` styles a cell wearing
+    `.lbl`; `.tablewrap td` styles cells generally and `.tablewrap` is an
+    ancestor, not something a cell wears. A class inside `:not()` is the
+    opposite of worn, so pseudo-class arguments are dropped before the classes
+    are read, and a `::before` rule is dropped entirely.
+    """
+    selector = re.sub(r"\s+", " ", selector.strip().lower())
+    if PSEUDO_ELEMENT.search(selector):
+        return None
+    # Collapse arguments so a space inside :not(...) cannot split a compound.
+    last = _last_compound(re.sub(r"\([^()]*\)", "()", selector))
+    if ":" in last:
+        # A structural pseudo-class picks a subset of the cells - :first-child
+        # is the first column, not the table. Which cells that is cannot be
+        # read off the markup by class, and a check that stops a publish must
+        # not guess, so the rule is left unjudged.
+        return None
+    tag = re.match(r"^([a-z][-\w]*)", last)
+    return re.findall(r"\.([A-Za-z_][-\w]*)", last), (tag.group(1) if tag else "")
+
+
+def _attr_classes(attrs):
+    found = re.search(r"""class\s*=\s*("([^"]*)"|'([^']*)')""", attrs, re.I)
+    if not found:
+        return []
+    return (found.group(2) or found.group(3) or "").split()
+
+
+def _last_compound(selector):
+    parts = re.split(r"[\s>+~]+", re.sub(r"\s+", " ", selector.strip().lower()))
+    return parts[-1] if parts else ""
+
+
+def _unconditional_css(css):
+    """The rules that always apply — every at-rule block removed, braces balanced.
+
+    A size inside `@media` is a different layout, not a second size in the same
+    one: a table that becomes a stack of cards on a phone is entitled to set
+    its label apart. Only what the document says unconditionally is judged.
+    """
+    out, i, length = [], 0, len(css)
+    while i < length:
+        at = css.find("@", i)
+        if at < 0:
+            out.append(css[i:])
+            break
+        brace = css.find("{", at)
+        semi = css.find(";", at)
+        if brace < 0 or (0 <= semi < brace):
+            # A statement at-rule (@import, @charset) ends at the semicolon.
+            out.append(css[i:at])
+            i = (semi + 1) if semi >= 0 else length
+            continue
+        out.append(css[i:at])
+        depth, j = 0, brace
+        while j < length:
+            if css[j] == "{":
+                depth += 1
+            elif css[j] == "}":
+                depth -= 1
+                if depth == 0:
+                    break
+            j += 1
+        i = j + 1
+    return "".join(out)
+
+
+def _cell_type_sizes(styles):
+    """What size the document gives a body cell, and by which class.
+
+    `base` is the size the document states for its BODY cells — the last
+    declaration whose selector ends in a bare table or td. A bare `th` is
+    excluded on purpose: `thead th` carries the label register by design, and
+    reading it as the body size would compare every cell against the header. `by_class` is every
+    size a class puts on top of it. A document that states no base is not
+    judged: the reader owns the table's size and the document has not claimed
+    otherwise.
+    """
+    base = None
+    by_class = {}
+    refuses_to_wrap = set()
+    for raw_css in styles:
+        css = _unconditional_css(re.sub(r"/\*.*?\*/", "", raw_css, flags=re.S))
+        for match in re.finditer(r"([^{}]+)\{([^{}]*)\}", css, flags=re.S):
+            selector_group, body = match.groups()
+            declarations = split_declarations(body)
+            size = next(
+                (compact_css_value(value) for prop, value in declarations
+                 if prop == "font-size"),
+                None,
+            )
+            nowrap = any(
+                prop == "white-space" and "nowrap" in value
+                for prop, value in declarations
+            )
+            if size is None and not nowrap:
+                continue
+            for selector in selector_group.split(","):
+                target = _cell_target(selector)
+                if target is None:
+                    continue
+                names, tag = target
+                if names:
+                    if size is not None:
+                        for name in names:
+                            by_class[name] = size
+                    if nowrap:
+                        refuses_to_wrap.update(names)
+                elif tag in {"table", "td"}:
+                    if size is not None:
+                        base = size
+                    if nowrap:
+                        # An unqualified nowrap on every cell is the same
+                        # promise, made about the whole table.
+                        refuses_to_wrap.add("")
+    return base, by_class, refuses_to_wrap
+
+
+def _longest_cell_per_class(html):
+    """class -> (length, text) of the longest th/td wearing it.
+
+    "" holds the longest cell in the document whatever it wears, which is what
+    an unqualified th/td rule is making its promise about.
+    """
+    longest = {}
+    for match in re.finditer(r"<(t[hd])\b([^>]*)>(.*?)</\1\s*>", html, re.I | re.S):
+        text = unescape(re.sub(r"<[^>]+>", "", match.group(3)))
+        text = re.sub(r"\s+", " ", text).strip()
+        for name in _attr_classes(match.group(2)) + [""]:
+            if len(text) > longest.get(name, (-1, ""))[0]:
+                longest[name] = (len(text), text)
+    return longest
+
+
+def check_table_cell_type(html, styles):
+    """A table's body is one type size, and only a short value refuses to wrap.
+
+    Both failures come from one habit: a class written for numerals — smaller,
+    monospaced, `white-space: nowrap` — applied to the whole `<td>` rather than
+    to the numerals inside it. When the cells it lands on hold sentences, two
+    things break at once.
+
+    The column it styles is set in a different size from its neighbours, so a
+    reader scanning across sees the type change size mid-row; and if the face
+    is monospaced it carries no CJK, so the same script renders at two sizes
+    one column apart. That is not a house-style preference — nothing in the
+    document says a table should have two type sizes, and the author reading
+    the source cannot see that it does.
+
+    `nowrap` on prose is worse than untidy: the cell can never break, so the
+    table takes a width no viewport can give it and pushes the whole page
+    sideways. `READER_PATCH_CSS` rescues that from the reader's side below
+    700px by making the table scroll itself; the cause is here.
+
+    A numeric column set in mono is a real convention and stays legal — put it
+    on the numerals (`<span>`), or change only what tabular figures need
+    (`font-variant-numeric`), which costs no size and no glyph coverage.
+
+    Judged on both paths. A table too wide to read is broken whoever wrote it,
+    and the document that showed this brings its own design system.
+    """
+    if not re.search(r"<table[\s>]", html, re.I):
+        return []
+    base, by_class, refuses_to_wrap = _cell_type_sizes(styles)
+    longest = _longest_cell_per_class(html)
+    errors = []
+
+    def offender(name):
+        """The longest cell wearing this class, if it is prose."""
+        length, text = longest.get(name, (0, ""))
+        return (length, text) if length > CELL_PROSE_LIMIT else None
+
+    for name in sorted(by_class):
+        size = by_class[name]
+        if base is None or size == base:
+            continue
+        prose = offender(name)
+        if not prose:
+            continue
+        errors.append(
+            "'.%s' sets %s where the table's cells are %s, and it sits on a "
+            "%d-character cell (\"%s…\") — a size on a cell class is a claim "
+            "that the cell is short; on prose it gives one column a different "
+            "size from its neighbours"
+            % (name, size, base, prose[0], prose[1][:40])
+        )
+
+    for name in sorted(refuses_to_wrap):
+        prose = offender(name)
+        if not prose:
+            continue
+        errors.append(
+            "%s sets white-space: nowrap but sits on a %d-character cell "
+            "(\"%s…\") — nowrap says a cell is short; on prose it gives the "
+            "table a width no viewport can hold"
+            % ("a th/td rule" if name == "" else "'.%s'" % name,
+               prose[0], prose[1][:40])
+        )
+    return errors
+
+
 def check_figure_width(html, styles):
     """A figure that never states its width is sized by the page, not the doc.
 
@@ -451,6 +665,10 @@ def validate(path: Path, *, style: str, custom_template: bool) -> tuple[list[str
     raw_html = path.read_text(encoding="utf-8", errors="replace")
     clipping, inset = _svg_faults(raw_html)
     errors.extend(clipping)
+    # Measured on both paths, for the same reason clipping is: a table
+    # wider than any viewport is broken whoever designed it, and the house
+    # style has no opinion about how many sizes a table's body has.
+    errors.extend(check_table_cell_type(raw_html, parser.styles))
 
     if custom_template:
         return errors, notes

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -1864,5 +1864,74 @@ t('tdoc-pull still works against a config that has no token', () => {
 });
 
 
+// #420 — a class written for numerals, applied to the whole cell. The column it
+// styles ends up a different size from its neighbours, and `nowrap` on a
+// sentence gives the table a width no viewport can hold. Judged on BOTH paths:
+// the document that showed this brought its own design system.
+t('validator rejects a numeral cell class that lands on prose', () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'tdoc-cells-'));
+  const run = (name, css, rows, args = []) => {
+    const html = path.join(dir, name);
+    fs.writeFileSync(html, `<!doctype html><html><head>
+      <meta name="viewport" content="width=device-width, initial-scale=1">
+      <style>body { background: #fff; } th, td { background: none; border-radius: 0 }
+      ${css}</style>
+      </head><body><div class="wrap"><h1>T</h1><table><thead><tr><th>a</th><th>b</th></tr></thead>
+      <tbody>${rows}</tbody></table></div></body></html>`);
+    return spawnSync(path.join(BIN, 'tdoc-validate-template'), [html, ...args], { encoding: 'utf8' });
+  };
+  const PROSE = 'Bootstrap, profitable throughout, then caught the accounts the other one lost';
+  try {
+    const bad = run('bad.html',
+      'table { font-size: 13.2px } .num { font-family: Menlo, monospace; font-size: 12.6px; white-space: nowrap }',
+      `<tr><td class="k">Surge</td><td class="num">${PROSE}</td></tr>`,
+      ['--custom-template']);
+    assert(bad.status !== 0, 'a numeral class on a sentence should be rejected');
+    assert(/different size from its neighbours/.test(bad.stderr), bad.stderr);
+    assert(/no viewport can hold/.test(bad.stderr), bad.stderr);
+
+    // The same class is correct on the values it was written for.
+    const numbers = run('numbers.html',
+      'table { font-size: 13.2px } .num { font-family: Menlo, monospace; font-size: 12.6px; white-space: nowrap }',
+      '<tr><td class="k">Surge</td><td class="num">$1.4B ARR</td></tr>',
+      ['--custom-template']);
+    assert(numbers.status === 0, `a numeral class on numerals rejected: ${numbers.stderr}`);
+
+    // A cell class that agrees with the table's size changes nothing, whatever
+    // else it sets, and a deliberately large figure is not the narrowing this
+    // check is about.
+    const agrees = run('agrees.html',
+      'table { font-size: 14px } .lbl { font-size: 14px; font-weight: 600 } .big { font-size: 26px }',
+      `<tr><td class="lbl">${PROSE}</td><td class="big">42</td></tr>`,
+      ['--custom-template']);
+    assert(agrees.status === 0, `a matching size was rejected: ${agrees.stderr}`);
+
+    // Reaching only some cells is not a claim about the table: which cells
+    // :first-child picks cannot be read off the markup by class.
+    const subset = run('subset.html',
+      'table { font-size: 14px } td:first-child { white-space: nowrap; font-weight: 600 }',
+      `<tr><td>short</td><td>${PROSE}</td></tr>`,
+      ['--custom-template']);
+    assert(subset.status === 0, `a :first-child rule was judged: ${subset.stderr}`);
+
+    // A size inside @media is a different layout, not a second size in one.
+    const responsive = run('responsive.html',
+      'table { font-size: 14px } .lbl { font-size: 14px } '
+      + '@media (max-width: 700px) { td { font-size: 12.5px } }',
+      `<tr><td class="lbl">${PROSE}</td><td>x</td></tr>`,
+      ['--custom-template']);
+    assert(responsive.status === 0, `a media-scoped size was judged: ${responsive.stderr}`);
+
+    // House-style documents are judged by the same rule, not a different one.
+    const house = run('house.html',
+      'table { font-size: 13.2px } .num { font-size: 12.6px }',
+      `<tr><td class="num">${PROSE}</td><td>x</td></tr>`);
+    assert(house.status !== 0, 'the house-style path should apply the same rule');
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+
 console.log(`\n${pass} passed, ${fail} failed`);
 process.exit(fail ? 1 : 0);


### PR DESCRIPTION
Closes #420.

Reported from reading a live doc: "为什么后面的 column 变大了，不应该统一吗". It is the other way round — the earlier columns got *smaller*, because a class written for numerals was applied to the whole `<td>` and the cells it landed on hold sentences.

`https://tdoc.dev/d/rl-data-landscape/v/2`:

```css
table { font-size: 13.2px }
.num  { font-family: Menlo, monospace; font-size: 12.6px; white-space: nowrap }
```

Two failures from one habit. The `.num` column is set 0.6px smaller than the ones beside it, and Menlo carries no CJK — so the Chinese in it falls back to PingFang and renders as the same typeface at two sizes, one column apart. And its longest cell is **68 characters** of prose that is forbidden to ever wrap, which is what gives that table a width no viewport can hold.

`READER_PATCH_CSS` (#418) already rescues the second symptom from the reader's side, below 700px, by making the table scroll itself. This is the cause.

## Where it is caught

`bin/tdoc-validate-template`, as an **error** — `bin/tdoc-new:239` dies when it exits non-zero, so no version is ever written. Placed **above** the `custom_template` early return, beside the SVG clipping check and for the same stated reason: a table wider than any viewport is broken whoever designed it. The document that showed this brings its own design system; a check below that return would not have caught it.

## One predicate, both symptoms

A size or a `nowrap` on a cell class is a **claim that the cell is short**. The check tests the claim rather than the property, which is what keeps every legitimate shape legal:

| Stays legal | Why |
|---|---|
| `.num { font-family: Menlo }` on `$1.4B ARR` | short — the class describes what it sits on |
| `.big { font-size: 26px }` on `42` | a deliberate figure is not narrowing |
| `.lbl { font-size: 14px }` where the table is `14px` | agrees with the table; no second size |
| `@media (max-width:700px) { td { font-size: 12.5px } }` | a different layout, not a second size in one |
| `td:first-child { white-space: nowrap }` | picks a subset that cannot be matched by class — left unjudged |
| `td:not(.lbl)::before { font-size: 10px }` | styles generated content, not the cell |

The header keeps its own register: `thead th` is a label, so a bare `th` never sets the body's base size.

## Verification

- **203 real published documents** (every version under `~/tdocs`, plus the landing and start/templates docs): **0 flagged**. Four earlier drafts of this check each false-positived on some of them — matching on the property, reading a header rule as the body size, reading a class out of `:not()`, and judging media-scoped rules — and each is now a passing case in the test.
- The reported doc raises both errors, naming the class, both sizes, and the offending cell.
- Offline suite **73/73 green**.

`authoring/structure/components.md` gains the rule the file was missing: it said "numbers are tabular so a column lines up" without saying that tabular is `font-variant-numeric`, which costs no size and no glyph coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)