### PR TITLE
Lost comments keep their place: exact, then the neighbourhood, then a seat

### DIFF
--- a/server/frame-probe.js
+++ b/server/frame-probe.js
@@ -680,11 +680,20 @@
     // An anchor that cannot be placed still deserves a seat. Without a pin the
     // desktop rail has no coordinate to draw the card at, so the comment sits in
     // the data and nowhere on screen — while the phone drawer, which renders the
-    // list directly, shows it. Park it at the top of the document, flagged, and
-    // everything downstream keeps working unchanged: clustering, the rail, the
-    // dashed unanchored card, and the "move anchor" that puts it back.
+    // list directly, shows it.
+    //
+    // The seat goes at the END of the document, not the top. At the top a stack
+    // of comments from an older version is the first thing beside the title,
+    // which reads as "these matter most"; at the end it reads as what it is —
+    // what the last revision left behind. Everything downstream is unchanged:
+    // clustering, the rail, the dashed unanchored card, and the Re-anchor that
+    // puts one back where it belongs.
+    // Not the very last pixel: the rail culls a pin that falls outside the
+    // viewport, and a seat pinned to the document's final row is never on
+    // screen even when you scroll all the way down. Sit just above the end.
+    var seatY = Math.max(0, document.documentElement.scrollHeight - 160);
     function seat(c, extra) {
-      var pin = { id: c.id, docY: 0, lost: true, login: (c.author && c.author.login) || null,
+      var pin = { id: c.id, docY: seatY, lost: true, login: (c.author && c.author.login) || null,
         avatar_url: (c.author && c.author.avatar_url) || null, kind: (c.author && c.author.kind) || null,
         resolved: c.status === 'applied', deleted: !!c.deleted };
       if (extra) for (var k in extra) pin[k] = extra[k];

--- a/server/frame-probe.js
+++ b/server/frame-probe.js
@@ -581,6 +581,68 @@
     if (!s || !e) return null;
     try { var r = document.createRange(); r.setStart(s.node, s.offset); r.setEnd(e.node, e.offset); return r; } catch (x) { return null; }
   }
+  // The anchor's own words are gone, but its neighbours may not be. Every field
+  // needed for this is already saved — context_before and context_after — and
+  // findTextRange only ever used them to break ties between several copies of
+  // the anchor text. When the text itself has been rewritten it returns null
+  // before it ever looks at them, and the comment loses its place entirely.
+  //
+  // The tail of context_before and the head of context_after are the parts that
+  // touched the anchor, so the longest surviving run of either is the closest
+  // thing to where the words used to be. Measured on a real document: five
+  // comments whose text was rewritten still had 9–59 characters of neighbouring
+  // context alive in the new version.
+  //
+  // Approximate on purpose. The caller marks these unanchored, so the card is
+  // dashed and offers Re-anchor — a guess that admits it is a guess, rather than
+  // a pin that claims to point at somebody else's sentence.
+  var NEAR_CONTEXT_MIN = 12;
+  function findNearContext(anchor, view) {
+    if (!anchor || !view || !view.norm) return null;
+    var before = normalizeContext(anchor.context_before).trim();
+    var after = normalizeContext(anchor.context_after).trim();
+    var best = null; // { at, len }
+
+    // Suffixes of context_before: the end of it sat against the anchor.
+    for (var lb = before.length; lb >= NEAR_CONTEXT_MIN; lb--) {
+      var tail = before.slice(before.length - lb);
+      var i = view.norm.indexOf(tail);
+      if (i !== -1 && view.norm.indexOf(tail, i + 1) === -1) { best = { at: i + lb, len: lb }; break; }
+    }
+    // Prefixes of context_after: the start of it sat against the anchor. Only
+    // taken when it beats what the other side found — longer surviving run wins.
+    for (var la = after.length; la >= NEAR_CONTEXT_MIN; la--) {
+      if (best && la <= best.len) break;
+      var head = after.slice(0, la);
+      var j = view.norm.indexOf(head);
+      if (j !== -1 && view.norm.indexOf(head, j + 1) === -1) { best = { at: j, len: la }; break; }
+    }
+    if (!best) return null;
+    // Land ON the surviving context, not on the position just past it. For a
+    // before-match that position is where the anchor used to begin, which after a
+    // rewrite is often the whitespace between two blocks — a text node with no
+    // layout, whose rect is 0x0 at the top of the document.
+    //
+    // Prefer the single character adjacent to where the anchor sat; if that one
+    // cannot be measured either, widen to the whole surviving run, which spans
+    // real rendered text by construction. Only give up when neither can be
+    // measured — a spot with no rect is not a spot, and pinning to it would drop
+    // the comment at the top of the page.
+    var start = best.side === 'before' ? best.at - best.len : best.at;
+    var adjacent = best.side === 'before' ? best.at - 1 : best.at;
+    var tries = [
+      [Math.max(0, Math.min(adjacent, view.norm.length - 1)), 1],
+      [Math.max(0, start), best.len]
+    ];
+    for (var t = 0; t < tries.length; t++) {
+      var candidate = rangeFromNorm(view, tries[t][0], tries[t][1]);
+      if (!candidate) continue;
+      var box = candidate.getBoundingClientRect();
+      if (box.width || box.height) return candidate;
+    }
+    return null;
+  }
+
   function findTextRange(anchor, view) {
     // No length floor. A one-character anchor used to be refused outright,
     // which in CJK is an ordinary thing to want to comment on — and the
@@ -714,11 +776,22 @@
       if (c.anchor.kind !== 'text') return seat(c);
       var key = (c.anchor.text || '') + '\u0000' + (c.anchor.context_before || '') + '\u0000' + (c.anchor.context_after || '');
       var r = (key in _rangeCache) ? _rangeCache[key] : (_rangeCache[key] = findTextRange(c.anchor, docView()));
+      // Exact first, then the neighbourhood, then a seat at the end. The middle
+      // one is approximate, so it is NOT painted as a highlight and its pin is
+      // flagged: the card reads unanchored and offers Re-anchor.
+      var approximate = false;
+      if (!r) {
+        r = findNearContext(c.anchor, docView());
+        approximate = !!r;
+      }
       if (!r) return seat(c);
       _anchorTargets[c.id] = { range: r };
-      if (hl && !c.deleted) hl.add(r);
+      if (hl && !c.deleted && !approximate) hl.add(r);
       var rect = r.getBoundingClientRect();
-      pins.push({ id: c.id, docY: rect.top + (window.scrollY || 0), login: (c.author && c.author.login) || null, avatar_url: (c.author && c.author.avatar_url) || null, kind: (c.author && c.author.kind) || null, resolved: c.status === 'applied', deleted: !!c.deleted });
+      // Second line of defence: findNearContext already measures its candidates,
+      // but an exact hit can be invisible too (a rule moved into a hidden block).
+      if (approximate && !rect.width && !rect.height) return seat(c);
+      pins.push({ id: c.id, docY: rect.top + (window.scrollY || 0), lost: approximate || undefined, login: (c.author && c.author.login) || null, avatar_url: (c.author && c.author.avatar_url) || null, kind: (c.author && c.author.kind) || null, resolved: c.status === 'applied', deleted: !!c.deleted });
     });
     if (HL) CSS.highlights.set('tdoc-anchor', hl);
     setActiveAnchor(_activeAnchorId, false);

