### PR TITLE
The dismissal test waits for the frame, not the popup

### DIFF
--- a/server/frame-probe.js
+++ b/server/frame-probe.js
@@ -27,6 +27,16 @@
   // While something is open, the next click anywhere in the document only
   // dismisses it — it must not open a different comment or start a new one.
   var shellUiOpen = false;
+  // Mirrored onto <html> alongside the other frame state. The shell unmounts a
+  // card at commit and only tells us one effect + one postMessage later, so
+  // "the popup is gone from the shell" and "the frame will act on the next
+  // click again" are two different moments. Anything waiting on the second one
+  // has to be able to see it.
+  function setShellUiOpen(open) {
+    shellUiOpen = open;
+    if (open) document.documentElement.setAttribute('data-tdoc-ui-open', '');
+    else document.documentElement.removeAttribute('data-tdoc-ui-open');
+  }
   var swallowClick = false;
   var dismissDownX = 0, dismissDownY = 0;
   var COMMENT_ICON_PATH = 'M2 2H12A10 10 0 1 1 2 12V2Z';
@@ -1064,7 +1074,7 @@
     }
     else if (d.type === 'tdoc:theme') applyTheme(d.theme);
     else if (d.type === 'tdoc:mode') setInteractionMode(d.mode);
-    else if (d.type === 'tdoc:uiOpen') shellUiOpen = !!d.open;
+    else if (d.type === 'tdoc:uiOpen') setShellUiOpen(!!d.open);
     else if (d.type === 'tdoc:editFormat') formatEdit(d.command, d.value);
     else if (d.type === 'tdoc:editRestore') {
       var restoreRoot = findEditRoot();

--- a/test/browser-editing.test.js
+++ b/test/browser-editing.test.js
@@ -288,6 +288,14 @@ async function chooseMode(page, label) {
         };
       });
       const openCount = () => page.locator('.tdoc-popup, .tdoc-margin-comment.active').count();
+      // The frame, not the shell, decides whether a click dismisses or acts, and
+      // it decides from its own copy of the open state — which arrives one
+      // effect and one postMessage after the shell has already mounted or
+      // unmounted the card. openCount() is the shell's half of that; a click
+      // sent between the two halves is read as a dismissal and never opens the
+      // composer, which is what made this test fail one run in four.
+      const frameKnows = (open) => frame.waitForFunction(
+        (want) => document.documentElement.hasAttribute('data-tdoc-ui-open') === want, open);
       const clickAt = async (point) => {
         await page.mouse.click(box.x + point.x, box.y + point.y);
         await page.waitForTimeout(250);
@@ -296,8 +304,10 @@ async function chooseMode(page, label) {
       // 1. A drag while something is open is a selection, not a dismissal.
       //    Clearing on mousedown unmounted the focused composer, and losing
       //    that focus wiped the selection mid-drag.
+      await frameKnows(false);
       await clickAt(geometry.first);
       assert(await openCount() > 0, 'precondition: a word click did not open the composer');
+      await frameKnows(true);
       await page.mouse.move(box.x + geometry.drag.x1, box.y + geometry.drag.y);
       await page.mouse.down();
       await page.mouse.move(box.x + geometry.drag.x2, box.y + geometry.drag.y, { steps: 12 });
@@ -305,13 +315,14 @@ async function chooseMode(page, label) {
       await page.waitForTimeout(400);
       assert(await openCount() > 0, 'a drag while something was open reported no selection');
       await page.locator('.tdoc-popup button.x').click().catch(() => {});
-      await page.waitForTimeout(200);
+      await frameKnows(false);
 
       // 2. The artifact pill is our own UI, but while a card is open it is
       //    outside that card like anything else: it dismisses, it does not
       //    open an element comment.
       await clickAt(geometry.first);
       assert(await openCount() > 0, 'precondition: composer did not reopen');
+      await frameKnows(true);
       // Dispatch the hover inside the frame: Playwright's own hover() checks
       // actionability against the top document, where the open composer sits
       // over the artifact and the check never settles.
@@ -323,9 +334,13 @@ async function chooseMode(page, label) {
         }));
       });
       await frame.locator('.tdoc-comment-pill').waitFor({ state: 'visible' });
