### PR TITLE
A first doc names public out loud, because access only tightens by omission

### DIFF
--- a/FIRST-DOC.md
+++ b/FIRST-DOC.md
@@ -68,7 +68,7 @@ The whole to-do list, in order. Nothing else is work:
    layer 3. Budget: fifteen seconds.
 2. Copy **the template below** into `v1/index.html`. Fill its numbers and its
    three lines. Do not restyle it, do not add a figure, do not add a section.
-3. Pick the slug (Step 6d) and publish privately (Step 7). Hand over the link.
+3. Pick the slug (Step 6d) and publish it open (Step 7). Hand over the link.
 
 That is the doc. **Steps 3 to 6 describe the shape the template already has**
 — they are the reasoning behind it, not a checklist to work through. Do not
@@ -690,7 +690,7 @@ Write it with the flag that marks it as this journey's doc, then publish it:
 bash "$SKILL_DIR/bin/tdoc-write" --first-doc --slug what-ai-knows-<name> \
   --title "What does AI know about <Name>?" --style <style> \
   --prompt "<the line the human pasted>" --html-file /tmp/what-ai-knows-<name>.html
-bash "$SKILL_DIR/bin/tdoc-publish" what-ai-knows-<name>
+bash "$SKILL_DIR/bin/tdoc-publish" --visibility public --history public what-ai-knows-<name>
 ```
 
 `--first-doc` is how tdoc.dev knows this is the doc the onboarding was waiting
@@ -698,11 +698,17 @@ for, whatever slug it ends up on — a second run, or a `-2` after a collision,
 takes over from the earlier one. Without the flag the journey can keep
 watching an older doc and never move.
 
-**No access flags.** A first doc publishes the way every other doc does:
-readable by anyone with the link, listed nowhere. Do not pass `--visibility`,
-`--history`, or `--allow-user` — a first doc that arrives locked cannot be
-shown to anybody, and the whole point of the link is that it works when they
-send it to someone.
+**Say `public` out loud.** A first doc that arrives locked cannot be shown to
+anybody, and the whole point of the link is that it works when they send it to
+someone. Passing nothing is not the same as passing `public`: access is sticky
+on both sides — the CLI leaves an existing `access` block in `meta.json` alone,
+and the worker carries the stored one forward when an upload names none — so a
+flagless publish over a doc an earlier run locked stays locked. That case is
+not rare; it is every re-run, and every `-2` after a slug collision. Name the
+policy and the doc is open whatever came before it.
+
+Never pass `--allow-user` here. An allow-list on a first doc is a restriction
+nobody asked for.
 
 Then say, in one line each:
 
@@ -737,6 +743,6 @@ first doc something a static tutorial never has — a reason to come back.
 - Do not comment on the person's life, mood, or circumstances. The subject is
   the work, not them.
 - Do not end on a `localhost` URL, and do not ask for permission before the
-  page exists. Publish it privately and let them open it up from there.
+  page exists. Publish it open and let closing it be their decision.
 - Do not build a fixture, a template, or a starter repo. This page is written
   fresh each time, by you, from this file.

--- a/SKILL.md
+++ b/SKILL.md
@@ -1170,6 +1170,11 @@ Remote storage holds optional `meta.access`:
 - **private**: the doc publisher (hosted `github_login`, or `TDOC_OWNER` on BYOK/legacy) + `allowed_users`. Gates `/d/.../v/N`, export, fork, `GET /api/comments`.
 - **history_visibility**: version picker visibility (new policies default owner-only / pure-publish).
 - Legacy meta without `access` stays world-readable + full history (back-compat).
+- **Access only ever tightens by omission.** A flag left out keeps what is
+  already stored — the CLI leaves an existing `meta.access` alone, and the
+  worker carries the stored block forward when an upload names none. A publish
+  that means to OPEN a doc must say so (`--visibility public`); this is why
+  FIRST-DOC.md names the policy instead of publishing flagless.
 - Initial publish can set access via `tdoc-publish --visibility|--history|--commenting|--allow-user`.
 - After publish, access must be mutable directly on remote storage (`PATCH /api/doc/access` with the upload token) without local `meta.json` or full HTML re-upload.
 - `/me` on hosted tdoc.dev lists the signed-in account's docs. On BYOK it lists the worker operator's docs. Remote write actions still use the upload token for CLI; the publisher's session cookie may mutate their own docs (CSP on every response).

--- a/bin/tdoc-publish
+++ b/bin/tdoc-publish
@@ -1416,6 +1416,13 @@ fi
 # JUL-31 access policy: merge flags into local meta.json so /api/upload
 # carries them. Defaults for a brand-new access block: unlisted + owner
 # history (pure publish). Existing access blocks keep unspecified fields.
+#
+# Access is sticky, deliberately: a flag left out never loosens what is already
+# there, here or on the worker (which carries a stored access block forward
+# when an upload names none). Silently flinging open a doc somebody locked is
+# the one bug this file must never have. The cost is that a publish meaning to
+# OPEN a doc has to say so — which is why FIRST-DOC.md names `public`
+# explicitly instead of relying on the flagless default.
 if [ -n "$VISIBILITY_FLAG" ] || [ -n "$HISTORY_FLAG" ] || [ -n "$COMMENTING_FLAG" ] || [ ${#ALLOW_USERS[@]} -gt 0 ]; then
   case "${VISIBILITY_FLAG:-}" in
     ''|public|unlisted|private) ;;
@@ -1429,11 +1436,11 @@ if [ -n "$VISIBILITY_FLAG" ] || [ -n "$HISTORY_FLAG" ] || [ -n "$COMMENTING_FLAG
     ''|owner|invited|signed_in|off) ;;
     *) echo "[tdoc] invalid --commenting '$COMMENTING_FLAG' (owner|invited|signed_in|off)" >&2; exit 1 ;;
   esac
-  # Written with node, not jq. FIRST-DOC.md step 7 makes the very first doc a
-  # `--visibility private --history owner` publish, so this block is on the
-  # hosted path for every new user — and #256 removed jq from that path
-  # precisely because macOS does not ship it. It was missed then because the
-  # test only checked inside the functions that changed.
+  # Written with node, not jq. FIRST-DOC.md step 7 publishes the very first doc
+  # `--visibility public --history public`, so this block is on the hosted path
+  # for every new user — and #256 removed jq from that path precisely because
+  # macOS does not ship it. It was missed then because the test only checked
+  # inside the functions that changed.
   ALLOW_JSON="$(printf '%s\n' "${ALLOW_USERS[@]:-}" | node -e '
     let s = "";
     process.stdin.on("data", (d) => { s += d; });

--- a/skills/tdoc/SKILL.md
+++ b/skills/tdoc/SKILL.md
@@ -1170,6 +1170,11 @@ Remote storage holds optional `meta.access`:
 - **private**: the doc publisher (hosted `github_login`, or `TDOC_OWNER` on BYOK/legacy) + `allowed_users`. Gates `/d/.../v/N`, export, fork, `GET /api/comments`.
 - **history_visibility**: version picker visibility (new policies default owner-only / pure-publish).
 - Legacy meta without `access` stays world-readable + full history (back-compat).
+- **Access only ever tightens by omission.** A flag left out keeps what is
+  already stored — the CLI leaves an existing `meta.access` alone, and the
+  worker carries the stored block forward when an upload names none. A publish
+  that means to OPEN a doc must say so (`--visibility public`); this is why
+  FIRST-DOC.md names the policy instead of publishing flagless.
 - Initial publish can set access via `tdoc-publish --visibility|--history|--commenting|--allow-user`.
 - After publish, access must be mutable directly on remote storage (`PATCH /api/doc/access` with the upload token) without local `meta.json` or full HTML re-upload.
 - `/me` on hosted tdoc.dev lists the signed-in account's docs. On BYOK it lists the worker operator's docs. Remote write actions still use the upload token for CLI; the publisher's session cookie may mutate their own docs (CSP on every response).

--- a/test/onboarding-journey.test.js
+++ b/test/onboarding-journey.test.js
@@ -117,7 +117,13 @@ t('the server stamps what the agent does: token, read, reply, publish', () => {
   assert(tdocNew.includes('--first-doc)  FIRST_DOC=1; shift ;;') && tdocNew.includes('out["origin"] = "first-doc"') && tdocNew.includes('meta.get("origin") == "first-doc"'), 'tdoc-write --first-doc marks the meta, and the mark survives later versions');
   const firstDocRecipe = read('FIRST-DOC.md');
   assert(firstDocRecipe.includes('bash "$SKILL_DIR/bin/tdoc-write" --first-doc --slug what-ai-knows-<name>'), 'FIRST-DOC.md tells the agent to mark it');
-  assert(firstDocRecipe.includes('bash "$SKILL_DIR/bin/tdoc-publish" what-ai-knows-<name>') && !/tdoc-publish --visibility private --history owner/.test(firstDocRecipe), 'the first doc publishes with no access flags — a locked first doc cannot be shown to anyone');
+  // Provably public, not public-by-default: access is sticky on both sides, so
+  // a flagless publish over a doc an earlier run locked stays locked.
+  assert(firstDocRecipe.includes('bash "$SKILL_DIR/bin/tdoc-publish" --visibility public --history public what-ai-knows-<name>'), 'the first doc names public out loud');
+  assert(!/private/.test(firstDocRecipe.slice(firstDocRecipe.indexOf('## Step 7'), firstDocRecipe.indexOf('## If there is no history')).replace('`tdoc-publish --visibility private <slug>` makes it theirs alone', '')), 'step 7 mentions private only as the way to lock it');
+  assert(!/publish (it )?privately/i.test(firstDocRecipe), 'and no leftover instruction to publish privately');
+  assert(!/--visibility private --history owner/.test(read('bin/tdoc-publish')), 'the CLI comment no longer claims first docs publish private');
+  assert(read('SKILL.md').includes('**Access only ever tightens by omission.**'), 'the access policy says why a publish that opens a doc must say so');
   assert(server.includes('function isFirstDocProductMeta(meta)') && server.includes('function adoptFirstDocLocal(slug)') && server.includes('if (marked && rec.first_doc !== marked.slug && !rec.shared) {'), 'the local twin adopts the marked doc too');
   assert(upload.indexOf("'published_first'") > upload.indexOf("productEvent(env, 'publish_succeeded'"), 'stamps happen after the write succeeded, never before');
   const post = worker.slice(worker.indexOf("if (p === '/api/comments' && method === 'POST')"), worker.indexOf("if (p === '/api/comments' && method === 'PATCH')"));


### PR DESCRIPTION
Refs #487. Follow-up to #503, which was half a fix.

## The bug #503 left

#503 removed the access flags from FIRST-DOC.md step 7, on the reading that flagless publish means open. That holds for a doc that has never been published, and only for that doc.

Access is sticky on **both** sides:

- `bin/tdoc-publish` gates its entire access-merge block on at least one flag being present. No flags → the block never runs → an existing `access` in `meta.json` is uploaded verbatim.
- the worker's upload path does the same: `if (!incoming.access && prev && prev.access) incoming.access = prev.access;`

So a flagless publish over a doc an earlier run locked **stays locked**. That is not an edge case — it is every re-run of FIRST-DOC, and every `-2` after a slug collision, which is exactly the population most likely to hit it.

## The fix

Step 7 publishes `--visibility public --history public`. Explicit, so the result does not depend on what came before it.

**The stickiness stays.** A flag left out must never loosen what is already stored — silently opening a doc somebody deliberately locked is the one bug the publish path cannot have. The rule is now written down where each half of it lives (`bin/tdoc-publish` and SKILL.md's access-policy section), together with its consequence: a publish that means to *open* a doc has to say so.

Also fixed, both stale since #503: the step summary's "publish privately (Step 7)", the Do-not list's "Publish it privately and let them open it up from there", and the CLI comment claiming first docs publish `--visibility private --history owner`.

## Verified

`npm test`: 78 suites green, with assertions that step 7 names public, that no "publish privately" instruction survives anywhere in the recipe, and that the access-policy note exists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)