### PR TITLE
The claim-by-handle window is retired

### DIFF
--- a/test/account-email-groundwork.test.js
+++ b/test/account-email-groundwork.test.js
@@ -29,7 +29,7 @@ function assert(c, m) { if (!c) throw new Error(m || 'assertion failed'); }
 // in phase 1 — reads /user/emails. Everything else falls through to the
 // real fetch (none of these tests need it).
 const realFetch = globalThis.fetch;
-function stubGitHub({ login, emails }) {
+function stubGitHub({ login, id, emails }) {
   globalThis.fetch = async (input, init) => {
     const url = String(input && input.url ? input.url : input);
     if (url.includes('github.com/login/oauth/access_token')) {
@@ -39,7 +39,7 @@ function stubGitHub({ login, emails }) {
       return Response.json(emails);
     }
     if (url.includes('api.github.com/user')) {
-      return Response.json({ login, avatar_url: '', name: login });
+      return Response.json({ login, id, avatar_url: '', name: login });
     }
     return realFetch(input, init);
   };
@@ -87,9 +87,14 @@ function sessionFromCookie(env, r) {
     const env = makeEnv(mod.CommentsStore);
     env.META.map.set('hosted-account:alice', JSON.stringify({
       account_id: 'acct_alice0000', github_login: 'alice', created: '2026-01-01T00:00:00Z',
+      identities: [{ provider: 'github', sub: '101', handle: 'alice' }],
+    }));
+    env.META.map.set('account-idp:github:101', JSON.stringify({
+      account_id: 'acct_alice0000', created: '2026-01-01T00:00:00Z',
     }));
     stubGitHub({
       login: 'Alice',
+      id: 101,
       emails: [
         { email: 'old@example.com', primary: false, verified: true },
         { email: 'Alice@Example.COM', primary: true, verified: true },
@@ -111,8 +116,12 @@ function sessionFromCookie(env, r) {
     const env = makeEnv(mod.CommentsStore);
     env.META.map.set('hosted-account:mallory', JSON.stringify({
       account_id: 'acct_mallory00', github_login: 'mallory', created: '2026-01-01T00:00:00Z',
+      identities: [{ provider: 'github', sub: '102', handle: 'mallory' }],
     }));
-    stubGitHub({ login: 'mallory', emails: [{ email: 'victim@example.com', primary: true, verified: false }] });
+    env.META.map.set('account-idp:github:102', JSON.stringify({
+      account_id: 'acct_mallory00', created: '2026-01-01T00:00:00Z',
+    }));
+    stubGitHub({ login: 'mallory', id: 102, emails: [{ email: 'victim@example.com', primary: true, verified: false }] });
     const { data } = await devicePoll(worker, env);
     assert(data.ok === true, `poll failed: ${JSON.stringify(data)}`);
     assert(!env.META.map.has('account-email:victim@example.com'),
@@ -127,8 +136,12 @@ function sessionFromCookie(env, r) {
     }));
     env.META.map.set('hosted-account:second', JSON.stringify({
       account_id: 'acct_second000', github_login: 'second', created: '2026-01-01T00:00:00Z',
+      identities: [{ provider: 'github', sub: '103', handle: 'second' }],
     }));
-    stubGitHub({ login: 'second', emails: [{ email: 'shared@example.com', primary: true, verified: true }] });
+    env.META.map.set('account-idp:github:103', JSON.stringify({
+      account_id: 'acct_second000', created: '2026-01-01T00:00:00Z',
+    }));
+    stubGitHub({ login: 'second', id: 103, emails: [{ email: 'shared@example.com', primary: true, verified: true }] });
     const { data } = await devicePoll(worker, env);
     assert(data.ok === true, `poll failed: ${JSON.stringify(data)}`);
     const idx = kvJson(env, 'account-email:shared@example.com');
@@ -174,9 +187,15 @@ function sessionFromCookie(env, r) {
     const env = makeEnv(mod.CommentsStore);
     env.META.map.set('hosted-account:keeper', JSON.stringify({
       account_id: 'acct_keeper000', github_login: 'keeper', created: '2026-01-01T00:00:00Z',
-      email: 'keeper@example.com', identities: [{ provider: 'google', sub: 'g-123' }],
+      email: 'keeper@example.com', identities: [
+        { provider: 'google', sub: 'g-123' },
+        { provider: 'github', sub: '104', handle: 'keeper' },
+      ],
     }));
-    stubGitHub({ login: 'keeper', emails: [] }); // no scope yet → no email this time
+    env.META.map.set('account-idp:github:104', JSON.stringify({
+      account_id: 'acct_keeper000', created: '2026-01-01T00:00:00Z',
+    }));
+    stubGitHub({ login: 'keeper', id: 104, emails: [] }); // no scope yet → no email this time
     const { data } = await devicePoll(worker, env);
     assert(data.ok === true, `poll failed: ${JSON.stringify(data)}`);
     const rec = kvJson(env, 'hosted-account:keeper');

--- a/test/identity-recycling.test.js
+++ b/test/identity-recycling.test.js
@@ -210,27 +210,47 @@ async function claimAccount(worker, env, cookie) {
     assert(ids[0].linked_at && ids[0].last_seen, 'link timestamps missing');
   });
 
-  await t('accounts predating the stable index are upgraded on next sign-in', async () => {
+  await t('a backfilled record resolves by its numeric id, handle irrelevant', async () => {
     const env = makeEnv(mod.CommentsStore);
-    // A legacy record: handle index only, no identities, no idp link.
+    // The shape backfill-github-identities.mjs leaves behind.
+    env.META.map.set('hosted-account:frank', JSON.stringify({
+      account_id: 'acct_frank0000', github_login: 'frank', created: '2026-01-01T00:00:00Z',
+      identities: [{ provider: 'github', sub: '444', handle: 'frank' }],
+    }));
+    env.META.map.set('account-idp:github:444', JSON.stringify({
+      account_id: 'acct_frank0000', created: '2026-01-01T00:00:00Z',
+    }));
+    stubProviders({ ghLogin: 'frank', ghId: 444, ghEmail: 'frank@example.com' });
+    const frank = await githubSignIn(worker, env);
+    assert(frank.account_id === 'acct_frank0000', 'backfilled account did not resolve by id');
+  });
+
+  await t('a handle-only record is not claimable by an unknown GitHub id', async () => {
+    const env = makeEnv(mod.CommentsStore);
+    // The pre-backfill shape: handle index only, no recorded id. Nothing can
+    // tell its returning owner from a squatter wearing the freed name, so
+    // NOBODY claims it by handle — the claim window is retired.
     env.META.map.set('hosted-account:frank', JSON.stringify({
       account_id: 'acct_frank0000', github_login: 'frank', created: '2026-01-01T00:00:00Z',
     }));
     stubProviders({ ghLogin: 'frank', ghId: 444, ghEmail: 'frank@example.com' });
     const frank = await githubSignIn(worker, env);
-    assert(frank.account_id === 'acct_frank0000', 'legacy account was not resolved by handle');
-    await claimAccount(worker, env, `tdoc_sid=${frank.sid}`);
-    const link = JSON.parse(env.META.map.get('account-idp:github:444') || 'null');
-    assert(link && link.account_id === 'acct_frank0000',
-      `legacy account was not upgraded: ${JSON.stringify(link)}`);
+    assert(!frank.account_id, `sign-in claimed a handle-only record: ${JSON.stringify(frank)}`);
+    const minted = await claimAccount(worker, env, `tdoc_sid=${frank.sid}`);
+    assert(minted.account_id && minted.account_id !== 'acct_frank0000',
+      `mint claimed a handle-only record: ${JSON.stringify(minted)}`);
   });
 
   await t('a legacy GitHub publisher lands on their account through the provider, no second button', async () => {
     const env = makeEnv(mod.CommentsStore, { ...OIDC_ENV, CLERK_SECRET_KEY: 'sk_test_stub' });
-    // The legacy shape: handle index only — published before phase 1, so no
-    // email index and no stable id anywhere.
+    // A backfilled legacy publisher: numeric id recorded, but no email index
+    // and no oidc link yet — the provider door has never seen her.
     env.META.map.set('hosted-account:gina', JSON.stringify({
       account_id: 'acct_gina00000', github_login: 'gina', created: '2026-01-01T00:00:00Z',
+      identities: [{ provider: 'github', sub: '555', handle: 'gina' }],
+    }));
+    env.META.map.set('account-idp:github:555', JSON.stringify({
+      account_id: 'acct_gina00000', created: '2026-01-01T00:00:00Z',
     }));
     const calls = {};
     stubProviders({ oidcSub: 'user_gina', oidcEmail: 'gina@new-mail.com', clerkExternal: { id: 555, username: 'gina' }, calls });
@@ -256,8 +276,13 @@ async function claimAccount(worker, env, cookie) {
 
   await t('a token mint on a handle-less session does not erase the bridged handle', async () => {
     const env = makeEnv(mod.CommentsStore, { ...OIDC_ENV, CLERK_SECRET_KEY: 'sk_test_stub' });
+    // Backfilled shape — the bridge resolves her through the numeric id.
     env.META.map.set('hosted-account:gina', JSON.stringify({
       account_id: 'acct_gina00000', github_login: 'gina', created: '2026-01-01T00:00:00Z',
+      identities: [{ provider: 'github', sub: '555', handle: 'gina' }],
+    }));
+    env.META.map.set('account-idp:github:555', JSON.stringify({
+      account_id: 'acct_gina00000', created: '2026-01-01T00:00:00Z',
     }));
     stubProviders({ oidcSub: 'user_gina', oidcEmail: 'gina@new-mail.com', clerkExternal: { id: 555, username: 'gina' } });
     await oidcSignIn(worker, env);

--- a/worker/backfill-github-identities.mjs
+++ b/worker/backfill-github-identities.mjs
@@ -1,0 +1,66 @@
+#!/usr/bin/env node
+// Backfill the immutable GitHub numeric id onto hosted-account records that
+// predate the identity index.
+//
+// Why: account resolution is id-first (`account-idp:github:<id>`), and the
+// worker no longer falls back to claiming an account by handle — a freed
+// GitHub name can be registered by anyone, and a handle-only record cannot
+// tell its returning owner from a squatter wearing the name. That fallback
+// is safe to retire only once every record carries its id, which is what
+// this script does. Run it BEFORE deploying a worker that includes the
+// retirement; installs with no handle-only records have nothing to do.
+//
+// The id for each handle comes from GitHub's public API *today* — correct as
+// long as the handle has not changed hands since the record was written.
+// Review the printed handle → id mapping before confirming; if a handle
+// looks reclaimed, exclude it and resolve that account by hand.
+//
+// Usage:
+//   node worker/backfill-github-identities.mjs <kv-namespace-id>            # dry run
+//   node worker/backfill-github-identities.mjs <kv-namespace-id> --write
+//
+// Needs: wrangler logged in to the Cloudflare account that owns the KV.
+
+import { execFileSync } from 'node:child_process';
+
+const ns = process.argv[2];
+const write = process.argv.includes('--write');
+if (!ns) {
+  console.error('usage: node worker/backfill-github-identities.mjs <kv-namespace-id> [--write]');
+  process.exit(1);
+}
+
+const kv = (args, input) => execFileSync('npx', ['wrangler', 'kv', 'key', ...args, '--namespace-id', ns, '--remote'], {
+  encoding: 'utf8', input, stdio: ['pipe', 'pipe', 'pipe'],
+});
+
+const listing = JSON.parse(kv(['list', '--prefix', 'hosted-account:']).replace(/^[^[]*/, ''));
+let touched = 0;
+for (const { name } of listing) {
+  const handle = name.slice('hosted-account:'.length);
+  const rec = JSON.parse(kv(['get', name]));
+  if (Array.isArray(rec.identities) && rec.identities.some((i) => i && i.provider === 'github')) {
+    console.log(`ok    ${handle} — already carries a github identity`);
+    continue;
+  }
+  const r = await fetch(`https://api.github.com/users/${encodeURIComponent(handle)}`, {
+    headers: { 'Accept': 'application/json', 'User-Agent': 'tdoc-backfill' },
+  });
+  if (!r.ok) {
+    console.log(`SKIP  ${handle} — GitHub /users lookup failed (${r.status}); resolve by hand`);
+    continue;
+  }
+  const gh = await r.json();
+  const id = gh && gh.id ? String(gh.id) : null;
+  if (!id) { console.log(`SKIP  ${handle} — no id in GitHub response`); continue; }
+  const now = new Date().toISOString();
+  const identities = Array.isArray(rec.identities) ? rec.identities.slice() : [];
+  identities.push({ provider: 'github', sub: id, handle, linked_at: now, last_seen: now });
+  console.log(`${write ? 'WRITE' : 'would'} ${handle} → github id ${id} (account ${rec.account_id})`);
+  if (write) {
+    kv(['put', name, JSON.stringify({ ...rec, identities })]);
+    kv(['put', `account-idp:github:${id}`, JSON.stringify({ account_id: rec.account_id, created: now })]);
+    touched++;
+  }
+}
+console.log(write ? `done — ${touched} record(s) backfilled` : 'dry run — re-run with --write to apply');

--- a/worker/worker.js
+++ b/worker/worker.js
@@ -3131,10 +3131,12 @@ function syncDocumentTitle(html, title) {
 //   account-idp:<provider>:<sub>  → account_id   authoritative. `sub` is the
 //       provider's own immutable id (GitHub's numeric user id, Clerk's
 //       user_xxx). It is never reused and never edited by the user.
-//   hosted-account:<login>        → account_id   legacy, and unsafe alone: a
-//       GitHub login can be RENAMED and the old name becomes available for
-//       anyone to register. Kept so existing accounts resolve, and upgraded
-//       to an idp index the first time their owner signs in.
+//   hosted-account:<login>        → account_id   the CURRENT holder's record,
+//       never proof by itself: a GitHub login can be RENAMED and the old name
+//       becomes available for anyone to register. Every live record carries
+//       its numeric id (backfilled via scripts/backfill-github-identities.mjs
+//       for the ones that predated the index), so resolution never rests on
+//       the handle alone.
 //   account-email:<email>         → account_id   a merge hint, used only when
 //       no idp index exists yet. Addresses change hands (a company reassigns
 //       a departed employee's mailbox), so treating one as proof of identity
@@ -3269,19 +3271,14 @@ async function hostedAccountForGithub(env, login, verifiedEmail = null, githubId
       // Known id: that account, whatever handle it wears today.
       try { rec = JSON.parse(await env.META.get(`hosted-account:${norm}`)); } catch {}
       if (!rec || rec.account_id !== id) rec = { account_id: id, github_login: norm, created: new Date().toISOString() };
-    } else {
-      // Unknown id. The handle index may still name an account — but it was
-      // written for whoever held this handle BEFORE, and a freed GitHub name
-      // can be registered by anyone. Claim it only if it has no stable owner
-      // yet (a legacy account, upgraded here); if it already belongs to a
-      // different id, this is a different person wearing a recycled name and
-      // they start clean.
-      const legacy = await lookupHostedAccount(env, login);
-      if (legacy) {
-        const owner = (legacy.identities || []).find((i) => i && i.provider === 'github');
-        if (!owner) rec = legacy;
-      }
     }
+    // Unknown id: they start clean. The handle index may still name an
+    // account, but it was written for whoever held this handle BEFORE, and a
+    // freed GitHub name can be registered by anyone. There used to be a
+    // claim-by-handle window here for legacy records with no recorded id —
+    // retired once every live record was backfilled with its numeric id
+    // (scripts/backfill-github-identities.mjs), because the window could not
+    // tell a returning owner from a squatter wearing the freed name.
   }
   if (!rec && !githubId) rec = await lookupHostedAccount(env, login);
   if (!rec) {
@@ -4742,11 +4739,12 @@ export default {
         const email = await ghVerifiedEmail(r.access_token);
         // user.id is GitHub's immutable identifier; user.login is a display
         // name the owner can change — and whose old value anyone may then
-        // register. Resolve on the id, falling back to the handle for
-        // accounts that predate it.
+        // register. Resolve on the id, and ONLY the id — the handle fallback
+        // for pre-index accounts is retired (records were backfilled with
+        // their numeric ids), because it handed a freed handle's account to
+        // whoever registered the name next.
         const ghId = user.id ? String(user.id) : null;
-        const existing = (ghId && await accountIdByIdp(env, 'github', ghId))
-          ? true : await lookupHostedAccount(env, user.login);
+        const existing = !!(ghId && await accountIdByIdp(env, 'github', ghId));
         const account = existing ? await hostedAccountForGithub(env, user.login, email, ghId) : null;
         const sid = rand(24);
         const session = {
@@ -5547,14 +5545,10 @@ export default {
         if (!account_id && sub) {
           bridged = await clerkExternalGithub(env, sub);
           if (bridged) {
+            // The numeric id, and only the numeric id — the claim-by-handle
+            // window for records with no recorded id is retired (records were
+            // backfilled), same as the direct GitHub flow.
             if (bridged.ghId) account_id = await accountIdByIdp(env, 'github', bridged.ghId);
-            if (!account_id && bridged.handle) {
-              const legacy = await lookupHostedAccount(env, bridged.handle);
-              // Same guard as the direct flow: a handle whose account already
-              // has a stable GitHub owner is not claimable through a name.
-              const owned = legacy && (legacy.identities || []).some((i) => i && i.provider === 'github');
-              if (legacy && !owned) account_id = legacy.account_id;
-            }
             if (account_id) {
               // Write the links NOW, not at mint: the whole point is that the
               // very next sign-in resolves exactly, and this person may read
@@ -5674,8 +5668,8 @@ export default {
         if (!user.login) return json({ error: 'no_user', message: user.message || 'GitHub /user returned no login' }, { status: 500 });
         const email = await ghVerifiedEmail(r.access_token);
         const ghId = user.id ? String(user.id) : null;
-        const existing = (ghId && await accountIdByIdp(env, 'github', ghId))
-          ? true : await lookupHostedAccount(env, user.login);
+        // Id only, same as the web callback: the handle fallback is retired.
+        const existing = !!(ghId && await accountIdByIdp(env, 'github', ghId));
         const account = existing ? await hostedAccountForGithub(env, user.login, email, ghId) : null;
         const sid = rand(24);
         // Store only the identity we actually use. The GitHub access token is


### PR DESCRIPTION
## The hole

A `hosted-account:<handle>` record with no recorded GitHub numeric id (pre-identity-index accounts) could be claimed by whoever wears the handle today. Three paths fell back to the handle index when the id was unknown: device-flow sign-in, token mint (`hostedAccountForGithub`), and the Clerk bridge in the OIDC callback. The fallback existed so legacy owners could resolve their accounts on first post-migration sign-in — but it cannot distinguish a returning owner from a squatter who registered the freed name after a rename/deletion, and it stayed open indefinitely. A successful claim is durable: `linkIdentity` immediately binds the claimer's ids to the account.

## The fix — backfill, then close the window

Instead of heuristics (account-age guards, time-boxes), the simple thing: record the immutable numeric id on every live record, then resolve on the id and **only** the id. An unknown id starts clean, whatever name it wears.

- `worker/backfill-github-identities.mjs` (new): writes `identities` + `account-idp:github:<id>` for every hosted-account record that lacks a GitHub identity, ids fetched from GitHub's public API. Dry-run by default; prints the handle → id mapping for review before `--write`.
- Sign-in (both device-poll sites), mint, and bridge: handle fallback removed; id-first resolution only.

**Deploy order matters**: run the backfill against production KV before this deploys, or legacy owners signing in would mint fresh empty accounts. tdoc.dev has exactly 5 un-backfilled records (all known, verified against GitHub's public API today).

Pinned by tests: a backfilled record resolves by id with the handle irrelevant; a handle-only record is claimable by nobody — not at sign-in, not at mint, not through the bridge. Offline suite: 75/75 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SRBHeJR28SHyZSLzTEdhsM