### PR TITLE
artifact-shell is green again, and a suite no longer poisons the next one

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,7 @@ telemetry/supabase/.temp/
 marketing/
 worker/wrangler.local.toml
 worker/.dev.vars
+
+# Gated browser suites write journey scratch into the fixture root.
+test/fixtures/tdocs/.onboarding.json
+test/fixtures/tdocs/.agent-read.json

--- a/test/artifact-shell.test.js
+++ b/test/artifact-shell.test.js
@@ -301,10 +301,12 @@ const SLUG = 'hostile-body-css';
       await page.waitForSelector('.tdoc-margin-comment .tdoc-reply-toggle', { timeout: 2000 });
       await page.click('.tdoc-margin-comment .tdoc-reply-toggle');
       await page.waitForSelector('.tdoc-margin-comment .tdoc-reply-form.open textarea', { timeout: 2000 });
-      await openCardMenu(page, '.tdoc-margin-comment');
-      const hasDelete = await page.evaluate(() => !!document.querySelector('.ui-menu-popup .del'));
-      await closeCardMenu(page);
-      if (!hasDelete) throw new Error('card missing delete control');
+      // No menu assertion here. Every control in the ⋯ menu is gated on the
+      // viewer being somebody — author, owner, or both — and this rig browses
+      // anonymously, so the trigger correctly never renders. Delete is proved
+      // where it can be: the authed block below.
+      const menu = await page.evaluate(() => !!document.querySelector('.tdoc-margin-comment [aria-label="More actions"]'));
+      if (menu) throw new Error('an anonymous viewer was offered the card menu');
     });
 
     await t('a submitted reply closes its composer and lands visibly in the thread (#349)', async () => {
@@ -536,7 +538,12 @@ const SLUG = 'hostile-body-css';
 
     await t('agent comment: pin shows the agent mark, card shows a resolved chip', async () => {
       await page.setViewportSize({ width: 1400, height: 900 });
+      // c_fixture_3 is resolved, and resolved threads are out of the margin
+      // until the reader asks for them (the switch defaults off, #617). Ask
+      // through the same key the switch writes, before the shell reads it.
       await page.goto(shellUrl, { waitUntil: 'networkidle' });
+      await page.evaluate(() => localStorage.setItem('tdoc-show-resolved', '1'));
+      await page.reload({ waitUntil: 'networkidle' });
       await page.waitForSelector('.tdoc-pin[data-id="c_fixture_3"]', { timeout: 3000 });
       // the agent's pin carries the resolved state + an agent logo (not an anon dot)
       const pinInfo = await page.evaluate(() => {
@@ -550,6 +557,7 @@ const SLUG = 'hostile-body-css';
       const chip = await page.$eval('.tdoc-margin-comment .tdoc-resolved-chip', el => el.textContent).catch(() => null);
       if (!chip || !/fixed/.test(chip)) throw new Error('card missing resolved chip: ' + chip);
       const agentAuthor = await page.evaluate(() => !!document.querySelector('.tdoc-margin-comment .author.tdoc-agent-author img'));
+      await page.evaluate(() => localStorage.removeItem('tdoc-show-resolved'));
       if (!agentAuthor) throw new Error('card did not render the agent author with a logo');
     });
 
@@ -571,53 +579,6 @@ const SLUG = 'hostile-body-css';
       // picking a row opens that comment's card
       await page.click('.tdoc-cluster-pop.open .tdoc-cluster-row[data-id="c_fixture_4"]');
       await page.waitForSelector('.tdoc-margin-comment[data-comment-id="c_fixture_4"]', { timeout: 2000 });
-    });
-
-    await t('re-anchor: "move anchor" rebinds a comment to a new frame selection', async () => {
-      const snapshot = fs.readFileSync(COMMENTS_FIXTURE, 'utf8');
-      try {
-        await page.setViewportSize({ width: 1400, height: 900 });
-        await page.goto(shellUrl, { waitUntil: 'networkidle' });
-        await page.waitForSelector('.tdoc-pin[data-id="c_fixture_1"]', { timeout: 3000 });
-        await page.click('.tdoc-pin[data-id="c_fixture_1"]');
-        await page.waitForSelector('.tdoc-margin-comment.active .tdoc-reanchor-btn', { timeout: 2000 });
-        // the "move anchor" affordance is visible on the active card
-        const btnVisible = await page.evaluate(() => {
-          const b = document.querySelector('.tdoc-margin-comment.active .tdoc-reanchor-btn');
-          return b && getComputedStyle(b).display !== 'none';
-        });
-        if (!btnVisible) throw new Error('move-anchor button not visible on active card');
-        await page.click('.tdoc-margin-comment.active .tdoc-reanchor-btn');
-        // banner appears; body enters re-anchoring mode
-        const remode = await page.evaluate(() => document.body.classList.contains('tdoc-reanchoring') &&
-          getComputedStyle(document.querySelector('.tdoc-reanchor-banner')).display !== 'none');
-        if (!remode) throw new Error('re-anchor banner/mode did not engage');
-        // select para-2 in the frame → shell PATCHes the anchor instead of opening a composer
-        const frame = page.frames().find(f => f.url().includes(SLUG) && f !== page.mainFrame());
-        await frame.evaluate(() => {
-          const p = document.getElementById('para-2');
-          const r = document.createRange(); r.selectNodeContents(p);
-          const s = window.getSelection(); s.removeAllRanges(); s.addRange(r);
-          const rect = p.getBoundingClientRect();
-          document.dispatchEvent(new MouseEvent('mouseup', { clientX: rect.left + 20, clientY: rect.top + 8, bubbles: true, cancelable: true, view: window, button: 0 }));
-        });
-        // wait for the PATCH to land in the fixture
-        let anchored = null;
-        for (let i = 0; i < 40; i++) {
-          try {
-            const parsed = JSON.parse(fs.readFileSync(COMMENTS_FIXTURE, 'utf8'));
-            const c = parsed.find(x => x.id === 'c_fixture_1');
-            if (c && c.anchor && /second paragraph/.test(c.anchor.text || '')) { anchored = c; break; }
-          } catch (e) { /* server mid-write; retry */ }
-          await page.waitForTimeout(50);
-        }
-        if (!anchored) throw new Error('comment was not re-anchored to the new selection');
-        // re-anchoring exits the mode and does NOT open a composer
-        const composerOpen = await page.evaluate(() => !!document.querySelector('.tdoc-popup'));
-        if (composerOpen) throw new Error('re-anchor selection wrongly opened the composer');
-      } finally {
-        fs.writeFileSync(COMMENTS_FIXTURE, snapshot);
-      }
     });
 
     await t('?comment= deep-link opens the target comment card on load', async () => {
@@ -811,6 +772,10 @@ const SLUG = 'hostile-body-css';
     });
 
     await t('dark mode keeps text highlights visibly painted', async () => {
+      // The narrow tests above leave the window at phone width, and the theme
+      // control is in the overflow menu there. Come back to the wide bar.
+      await page.setViewportSize({ width: 1400, height: 900 });
+      await page.goto(shellUrl, { waitUntil: 'networkidle' });
       await page.evaluate(() => localStorage.setItem('tdoc-theme', 'light'));
       await page.reload({ waitUntil: 'networkidle' });
       await page.click('#tdoc-theme-btn');
@@ -963,6 +928,55 @@ const SLUG = 'hostile-body-css';
           await closeCardMenu(page);
           const shouty = labels.filter((label) => label && label[0] !== label[0].toUpperCase());
           if (shouty.length) throw new Error(`the menu is not written one way: ${JSON.stringify(labels)}`);
+        });
+
+        await t('re-anchor: "move anchor" rebinds a comment to a new frame selection', async () => {
+          const snapshot = fs.readFileSync(COMMENTS_FIXTURE, 'utf8');
+          try {
+            await page.setViewportSize({ width: 1400, height: 900 });
+            await page.goto(authedUrl, { waitUntil: 'networkidle' });
+            await page.waitForSelector('.tdoc-pin[data-id="c_fixture_1"]', { timeout: 3000 });
+            await page.click('.tdoc-pin[data-id="c_fixture_1"]');
+            await page.waitForSelector('.tdoc-margin-comment.active', { timeout: 2000 });
+            // Move anchor lives in the card's ⋯ menu since #432, and a menu renders
+            // through a portal — it is not a descendant of the card.
+            await openCardMenu(page, '.tdoc-margin-comment.active');
+            const btnVisible = await page.evaluate(() => {
+              const b = document.querySelector('.ui-menu-popup .tdoc-reanchor-btn');
+              return !!b && getComputedStyle(b).display !== 'none';
+            });
+            if (!btnVisible) throw new Error('move-anchor not offered in the card menu');
+            await page.click('.ui-menu-popup .tdoc-reanchor-btn');
+            // banner appears; body enters re-anchoring mode
+            const remode = await page.evaluate(() => document.body.classList.contains('tdoc-reanchoring') &&
+              getComputedStyle(document.querySelector('.tdoc-reanchor-banner')).display !== 'none');
+            if (!remode) throw new Error('re-anchor banner/mode did not engage');
+            // select para-2 in the frame → shell PATCHes the anchor instead of opening a composer
+            const frame = page.frames().find(f => f.url().includes(SLUG) && f !== page.mainFrame());
+            await frame.evaluate(() => {
+              const p = document.getElementById('para-2');
+              const r = document.createRange(); r.selectNodeContents(p);
+              const s = window.getSelection(); s.removeAllRanges(); s.addRange(r);
+              const rect = p.getBoundingClientRect();
+              document.dispatchEvent(new MouseEvent('mouseup', { clientX: rect.left + 20, clientY: rect.top + 8, bubbles: true, cancelable: true, view: window, button: 0 }));
+            });
+            // wait for the PATCH to land in the fixture
+            let anchored = null;
+            for (let i = 0; i < 40; i++) {
+              try {
+                const parsed = JSON.parse(fs.readFileSync(COMMENTS_FIXTURE, 'utf8'));
+                const c = parsed.find(x => x.id === 'c_fixture_1');
+                if (c && c.anchor && /second paragraph/.test(c.anchor.text || '')) { anchored = c; break; }
+              } catch (e) { /* server mid-write; retry */ }
+              await page.waitForTimeout(50);
+            }
+            if (!anchored) throw new Error('comment was not re-anchored to the new selection');
+            // re-anchoring exits the mode and does NOT open a composer
+            const composerOpen = await page.evaluate(() => !!document.querySelector('.tdoc-popup'));
+            if (composerOpen) throw new Error('re-anchor selection wrongly opened the composer');
+          } finally {
+            fs.writeFileSync(COMMENTS_FIXTURE, snapshot);
+          }
         });
 
         await t('editing rewrites the comment in place and marks it edited (#349)', async () => {

--- a/test/fixtures/tdocs/hostile-body-css/v1/index.html
+++ b/test/fixtures/tdocs/hostile-body-css/v1/index.html
@@ -30,7 +30,7 @@
   <canvas id="art-canvas" width="240" height="140" style="display:block;width:240px;height:140px;background:#334">A commentable artifact (canvas) for element-comment tests.</canvas>
   <p><a id="internal-link" href="/d/hostile-body-css/v/1">An internal link that must navigate the top page, not the frame.</a></p>
   <div id="scroll-wrap" style="overflow-x:auto;width:100%">
-    <svg id="wide-graph" width="2400" height="120" style="display:block" role="img" aria-label="wide graph">
+    <svg id="wide-graph" width="2400" height="120" style="display:block;width:2400px;min-width:2400px;max-width:none" role="img" aria-label="wide graph">
       <rect x="0" y="0" width="2400" height="120" fill="#265"></rect>
       <text x="20" y="60" fill="#fff">A 2400px-wide graph inside a horizontal scroll container — the hover outline must clip to the container.</text>
     </svg>

--- a/test/helpers/fixture-server.js
+++ b/test/helpers/fixture-server.js
@@ -168,6 +168,15 @@ async function resolveTarget({ port, e2eUser } = {}) {
   // the whole browser suite at somebody else's server.
   if (port === undefined) port = await reservePort();
   else await assertPortFree(port);
+  // The server writes journey state into the fixture root and never clears it,
+  // so one suite's run changes what the next one sees: a stamped `commented`
+  // sends the onboarding wizard to its welcome-back screen, and a suite that
+  // expects the paste step waits for markup that will never come. Clear the
+  // scratch files every boot so each run starts where the committed fixture
+  // says it starts.
+  for (const scratch of ['.onboarding.json', '.agent-read.json']) {
+    try { fs.rmSync(path.join(FIXTURE_ROOT, scratch), { force: true }); } catch {}
+  }
   // Default: boot the local server against the committed fixture.
   const serverPath = path.join(__dirname, '..', '..', 'server', 'server.js');
   const child = spawn('node', [serverPath], {


### PR DESCRIPTION
Fixes #512.

`artifact-shell` failed 6 of 43 on main. None of them was a broken product — five were the suite looking where the shell stopped putting things, and one was the fixture no longer meeting its own premise. A seventh problem showed up while fixing them, and it is the interesting one.

## The five drifts

| test | why it failed | fix |
|---|---|---|
| comment card has a working Reply box | asked for **Delete** in the card's ⋯ menu; every control in that menu is identity-gated and this rig browses anonymously, so the trigger correctly never renders | assert what fits an anonymous reader — *no* menu is offered. Delete stays proved in the authed block. |
| agent comment: pin + resolved chip | `c_fixture_3` is resolved, and resolved threads left the margin when the reveal switch landed (defaults off) | ask for them first, then put the key back |
| re-anchor: move anchor | same menu, same gate — and not a card descendant since #432 | moved into the authed block; opens the menu |
| dark mode keeps highlights painted | the narrow tests above leave the window at phone width, where the theme control is in the overflow menu | come back to the wide bar first |
| hover outline clips to its scroll container | the reading template makes svg fluid, so the fixture's 2400px graph rendered at container width and the overflow being measured was gone | fixture pins the width |

## The sixth: one suite poisoned the next

While verifying, `ui.test.js` — green when #511 merged, unchanged since — went red waiting for the paste step's terminal.

The local server writes journey state into the fixture root (`.onboarding.json`) and nothing ever cleared it. `artifact-shell` posts comments, which stamps `commented`. On the next run `stepFromRecord` returns `sendback`, so the wizard opens on its **welcome-back** screen and the paste-step markup never appears.

So the suites' results depended on what ran before them. `resolveTarget` now clears that scratch on every boot, and both scratch files are gitignored.

Verified in the order that used to fail: `artifact-shell` then `ui` — 43/0 then 12/0.

## All gated suites

| suite | result |
|---|---|
| artifact-shell | 43 / 0 |
| ui | 12 / 0 |
| responsive | 32 / 0 (4 published-only skips) |
| browser-editing | 18 / 0 |
| anchor-scenarios | 10 / 0 |
| csp-xss | 7 / 0 |

`npm test`: 78 offline suites green.

Worth doing next, and out of scope here: these suites still run nowhere. Issue #512 suggests a schedule rather than per-PR, since they need a browser.

🤖 Generated with [Claude Code](https://claude.com/claude-code)