### PR TITLE
A table wider than its container is not a phone problem

### DIFF
--- a/server/reader.css
+++ b/server/reader.css
@@ -131,8 +131,11 @@
   .tdoc-table-scroll > table { max-width: none; }
 
   /* An unwrapped table cannot shrink below its content, so max-width alone
-     leaves it pushing the page sideways on a phone. On narrow viewports it
-     becomes a block that scrolls itself. Mirrored as READER_PATCH_CSS at serve
+     leaves it pushing the page sideways. NOT scoped to a phone width: what
+     breaks is a table wider than its container, which a 768px tablet and a
+     narrowed desktop window hit too — a real doc still overflowed by 171px at
+     701px, 164 at 768 and 20 at 1024 while this was behind @media(max-width:700px).
+     A table that already fits is unchanged; one that does not scrolls itself. Mirrored as READER_PATCH_CSS at serve
      time, which is what reaches documents baked before this existed.
 
      Not :where() and not overridable, unlike the rest of this file: the thing
@@ -140,17 +143,15 @@
      `table{min-width:880px}`), so a zero-specificity version loses to exactly
      the declaration it exists to defeat. Same reasoning as the canvas/img
      `max-width:100% !important` above. Desktop is untouched. */
-  @media (max-width: 700px) {
-    body table:not(.tdoc-table-scroll > table) { display: block !important; min-width: 0 !important; max-width: 100% !important; overflow-x: auto; -webkit-overflow-scrolling: touch; }
-    /* Zeroing min-width lets the block fit the screen, but it also lets the
+  body table:not(.tdoc-table-scroll > table) { display: block !important; min-width: 0 !important; max-width: 100% !important; overflow-x: auto; -webkit-overflow-scrolling: touch; }
+    /* Zeroing min-width lets the block fit its container, but it also lets the
        table collapse below the width the author designed for — a doc built for
-       880px squeezed its prose column to 62px, two characters a line. The rows
-       lay out at max-content instead, so columns keep a readable width and the
-       block scrolls them. */
-    body table:not(.tdoc-table-scroll > table) > thead,
-    body table:not(.tdoc-table-scroll > table) > tbody,
-    body table:not(.tdoc-table-scroll > table) > tfoot { display: table !important; width: max-content !important; min-width: 100% !important; }
-  }
+       880px squeezed its prose column to 62px. The rows lay out at max-content
+       instead, so columns keep the width their content needs and the block
+       scrolls them. */
+  body table:not(.tdoc-table-scroll > table) > thead,
+  body table:not(.tdoc-table-scroll > table) > tbody,
+  body table:not(.tdoc-table-scroll > table) > tfoot { display: table !important; width: max-content !important; min-width: 100% !important; }
   /* Pre/code blocks scroll horizontally instead of breaking the layout. */
   :where(body pre) { max-width: 100%; overflow-x: auto; }
   @media print {

--- a/server/server.js
+++ b/server/server.js
@@ -641,7 +641,7 @@ function frameCspHeader(nonce) {
 // documents bake their reader CSS at creation: changing that file alone fixes
 // nothing that is already published. Kept byte-identical in server.js —
 // test/reader-patch-drift.test.js holds the two together.
-const READER_PATCH_CSS = '@media (max-width:700px){body table:not(.tdoc-table-scroll>table){display:block!important;min-width:0!important;max-width:100%!important;overflow-x:auto;-webkit-overflow-scrolling:touch}body table:not(.tdoc-table-scroll>table)>thead,body table:not(.tdoc-table-scroll>table)>tbody,body table:not(.tdoc-table-scroll>table)>tfoot{display:table!important;width:max-content!important;min-width:100%!important}}';
+const READER_PATCH_CSS = 'body table:not(.tdoc-table-scroll>table){display:block!important;min-width:0!important;max-width:100%!important;overflow-x:auto;-webkit-overflow-scrolling:touch}body table:not(.tdoc-table-scroll>table)>thead,body table:not(.tdoc-table-scroll>table)>tbody,body table:not(.tdoc-table-scroll>table)>tfoot{display:table!important;width:max-content!important;min-width:100%!important}';
 
 const READER_CSS_PATH = path.join(__dirname, 'reader.css');
 function readerCss() {

--- a/test/reader-patch-drift.test.js
+++ b/test/reader-patch-drift.test.js
@@ -34,7 +34,11 @@ t('the two literals are byte-identical', () => {
 
 t('it is the narrow-viewport table rule, and it spares wrapped tables', () => {
   const css = literal(worker) || '';
-  assert(/@media \(max-width:\s*700px\)/.test(css), 'the patch is no longer scoped to narrow viewports');
+  // Deliberately NOT scoped to a phone width: a table wider than its container
+  // breaks a 768px tablet and a narrowed desktop too. Measured on a real doc,
+  // still 171px over at 701px and 20px over at 1024 while it was behind
+  // @media(max-width:700px).
+  assert(!/@media/.test(css), 'the patch went back behind a media query; 701px and up regress');
   assert(/overflow-x:\s*auto/.test(css), 'the patch no longer makes the table scrollable');
   // The author's own `table{min-width:880px}` is what breaks the phone, so this
   // rule has to outrank it — a :where() version loses to the declaration it
@@ -71,7 +75,7 @@ t('the patch anchors on the opening <head>, not the closing one', () => {
 t('newly baked documents get the same rule from reader.css', () => {
   // The patch reaches documents baked before it existed; reader.css is what
   // downloads and self-contained copies carry.
-  assert(/@media \(max-width: 700px\)/.test(reader), 'reader.css lost the narrow-viewport table rule');
+  assert(/table:not\(\.tdoc-table-scroll > table\) \{ display: block/.test(reader), 'reader.css lost the table rule');
   assert(/not\(\.tdoc-table-scroll > table\)/.test(reader), 'reader.css no longer spares wrapped tables');
 });
 

--- a/worker/worker.js
+++ b/worker/worker.js
@@ -1564,7 +1564,7 @@ const READER_BLOCK_RE = /<style[^>]*\bid="tdoc-reader"/i;
 // documents bake their reader CSS at creation: changing that file alone fixes
 // nothing that is already published. Kept byte-identical in server.js —
 // test/reader-patch-drift.test.js holds the two together.
-const READER_PATCH_CSS = '@media (max-width:700px){body table:not(.tdoc-table-scroll>table){display:block!important;min-width:0!important;max-width:100%!important;overflow-x:auto;-webkit-overflow-scrolling:touch}body table:not(.tdoc-table-scroll>table)>thead,body table:not(.tdoc-table-scroll>table)>tbody,body table:not(.tdoc-table-scroll>table)>tfoot{display:table!important;width:max-content!important;min-width:100%!important}}';
+const READER_PATCH_CSS = 'body table:not(.tdoc-table-scroll>table){display:block!important;min-width:0!important;max-width:100%!important;overflow-x:auto;-webkit-overflow-scrolling:touch}body table:not(.tdoc-table-scroll>table)>thead,body table:not(.tdoc-table-scroll>table)>tbody,body table:not(.tdoc-table-scroll>table)>tfoot{display:table!important;width:max-content!important;min-width:100%!important}';
 function hasReaderBlock(html) {
   return READER_BLOCK_RE.test(html);
 }


### PR DESCRIPTION
Fixes #422. Follow-up to #418, found by sweeping every responsive width instead of only the one that was reported.

#418 scoped the table rule to `@media (max-width: 700px)` — "don't touch desktop". That boundary is wrong: what breaks a page is **a table wider than its container**, and a container gets narrower than a table on a tablet and in a narrowed desktop window too.

## Measured against the deployed fix

| viewport | document overflow |
|---|---|
| 320–700px | 0 ✓ |
| **701px** | **171px** ✗ |
| **768px** — tablet, phone landscape | **164px** ✗ |
| **834px** | **115px** ✗ |
| **1024px** | **20px** ✗ |

The author's `table{min-width:880px}` went unchecked above 700.

## The change

Drop the media query. The rule is self-limiting — a table that already fits is laid out exactly as before, because `max-width:100%` on the block and `min-width:100%` on the rows only bite when the content is wider. Nothing about it was ever phone-specific.

Swept again on this branch — four docs × eleven widths, 320 → 1280:

```
rl-data-landscape          320:✓ 375:✓ 390:✓ 430:✓ 600:✓ 700:✓ 701:✓ 768:✓ 834:✓ 1024:✓ 1280:✓
tdoc-sys-paper             (same)
santa-cruz-surf-roadtrip   (same)
overflow-repro             (same)
```

Column widths stay sensible and grow with the container: `[64,224,220]` at 375px, `[92,292,288]` at 1024px.

The drift test now asserts the **absence** of a media query, with the measured numbers in the comment, so the scoping cannot quietly come back.

`npm test` — **73/73 offline green**; browser-editing 17/17, responsive 32/32.

🤖 Generated with [Claude Code](https://claude.com/claude-code)