+      // boundingBox() is already in main-frame coordinates for an element inside
+      // an iframe. Adding the doc-frame offset a second time put this click 48px
+      // below the pill, on plain prose — which also dismisses, so the assertion
+      // passed without ever touching the pill it is named after.
       const pill = await frame.locator('.tdoc-comment-pill').boundingBox();
       assert(pill, 'hovering the artifact did not show the comment pill');
-      await page.mouse.click(box.x + pill.x + pill.width / 2, box.y + pill.y + pill.height / 2);
+      await page.mouse.click(pill.x + pill.width / 2, pill.y + pill.height / 2);
       await page.waitForTimeout(400);
       assert(await openCount() === 0, 'clicking the artifact pill opened a comment instead of dismissing');
 


### PR DESCRIPTION
Fixes #429. Flagged as an unrelated flake in #428; this is its own issue and its own PR.

`dismissal spares the drag and the artifact pill` failed about one run in four. It was never the drag or the pill — every failure was the test's own first assertion:

```
  ✗ dismissal spares the drag and the artifact pill
    precondition: a word click did not open the composer
```

## The race

Closing a card lands in two steps. React unmounts `.tdoc-popup` at commit; the frame — which is what actually decides whether a click dismisses or acts — hears about it one `useEffect` and one `postMessage` later:

```js
// shell/src/document-shell.jsx
useEffect(() => {
  const open = Boolean((openCommentId || openClusterKey || composer) && !reanchorId);
  bridge.send({ type: 'tdoc:uiOpen', open });
}, [...]);
```

The preceding test ends by clicking `.tdoc-popup button.x`. This one measures geometry and clicks a word a few milliseconds after that. When the mousedown lands inside the gap, `shellUiOpen` in `server/frame-probe.js` is still `true`, so the frame reads the click as a dismissal — `swallowClick = true`, mousedown returns early, mouseup posts `tdoc:cleared` instead of reporting a word selection. No composer, failed precondition.

`openCount()` only ever watched the shell's half of a two-part state change. Same shape as the Move anchor test, where the banner renders before the frame has been told it is re-anchoring.

## The fix

`data-tdoc-selecting`, `data-tdoc-editing` and `data-tdoc-interaction-mode` are already mirrored onto `<html>` in the frame, and tests already wait on them. `shellUiOpen` was the one piece of frame state that was not, so nothing could wait for it. Mirror it as `data-tdoc-ui-open` and gate the test on the frame's own copy:

```js
const frameKnows = (open) => frame.waitForFunction(
  (want) => document.documentElement.hasAttribute('data-tdoc-ui-open') === want, open);
```

Three gates: before the opening click, after it, and after the close between step 1 and step 2 (replacing a 200ms sleep). No blanket waits added.

## A second defect in the same test

Step 2 never clicked the pill. `boundingBox()` is already in main-frame coordinates for an element inside an iframe; the test added the doc-frame offset a second time. Measured live:

```
docframe box y=48
pill via frame.locator().boundingBox()          y=252.98   <- already absolute
pill via frame.evaluate(getBoundingClientRect)  y=204.98
click landed at y=316; elementFromPoint there = a plain <p>
```

48px below the pill, on prose. A click on prose while a card is open also dismisses, so `openCount() === 0` passed and the assertion has been vacuous since #403 — the pill path it is named after was never exercised. Dropping the doubled offset puts the click on the pill centre, and the new `frameKnows(true)` gate is what keeps that real click deterministic.

## Testing

Baseline on clean `origin/main`, 10 runs: **2 failures**, both the same assertion.

After, 8 consecutive runs of `node test/browser-editing.test.js`: **8/8 green, 18 passed 0 failed each**.

`node test/run.js` (the offline merge gate): **PASS — all 75 suites green**, including `dismiss-rule.test.js`, whose four source-shape guards still hold.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