--- a/test/anchor-rewrite-fallback.test.js
+++ b/test/anchor-rewrite-fallback.test.js
@@ -1,0 +1,240 @@
+// A comment whose sentence was rewritten must stay where the sentence was.
+//
+// Republishing a document rewrites its prose. The anchor stores the commented
+// text and its two neighbours, and the probe only ever searched for the text —
+// so once an author reworded that sentence, every comment on it resolved to
+// nothing and the whole set collapsed into one pile (#460). Five comments
+// spread across a long document arrived stacked on top of each other, which
+// reads as "the comments are gone" even though every one of them was saved.
+//
+// The neighbours usually survive the rewrite. This suite publishes v1, comments
+// on a sentence, publishes a v2 that rewords exactly that sentence, and asks
+// where the comment went:
+//
+//   - it lands beside the surviving neighbour, not at the foot of the page
+//   - it reads unanchored, because a neighbour is a guess and the card must
+//     say so rather than point confidently at somebody else's words
+//   - it paints no highlight — an approximate range must not underline prose
+//     the person never selected
+//
+// and the opposite case, where the neighbours are gone too, must still take the
+// seat at the end rather than invent a position.
+//
+// Run with: node test/anchor-rewrite-fallback.test.js
+
+const fs = require('fs');
+const http = require('http');
+const os = require('os');
+const path = require('path');
+const { spawn } = require('child_process');
+const { requirePlaywrightOrSkip, reservePort } = require('./helpers/fixture-server');
+const { chromium } = requirePlaywrightOrSkip('anchor-rewrite-fallback.test.js');
+
+let pass = 0, fail = 0;
+function ok(name) { console.log(`  ✓ ${name}`); pass++; }
+function bad(name, error) { console.log(`  ✗ ${name}\n    ${error.message || error}`); fail++; }
+async function test(name, operation) {
+  try { await operation(); ok(name); } catch (error) { bad(name, error); }
+}
+function assert(condition, message) { if (!condition) throw new Error(message); }
+
+function waitForServer(port, timeout = 5_000) {
+  const deadline = Date.now() + timeout;
+  return new Promise((resolve, reject) => {
+    (function poll() {
+      const request = http.get({ host: '127.0.0.1', port, path: '/' }, (response) => {
+        response.resume(); resolve();
+      });
+      request.on('error', () => {
+        if (Date.now() >= deadline) reject(new Error('local anchor server did not start'));
+        else setTimeout(poll, 80);
+      });
+    })();
+  });
+}
+
+// Tall on purpose: the seat sits near the bottom, so a document that fits on one
+// screen cannot tell "landed beside its neighbour" apart from "took the seat".
+const filler = (tag) => Array.from({ length: 14 }, (_, i) =>
+  `<p>${tag} 段落 ${i + 1}：这一段只是把文档撑高，好让位置的差别量得出来。</p>`).join('\n');
+
+const V1 = `<!doctype html>
+<html lang="zh"><head><meta charset="utf-8"><title>rewrite</title></head><body>
+<h1>rewrite</h1>
+${filler('前')}
+<p id="keep-before">锚点前面这一句在两个版本里一字不改，是唯一的坐标。</p>
+<p id="target">这句话会在第二版里被整段改写，一个字都不留下。</p>
+<p id="keep-after">锚点后面这一句同样保持原样，可以从另一侧定位。</p>
+${filler('后')}
+<p id="orphan-before">孤儿评论的上文，第二版里会连它一起删掉。</p>
+<p id="orphan">这句连同它的邻居会在第二版里彻底消失。</p>
+<p id="orphan-after">孤儿评论的下文，第二版里也一并删掉。</p>
+</body></html>`;
+
+// Same document with the two commented sentences rewritten. The first one's
+// neighbours are untouched; the second one's neighbours go with it.
+const V2 = `<!doctype html>
+<html lang="zh"><head><meta charset="utf-8"><title>rewrite</title></head><body>
+<h1>rewrite</h1>
+${filler('前')}
+<p id="keep-before">锚点前面这一句在两个版本里一字不改，是唯一的坐标。</p>
+<p id="target">完全不同的措辞，与上一版没有任何共同的字。</p>
+<p id="keep-after">锚点后面这一句同样保持原样，可以从另一侧定位。</p>
+${filler('后')}
+<p>孤儿那三段整体换成了这一句，上下文一起没了。</p>
+</body></html>`;
+
+(async () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'tdoc-rewrite-'));
+  const slug = 'rewrite';
+  for (const [n, html] of [[1, V1], [2, V2]]) {
+    fs.mkdirSync(path.join(root, slug, `v${n}`), { recursive: true });
+    fs.writeFileSync(path.join(root, slug, `v${n}`, 'index.html'), html);
+  }
+  const now = new Date().toISOString();
+  fs.writeFileSync(path.join(root, slug, 'meta.json'), JSON.stringify({
+    slug, title: 'rewrite', versions: [{ n: 1, created: now }, { n: 2, created: now }],
+  }, null, 2));
+  const commentsFile = path.join(root, slug, 'comments.json');
+  fs.writeFileSync(commentsFile, '[]');
+
+  const port = await reservePort();
+  const server = spawn(process.execPath, [path.join(__dirname, '..', 'server', 'server.js')], {
+    env: { ...process.env, TDOC_DIR: root, TDOC_PORT: String(port), TDOC_E2E_USER: 'tester' },
+    stdio: ['ignore', 'ignore', 'inherit'],
+  });
+  const at = (n) => `http://127.0.0.1:${port}/d/${slug}/v/${n}`;
+  let browser;
+
+  // Pins arrive by postMessage; reading them is more honest than reading the
+  // rail, which only draws what is currently on screen.
+  async function pinsOn(url) {
+    const page = await browser.newPage({ viewport: { width: 1280, height: 900 } });
+    await page.addInitScript(() => {
+      window.__pins = [];
+      window.addEventListener('message', (event) => {
+        if (event.data && event.data.type === 'tdoc:pins' && event.data.pins) window.__pins = event.data.pins;
+      }, true);
+    });
+    try {
+      await page.goto(url, { waitUntil: 'networkidle' });
+      await page.waitForTimeout(1200);
+      const frame = page.frames().find((f) => f.url().includes('/frame'));
+      const geometry = await frame.evaluate(() => {
+        const box = (id) => {
+          const el = document.getElementById(id);
+          if (!el) return null;
+          const rect = el.getBoundingClientRect();
+          return Math.round(rect.top + (window.scrollY || 0));
+        };
+        const highlight = window.CSS && CSS.highlights && CSS.highlights.get('tdoc-anchor');
+        return {
+          docHeight: document.documentElement.scrollHeight,
+          keepBefore: box('keep-before'),
+          keepAfter: box('keep-after'),
+          highlighted: highlight ? highlight.size : 0,
+        };
+      });
+      return { pins: await page.evaluate(() => window.__pins), ...geometry };
+    } finally {
+      await page.close();
+    }
+  }
+
+  // Comment on a sentence the way a person does: select it, type, submit.
+  async function commentOn(elementId, body) {
+    const page = await browser.newPage({ viewport: { width: 1280, height: 900 } });
+    try {
+      await page.goto(at(1), { waitUntil: 'networkidle' });
+      await page.waitForTimeout(700);
+      const frame = page.frames().find((f) => f.url().includes('/frame'));
+      await frame.evaluate((id) => {
+        const node = document.getElementById(id).firstChild;
+        node.parentElement.scrollIntoView({ block: 'center' });
+        const range = document.createRange();
+        range.setStart(node, 0);
+        range.setEnd(node, node.textContent.length);
+        const selection = window.getSelection();
+        selection.removeAllRanges();
+        selection.addRange(range);
+        document.dispatchEvent(new MouseEvent('mouseup', { bubbles: true, view: window }));
+      }, elementId);
+      await page.waitForTimeout(400);
+      assert(await page.$('.tdoc-popup textarea'), `the composer never opened on #${elementId}`);
+      await page.fill('.tdoc-popup textarea', body);
+      await page.click('.tdoc-popup .submit');
+      await page.waitForTimeout(900);
+    } finally {
+      await page.close();
+    }
+  }
+
+  console.log('anchor rewrite fallback — a reworded sentence keeps its comments in place');
+  try {
+    await waitForServer(port);
+    browser = await chromium.launch({ headless: true });
+
+    await commentOn('target', 'this sentence gets rewritten');
+    await commentOn('orphan', 'this sentence and its neighbours vanish');
+    const saved = JSON.parse(fs.readFileSync(commentsFile, 'utf8'));
+    assert(saved.length === 2, `expected 2 saved comments, got ${saved.length}`);
+    const [rewritten, orphaned] = saved;
+
+    const v1 = await pinsOn(at(1));
+    await test('both comments anchor exactly on the version they were written on', () => {
+      const ids = v1.pins.map((p) => p.id);
+      assert(ids.includes(rewritten.id) && ids.includes(orphaned.id),
+        `v1 lost a pin: ${JSON.stringify(ids)}`);
+      const stillLost = v1.pins.filter((p) => p.lost).map((p) => p.id);
+      assert(!stillLost.length, `v1 should anchor both exactly, but ${JSON.stringify(stillLost)} read unanchored`);
+    });
+
+    const v2 = await pinsOn(at(2));
+    const seatY = Math.max(0, v2.docHeight - 160);
+    const pinOf = (id) => v2.pins.find((p) => p.id === id);
+
+    await test('a comment on a rewritten sentence lands beside its surviving neighbour', () => {
+      const pin = pinOf(rewritten.id);
+      assert(pin, 'the comment vanished from v2 entirely');
+      // Between the two untouched neighbours, give or take a line — not at the
+      // foot of the page, which is where every lost comment used to pile up.
+      const low = Math.min(v2.keepBefore, v2.keepAfter) - 80;
+      const high = Math.max(v2.keepBefore, v2.keepAfter) + 80;
+      assert(pin.docY >= low && pin.docY <= high,
+        `landed at ${pin.docY}, expected between ${low} and ${high} `
+        + `(#keep-before ${v2.keepBefore}, #keep-after ${v2.keepAfter}, seat ${seatY})`);
+      assert(Math.abs(pin.docY - seatY) > 100, `it took the seat at ${seatY} instead of the neighbourhood`);
+    });
+
+    await test('that comment reads unanchored, because a neighbour is a guess', () => {
+      assert(pinOf(rewritten.id).lost === true,
+        'the pin claims to be anchored — the card would offer no Re-anchor and show no dashed edge');
+    });
+
+    await test('an approximate spot paints no highlight over prose nobody selected', () => {
+      assert(v2.highlighted === 0,
+        `${v2.highlighted} range(s) highlighted in v2, but neither anchor's text survives`);
+    });
+
+    await test('a comment whose neighbours are gone too still takes the seat', () => {
+      const pin = pinOf(orphaned.id);
+      assert(pin, 'the orphaned comment vanished from v2 entirely');
+      assert(pin.lost === true, 'a seated comment must read unanchored');
+      assert(Math.abs(pin.docY - seatY) <= 8,
+        `expected the seat at ${seatY}, got ${pin.docY} — it guessed a position it cannot justify`);
+    });
+
+    await test('no comment is dropped at the top of the page', () => {
+      const stuck = v2.pins.filter((p) => p.docY <= 0).map((p) => p.id);
+      assert(!stuck.length,
+        `${JSON.stringify(stuck)} landed at y=0 — a match on a node with no layout, not a position`);
+    });
+  } finally {
+    if (browser) await browser.close();
+    try { server.kill('SIGTERM'); } catch (e) { /* already gone */ }
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+
+  console.log(`\n${pass} passed, ${fail} failed`);
+  process.exit(fail ? 1 : 0);
+})();


