### PR TITLE
The submenus get their source committed

### DIFF
--- a/shell/src/document/document-toolbar.jsx
+++ b/shell/src/document/document-toolbar.jsx
@@ -205,20 +205,35 @@ export function DocumentOverflowActions({
           it does — on a desktop that group is not rendered, and a rule floating
           at the top of the menu would be the only thing left of it. */}
       <AppMenuSeparator className="tdoc-mobile-overflow-only" />
-      <AppMenuItem className="tdoc-action-menu-item" data-action="copy" onClick={onCopyMarkdown}>
-        <Copy size={15} /> Copy as Markdown
-      </AppMenuItem>
+      {/* One row instead of three. Taking a copy of the document is a single
+          intent; which format is a detail that belongs one level down.
+          Duplicate stays out here — it makes a new document on tdoc, which is
+          not "take this one away". */}
+      <AppSubmenu
+        className="tdoc-action-menu-item tdoc-export-submenu-trigger"
+        trigger={(
+          <>
+            <Download size={15} />
+            <span>Download &amp; copy</span>
+            <ChevronRight className="tdoc-submenu-chevron" size={14} />
+          </>
+        )}
+      >
+        <AppMenuItem className="tdoc-action-menu-item" data-action="copy" onClick={onCopyMarkdown}>
+          <Copy size={15} /> Copy as Markdown
+        </AppMenuItem>
+        <AppMenuItem className="tdoc-action-menu-item" data-action="download" onClick={onDownload}>
+          <Download size={15} /> Download HTML
+        </AppMenuItem>
+        <AppMenuItem className="tdoc-action-menu-item" data-action="download-pdf" onClick={onPrint}>
+          <FileDown size={15} /> Download PDF
+        </AppMenuItem>
+      </AppSubmenu>
       {config.mode === 'published' ? (
         <AppMenuItem className="tdoc-action-menu-item" data-action="duplicate" onClick={onDuplicate}>
           <CopyPlus size={15} /> Duplicate
         </AppMenuItem>
       ) : null}
-      <AppMenuItem className="tdoc-action-menu-item" data-action="download" onClick={onDownload}>
-        <Download size={15} /> Download HTML
-      </AppMenuItem>
-      <AppMenuItem className="tdoc-action-menu-item" data-action="download-pdf" onClick={onPrint}>
-        <FileDown size={15} /> Download PDF
-      </AppMenuItem>
       {config.ownerManage ? <AppMenuSeparator /> : null}
       {config.ownerManage ? (
         <AppMenuItem className="tdoc-action-menu-item" data-action="delete" tone="danger" onClick={onDelete}>

--- a/shell/src/top-bar.jsx
+++ b/shell/src/top-bar.jsx
@@ -1,14 +1,16 @@
 import React, { useEffect, useState } from 'react';
 import {
   Bell,
+  ChevronRight,
   Library,
   LogIn,
   LogOut,
-  MoreHorizontal,
   Moon,
+  MoreHorizontal,
   Sun,
+  UserRound,
 } from 'lucide-react';
-import { AppMenu, AppMenuItem, AppMenuSeparator } from './ui/menu.jsx';
+import { AppMenu, AppMenuItem, AppMenuSeparator, AppSubmenu } from './ui/menu.jsx';
 import { useNotifications } from './hooks/use-notifications.js';
 import { NotificationsDialog, notificationTarget } from './notifications-dialog.jsx';
 
@@ -100,14 +102,29 @@ export function TopBar({
               <AppMenuItem className="tdoc-action-menu-item tdoc-mobile-overflow-only" onClick={() => { location.href = '/me'; }}>
                 <Library size={15} /> My docs
               </AppMenuItem>
-              <AppMenuItem className="tdoc-action-menu-item tdoc-mobile-overflow-only" onClick={signOut}>
-                <LogOut size={15} /> Sign out
-              </AppMenuItem>
-              {onSwitchAccount ? (
-                <AppMenuItem className="tdoc-action-menu-item" onClick={onSwitchAccount}>
-                  <LogIn size={15} /> Switch account
+              {/* Both of these are "the account", and neither is something you
+                  reach for often. Mobile-only like the rows above: on a desktop
+                  the account chip beside this menu already carries them, and
+                  Switch account used to appear in both. */}
+              <AppSubmenu
+                className="tdoc-action-menu-item tdoc-mobile-overflow-only tdoc-account-submenu-trigger"
+                trigger={(
+                  <>
+                    <UserRound size={15} />
+                    <span>My account</span>
+                    <ChevronRight className="tdoc-submenu-chevron" size={14} />
+                  </>
+                )}
+              >
+                <AppMenuItem className="tdoc-action-menu-item" onClick={signOut}>
+                  <LogOut size={15} /> Sign out
                 </AppMenuItem>
-              ) : null}
+                {onSwitchAccount ? (
+                  <AppMenuItem className="tdoc-action-menu-item" onClick={onSwitchAccount}>
+                    <LogIn size={15} /> Switch account
+                  </AppMenuItem>
+                ) : null}
+              </AppSubmenu>
             </>
           ) : authConfigured ? (
             <AppMenuItem className="tdoc-action-menu-item tdoc-mobile-overflow-only" onClick={onSignIn}>

--- a/test/browser-editing.test.js
+++ b/test/browser-editing.test.js
@@ -602,7 +602,9 @@ async function chooseMode(page, label) {
       await page.getByRole('button', { name: 'More actions' }).click();
       await page.locator('.ui-menu-popup').waitFor();
       const moreLabels = await page.locator('.ui-menu-popup .ui-menu-item').allTextContents();
-      for (const label of ['Publish', 'Copy as Markdown', 'My docs', 'Sign out']) {
+      // Copy as Markdown lives in "Download & copy" and Sign out in "My account"
+      // since the ⋯ menu was grouped (#443); the top level carries the groups.
+      for (const label of ['Publish', 'Download & copy', 'My docs', 'My account']) {
         assert(moreLabels.some((value) => value.trim() === label), `${label} missing from mobile More: ${moreLabels.join(', ')}`);
       }
       assert(moreLabels.some((value) => /^Versionsv\d+$/.test(value.trim())), `version submenu missing from mobile More: ${moreLabels.join(', ')}`);


### PR DESCRIPTION
Fixes #446. **main ships a bundle built from source that is not in the repository.**

#443 added `Download & copy` and `My account` to the ⋯ menu. The built bundle went in; the source did not — that commit ran `git add test/…` and took only the test files.

| | `tdoc-export-submenu-trigger` |
|---|---|
| `shell/src/…/document-toolbar.jsx` on main | **absent** |
| `server/runtime/shell.*.js` on main | present |
| tdoc.dev right now | present — it works |

Anyone running `npm run build:shell` silently deletes both submenus. I hit exactly that on an unrelated branch: five menu tests went red, and the obvious reading — *my change broke the menu* — was wrong. The menu had been rebuilt out of existence.

## Nothing else changes

Rebuilding from the restored source reproduces the committed bundle **byte for byte**: `git status server/runtime` is empty after `npm run build:shell`. That is the proof this source is what the shipped bundle was built from.

## The guard that should have caught it

The `shell runtime` job rebuilds and fails on a diff — *"someone edited shell/src without npm run build:shell"*. It guards **source ahead of bundle**. A **bundle ahead of source** passes it. Worth a follow-up.

`npm test` — **76/76 offline**; responsive **32/32**, artifact-shell **38/5**, ui 11/12 — all at the main baseline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)