### PR TITLE
The homepage is one v1, re-shipped in place

### DIFF
--- a/.github/workflows/publish-landing.yml
+++ b/.github/workflows/publish-landing.yml
@@ -141,15 +141,21 @@ jobs:
               done
             fi
 
-            # Same shape tdoc-publish sends. comments is omitted on purpose:
-            # the payload's comments.json is empty and the worker merges rather
-            # than replaces, so sending an empty list would read as intent to
-            # clear a thread it must not touch.
+            # Same shape tdoc-publish sends, plus `replace`. Each landing doc is
+            # one version re-shipped in place on every deploy; without the
+            # flag the worker treats a v1 that already exists as history and
+            # refuses to rewrite it (#458). It is honoured for the provider
+            # token only and only for the doc's latest version.
+            #
+            # comments is omitted on purpose: the payload's comments.json is
+            # empty and the worker merges rather than replaces, so sending an
+            # empty list would read as intent to clear a thread it must not
+            # touch.
             jq -n --arg slug "$slug" --argjson version "$ver" \
               --rawfile html "$dir/v$ver/index.html" \
               --slurpfile meta "$dir/meta.json" \
               --argjson widgets "$widgets" \
-              '{slug:$slug, version:$version, html:$html, meta:$meta[0]}
+              '{slug:$slug, version:$version, html:$html, meta:$meta[0], replace:true}
                + (if $widgets == {} then {} else {widgets:$widgets} end)' > payload.json
 
             code=$(curl -sS -o resp.json -w '%{http_code}' -X POST https://tdoc.dev/api/upload \

--- a/test/landing-republish.test.js
+++ b/test/landing-republish.test.js
@@ -1,0 +1,160 @@
+// #458 — the homepage is one v1, re-shipped in place.
+//
+// bin/tdoc-landing-release collapses landing/tornado-doc to a single v1 and
+// publish-landing.yml uploads that v1 on every deploy to main. The worker's
+// upload rule since #329 refuses to rewrite a version that already exists
+// unless the freshly-stamped bytes are identical — right for `tdoc publish`,
+// fatal for the homepage, whose bytes change with every reader.css change
+// (the repo HTML carries no baked reader block) and with every landing edit.
+// Every run from 2026-09-01 to 2026-09-04 died on that 409.
+//
+// The contract this pins: `replace: true` rewrites the LATEST version in
+// place, from the provider upload token only. Plain re-upload keeps its
+// guard, a hosted token cannot replace, a historical version cannot be
+// replaced, and a version above latest is unaffected by the flag.
+
+const { loadWorker, makeEnv, req, issue } = require('./helpers/worker-harness');
+
+let pass = 0, fail = 0;
+function ok(n) { console.log(`  ✓ ${n}`); pass++; }
+function bad(n, e) { console.log(`  ✗ ${n}\n    ${e && e.message ? e.message : e}`); fail++; }
+async function t(n, fn) { try { await fn(); ok(n); } catch (e) { bad(n, e); } }
+function assert(c, m) { if (!c) throw new Error(m || 'assertion failed'); }
+
+const TOKEN = 'provider-upload-token';
+const SLUG = 'tornado-doc';
+
+// The shape bin/tdoc-landing-release writes: one version, public, commentable,
+// history owner-only.
+function landingMeta(slug = SLUG) {
+  return {
+    slug,
+    title: 'tdoc',
+    created: '2026-08-01T00:00:00Z',
+    versions: [{ n: 1, created: '2026-08-28T00:00:00Z', prompt: 'tdoc landing page' }],
+    access: { visibility: 'public', history_visibility: 'owner', commenting: 'signed_in', allowed_users: [] },
+  };
+}
+
+function page(headline) {
+  return `<!doctype html><html><head><title>tdoc</title></head><body><h1>${headline}</h1><p>Prompt-native docs.</p></body></html>`;
+}
+
+async function upload(worker, env, body, token = TOKEN) {
+  const r = await worker.fetch(req('/api/upload', { method: 'POST', token, body }), env, {});
+  let data = {};
+  try { data = await r.json(); } catch {}
+  return { status: r.status, data };
+}
+
+function storedV1(env, slug = SLUG) {
+  return env.DOCS.map.get(`docs/${slug}/v1/index.html`) || '';
+}
+
+function versionsOf(env, slug = SLUG) {
+  return JSON.parse(env.META.map.get(`meta:${slug}`)).versions;
+}
+
+(async () => {
+  const mod = await loadWorker();
+  const worker = mod.default;
+  // The landing shell fetches a GitHub star count server-side; keep the suite
+  // offline and deterministic.
+  const realFetch = globalThis.fetch;
+  globalThis.fetch = async () => new Response('{}', { status: 404 });
+  console.log('landing republish (#458)');
+
+  const env = makeEnv(mod.CommentsStore, { TDOC_UPLOAD_TOKEN: TOKEN });
+
+  await t('first publish of the homepage slug lands v1', async () => {
+    const r = await upload(worker, env, { slug: SLUG, version: 1, html: page('First homepage'), meta: landingMeta() });
+    assert(r.status === 200 && r.data.ok === true, `expected 200 ok, got ${r.status} ${JSON.stringify(r.data)}`);
+    assert(storedV1(env).includes('First homepage'), 'v1 bytes not stored');
+    assert(versionsOf(env).map((v) => v.n).join() === '1', 'expected exactly v1');
+  });
+
+  await t('re-shipping identical bytes without replace is still accepted', async () => {
+    const r = await upload(worker, env, { slug: SLUG, version: 1, html: page('First homepage'), meta: landingMeta() });
+    assert(r.status === 200 && r.data.ok === true, `expected 200 ok, got ${r.status} ${JSON.stringify(r.data)}`);
+  });
+
+  await t('re-shipping changed bytes without replace is the 409 CI was dying on', async () => {
+    const r = await upload(worker, env, { slug: SLUG, version: 1, html: page('Second homepage'), meta: landingMeta() });
+    assert(r.status === 409, `expected 409, got ${r.status} ${JSON.stringify(r.data)}`);
+    assert(r.data.error === 'version_conflict' && r.data.baseVersion === 0 && r.data.latestVersion === 1,
+      `unexpected body ${JSON.stringify(r.data)}`);
+    assert(storedV1(env).includes('First homepage'), 'a refused upload must not touch the stored bytes');
+  });
+
+  await t('replace:true rewrites v1 in place — no v2, version list unchanged, sha refreshed', async () => {
+    const before = versionsOf(env)[0].sha;
+    const r = await upload(worker, env, { slug: SLUG, version: 1, html: page('Second homepage'), meta: landingMeta(), replace: true });
+    assert(r.status === 200 && r.data.ok === true, `expected 200 ok, got ${r.status} ${JSON.stringify(r.data)}`);
+    assert(r.data.url === `/d/${SLUG}/v/1`, `expected the v1 url, got ${r.data.url}`);
+    const stored = storedV1(env);
+    assert(stored.includes('Second homepage') && !stored.includes('First homepage'), 'v1 bytes were not replaced');
+    assert(!env.DOCS.map.has(`docs/${SLUG}/v2/index.html`), 'replace must not append a v2');
+    const versions = versionsOf(env);
+    assert(versions.map((v) => v.n).join() === '1', `expected exactly v1, got ${JSON.stringify(versions)}`);
+    assert(versions[0].sha && versions[0].sha !== before, 'the v1 entry must record the hash of the new bytes');
+    assert(versions[0].prompt === 'tdoc landing page', 'the landing version entry must keep its payload fields');
+  });
+
+  await t('tdoc.dev/ serves the replaced homepage', async () => {
+    const r = await worker.fetch(req('/'), env, {});
+    const html = await r.text();
+    assert(r.status === 200, `expected 200 from /, got ${r.status}`);
+    // What publish-landing.yml greps for after the upload: the doc, not the
+    // neutral fallback.
+    assert(html.includes('"slug":"tornado-doc"') && html.includes('"isLanding":true'),
+      'the homepage is on the neutral fallback, not the landing doc');
+    const frame = await worker.fetch(req(`/d/${SLUG}/v/1/frame`, { dest: 'iframe' }), env, {});
+    const body = await frame.text();
+    assert(frame.status === 200 && body.includes('Second homepage') && !body.includes('First homepage'),
+      `the frame does not carry the replaced bytes (${frame.status})`);
+  });
+
+  await t('a hosted account token cannot replace, even its own doc', async () => {
+    const hosted = await issue(worker, env, 'mallory');
+    const own = await upload(worker, env, { slug: 'mallory-doc', version: 1, html: page('mine') }, hosted.token);
+    assert(own.status === 200, `hosted publish failed ${own.status} ${JSON.stringify(own.data)}`);
+    const r = await upload(worker, env, { slug: 'mallory-doc', version: 1, html: page('rewritten'), replace: true }, hosted.token);
+    assert(r.status === 403 && r.data.error === 'replace_forbidden', `expected 403 replace_forbidden, got ${r.status} ${JSON.stringify(r.data)}`);
+    assert(storedV1(env, 'mallory-doc').includes('mine'), 'a refused replace must not touch the stored bytes');
+    const steal = await upload(worker, env, { slug: SLUG, version: 1, html: page('stolen'), replace: true }, hosted.token);
+    assert(steal.status === 403, `a hosted token must not replace the homepage, got ${steal.status}`);
+    assert(storedV1(env).includes('Second homepage'), 'the homepage bytes must be untouched');
+  });
+
+  await t('replace never rewrites a historical version; the latest still can be', async () => {
+    const two = await upload(worker, env, {
+      slug: SLUG, version: 2, html: page('Third homepage'),
+      meta: { ...landingMeta(), versions: [...landingMeta().versions, { n: 2, created: '2026-09-04T00:00:00Z' }] },
+    });
+    assert(two.status === 200, `appending v2 failed ${two.status} ${JSON.stringify(two.data)}`);
+    const hist = await upload(worker, env, { slug: SLUG, version: 1, html: page('Rewritten history'), meta: landingMeta(), replace: true });
+    assert(hist.status === 409 && hist.data.error === 'replace_not_latest' && hist.data.latestVersion === 2,
+      `expected 409 replace_not_latest, got ${hist.status} ${JSON.stringify(hist.data)}`);
+    assert(storedV1(env).includes('Second homepage'), 'v1 must be untouched');
+    const latest = await upload(worker, env, {
+      slug: SLUG, version: 2, html: page('Fourth homepage'), replace: true,
+      meta: { ...landingMeta(), versions: [...landingMeta().versions, { n: 2, created: '2026-09-04T00:00:00Z' }] },
+    });
+    assert(latest.status === 200, `replacing the latest failed ${latest.status} ${JSON.stringify(latest.data)}`);
+    assert((env.DOCS.map.get(`docs/${SLUG}/v2/index.html`) || '').includes('Fourth homepage'), 'v2 was not replaced');
+    assert(versionsOf(env).map((v) => v.n).join() === '1,2', 'replace must not change the version list');
+  });
+
+  await t('replace on a version above latest is a plain append', async () => {
+    const r = await upload(worker, env, {
+      slug: SLUG, version: 3, html: page('Fifth homepage'), replace: true,
+      meta: { ...landingMeta(), versions: [{ n: 1 }, { n: 2 }, { n: 3, created: '2026-09-04T01:00:00Z' }] },
+    });
+    assert(r.status === 200 && r.data.url === `/d/${SLUG}/v/3`, `expected v3 to land, got ${r.status} ${JSON.stringify(r.data)}`);
+    assert(versionsOf(env).map((v) => v.n).join() === '1,2,3', 'v3 must be appended');
+  });
+
+  globalThis.fetch = realFetch;
+  console.log(`\n${pass} passed, ${fail} failed`);
+  process.exit(fail ? 1 : 0);
+})().catch((e) => { console.error(e); process.exit(1); });

--- a/test/run.js
+++ b/test/run.js
@@ -55,6 +55,7 @@ const OFFLINE = [
   'rename-from-the-bar.test.js', // #383 renaming is metadata; only blank docs follow their heading
   'resolve-a-thread.test.js', // #357 a person can resolve; resolved threads leave the margin
   'tornado-doc-landing.test.js',
+  'landing-republish.test.js', // #458 the homepage is one v1, re-shipped in place with `replace`
   'browser-bundles-parse.test.js', // syntax-check what we inject into pages
   'tdoc-start.test.js',
   'landing-demo-tabs.test.js', // the homepage demo: four stages, one reader

--- a/test/tornado-doc-landing.test.js
+++ b/test/tornado-doc-landing.test.js
@@ -448,6 +448,11 @@ t('shipping the homepage ships content, not just worker code', () => {
   assert(/node bin\/tdoc-landing-release/.test(content),
     'publish workflow must build the release payload, not upload the working copy');
   assert(/https:\/\/tdoc\.dev\/api\/upload/.test(content), 'publish workflow does not POST to /api/upload');
+  // #458: each landing doc is one v1 re-shipped in place on every deploy. The
+  // worker refuses to rewrite an existing version unless asked in so many
+  // words, so a payload without `replace` 409s on every run after the first.
+  assert(/replace:\s*true/.test(content),
+    'publish workflow must send replace:true, or the homepage can never be republished');
   // The upload can succeed while the page still is not readable (access
   // gate, wrong slug). Green must mean the homepage actually renders.
   assert(/is still serving the neutral fallback/.test(content),

--- a/worker/worker.js
+++ b/worker/worker.js
@@ -6426,6 +6426,16 @@ export default {
       if (!isValidSlug(slug)) return json({ error: 'invalid_slug' }, { status: 400 });
       const verNum = Number(version);
       if (!Number.isInteger(verNum) || verNum < 1) return json({ error: 'invalid_version' }, { status: 400 });
+      // `replace: true` asks to rewrite the doc's LATEST version in place
+      // instead of appending one. It is the landing-doc contract (#458): the
+      // homepage, /start and /templates are each a single v1 that
+      // publish-landing.yml re-ships on every deploy. Provider token only — a
+      // hosted account's history is append-only, and the browser editor's
+      // conflict detection relies on that.
+      const replace = body.replace === true;
+      if (replace && !(auth.actor && auth.actor.kind === 'admin')) {
+        return json({ error: 'replace_forbidden', message: 'replace is accepted from the provider upload token only' }, { status: 403 });
+      }
       const writeGate = await requireDocWriteAccess(env, auth.actor, slug, { create: true });
       if (!writeGate.ok) return writeGate.response;
       const firstHostedPublish = !!(
@@ -6489,8 +6499,22 @@ export default {
         // Old-version uploads are best-effort repairs, never rewrites. This is
         // what prevents a stale local v8 from replacing a browser-created v8
         // while the CLI walks its historical versions before uploading v9.
+        //
+        // The one sanctioned rewrite is `replace` on the LATEST version. The
+        // landing docs need it: the repo HTML carries no baked reader block,
+        // so every upload re-stamps it with the current template and the bytes
+        // differ after any reader.css change — and a landing edit changes them
+        // outright. Bumping the version instead would grow the homepage's
+        // history by one per push to main, which the release script exists to
+        // avoid. A historical version is never replaced, flag or not: readers
+        // may be on it, and nothing above it was derived from the new bytes.
         if (existingHtml != null && existingHtml !== stampedHtml) {
-          return json({ error: 'version_conflict', baseVersion: verNum - 1, latestVersion: remoteLatest }, { status: 409 });
+          if (replace && verNum < remoteLatest) {
+            return json({ error: 'replace_not_latest', version: verNum, latestVersion: remoteLatest }, { status: 409 });
+          }
+          if (!replace) {
+            return json({ error: 'version_conflict', baseVersion: verNum - 1, latestVersion: remoteLatest }, { status: 409 });
+          }
         }
       }
       if (writesLatestMeta && writeGate.meta && env.COMMENTS && verNum > remoteLatest) {


### PR DESCRIPTION
## What & why

Fixes #458.

`publish tdoc.dev homepage` has failed on every run since the last green one on 2026-09-01: `POST /api/upload` for `tornado-doc` v1 returns `409 {"error":"version_conflict","baseVersion":0,"latestVersion":1}`, so nothing merged to `landing/` since then has reached tdoc.dev/.

The 409 is the pre-check #329 added to `/api/upload` ("old-version uploads are best-effort repairs, never rewrites"): a version that already exists is accepted only when the freshly-stamped bytes equal the stored bytes. The landing docs never satisfy it. The repo HTML carries no baked reader block, so `prepareDocVersion` injects the current `reader.css` on every upload, and every reader.css change since (#418, #423, #453) makes v1's bytes differ — as does any real landing edit. (`baseVersion: 0` is `verNum - 1` from that pre-check; the Durable Object reservation only runs for a version above latest and is never reached.)

The contract `bin/tdoc-landing-release` designed is one v1, replaced in place, history owner-only. Bumping the version from the workflow would grow the homepage's history by one per push to main. So the intent is now said in so many words:

- `/api/upload` accepts `replace: true`: rewrite the doc's **latest** version in place. Honoured for the provider upload token only (`403 replace_forbidden` for a hosted account token — a hosted doc's history stays append-only, and the browser editor's conflict detection relies on that). A historical version is never replaced (`409 replace_not_latest`). Above latest the flag is a no-op and the normal reservation path runs.
- `publish-landing.yml` sends `replace: true` for `tornado-doc`, `tdoc-start` and `tdoc-templates`.
- `test/landing-republish.test.js` drives the real worker with fake bindings: first publish, identical re-ship, the exact 409 CI was dying on, replace landing new bytes at v1 with no v2 and the version list unchanged, `/` and the frame serving the new bytes, a hosted token refused, a historical version refused, latest replaceable, above-latest unaffected. `tornado-doc-landing.test.js` pins that the workflow sends the flag.

The landing HTML itself is untouched.

## Checklist

- [x] `npm test` passes locally (offline suite): 77 suites green.
- [ ] `npm run test:all` with Playwright — not run; the change is server-side upload semantics with no browser-facing surface, and the new suite drives the worker in-process.
- [x] `SKILL.md` untouched.
- [x] Version untouched.

## Security note

Touches `worker/worker.js` (`/api/upload`) and the publish workflow. Untrusted input: the `replace` field of the upload body. It is read as a strict boolean, rejected with 403 unless the caller authenticated with `TDOC_UPLOAD_TOKEN` (the same actor that could already create and delete any doc), and even then only widens the existing latest-version write, never a historical version. No new token handling; the workflow's request and secret handling are unchanged.