### PR DESCRIPTION
Republishing a document rewrites its prose, and the probe only ever searched
for the commented text itself. Once an author reworded a sentence, every
comment on it resolved to nothing and took the seat — so five comments spread
across a long document arrived stacked in one pile, which reads as "the
comments are gone" even though all of them were saved.

Resolution now has three layers:

1. **The text, exactly** — unchanged.
2. **The neighbourhood** — the longest surviving run of `context_before`'s tail
   or `context_after`'s head. The anchor already stored both; `findTextRange`
   returned `null` before it ever looked at them.
3. **A seat at the end** — for a comment whose neighbours are gone too.

Layer 2 is a guess and says so: the pin is flagged, so the card reads
unanchored and offers Re-anchor, and **no highlight is painted**. Underlining
prose the person never selected would be worse than not placing the comment.

### Measured on the document that showed the bug

`tdoc-onboarding-journey` v2 — six comments, previously five in one pile:

| | before | after |
|---|---|---|
| exact | 1 | 1 |
| beside a surviving neighbour | — | 4 |
| seated at the end | 5 | 1 |

The one that still takes a seat has five unique characters of context left, and
its other neighbour is SVG boilerplate (`fill:#555`) that repeats — any
placement would point at a random style block. `d-c2neyy5s` v10's two
context-less comments stay seated, as they should.

### Two details the real document forced

- **Land on the surviving context character, not the position just past it.**
  For a before-match that position is where the anchor used to begin, which
  after a rewrite is often the whitespace between two blocks — a text node with
  no layout, whose rect is 0×0, dropping the pin at the top of the page.
- **When even that cannot be measured, widen to the whole surviving run**,
  which spans rendered text by construction. Give up only when neither can be
  measured; a spot with no rect is not a spot.

### Tests

`test/anchor-rewrite-fallback.test.js` publishes v1, comments on a sentence,
publishes a v2 that rewords exactly that sentence, and asserts where the
comment went. Verified to fail on the pre-fix probe at the right assertion
(`landed at 1435, expected between 650 and 896`).

- offline suite: **76/76**
- `anchor-scenarios`: **10/10**
- `anchor-rewrite-fallback`: **6/6** (new)
- `browser-editing`: **18/18**
- `artifact-shell`: same 5 pre-existing failures as `main`, verified by running
  both in this environment

🤖 Generated with [Claude Code](https://claude.com/claude-code)