### PR TITLE
The validator sees the rule after an @import, and dark rules fail

### DIFF
--- a/bin/tdoc-validate-template
+++ b/bin/tdoc-validate-template
@@ -159,13 +159,29 @@ STYLE_ACCENTS = {
 }
 
 
+def _after_at_rule_prelude(selector_group):
+    """The selector part of a naive `[^{}]+` match, with any statement at-rule
+    in front of it removed.
+
+    A selector can never contain `;`, but a statement at-rule (`@import`,
+    `@charset`) ends at one and leaves no block behind. The rule that follows
+    it therefore lands in the same `[^{}]+` run as the at-rule, and a caller
+    that judges the run by its first character reads the whole thing as one
+    `@`-prefixed selector and skips it -- silently taking the following rule
+    with it. Keeping only what follows the last `;` leaves an ordinary
+    selector to judge, so one `@import` line can no longer hide the rule
+    after it from every check in this file.
+    """
+    return selector_group.rsplit(";", 1)[-1]
+
+
 def _css_rules(blocks):
     """[css text] -> {selector: {prop: value}}, comments stripped."""
     out = {}
     for css in blocks:
         css = re.sub(r"/\*.*?\*/", "", css, flags=re.S)
         for m in re.finditer(r"([^{}]+)\{([^}]*)\}", css):
-            sel = " ".join(m.group(1).split())
+            sel = " ".join(_after_at_rule_prelude(m.group(1)).split())
             if not sel:
                 continue
             props = out.setdefault(sel, {})
@@ -178,6 +194,96 @@ def _css_rules(blocks):
 
 def _norm(v):
     return (v or "").replace(" ", "").replace('"', "'").lower()
+
+
+_NAMED_GROUNDS = {
+    "black": (0, 0, 0), "white": (255, 255, 255),
+}
+
+
+def _rgb(value):
+    """(r, g, b) for a colour this file can read statically, else None.
+
+    `var(--x)` and anything else that only a renderer can resolve returns None,
+    and the caller says nothing rather than guessing.
+    """
+    v = (value or "").strip().lower()
+    if v in _NAMED_GROUNDS:
+        return _NAMED_GROUNDS[v]
+    m = re.match(r"#([0-9a-f]{3})$", v)
+    if m:
+        return tuple(int(c * 2, 16) for c in m.group(1))
+    m = re.match(r"#([0-9a-f]{6})$", v)
+    if m:
+        h = m.group(1)
+        return tuple(int(h[i:i + 2], 16) for i in (0, 2, 4))
+    m = re.match(r"rgba?\(\s*([0-9]{1,3})\s*,\s*([0-9]{1,3})\s*,\s*([0-9]{1,3})", v)
+    if m:
+        return tuple(int(g) for g in m.groups())
+    return None
+
+
+def _is_dark(value):
+    """True when a colour is dark enough that the page was authored dark."""
+    rgb = _rgb(value)
+    if rgb is None:
+        return False
+    r, g, b = (c / 255 for c in rgb)
+    # Rec. 601 luma is enough to separate a dark ground from a light one; the
+    # decision here is not a contrast ratio, only which half of the range the
+    # author painted in.
+    return (0.299 * r + 0.587 * g + 0.114 * b) < 0.5
+
+
+DARK_THEME_SELECTOR = re.compile(
+    r"""\[\s*data-tdoc-theme\s*=\s*['"]?dark['"]?\s*\]""", re.I
+)
+PREFERS_DARK = re.compile(
+    r"prefers-color-scheme\s*:\s*dark", re.I
+)
+
+
+def check_dark_rules(styles):
+    """A document may not write dark rules at all -- it can only write light.
+
+    tdoc has no per-document dark palette. Dark mode is a whole-page
+    `filter: invert(1) hue-rotate(180deg)` that the frame applies over whatever
+    the document painted, so a hand-built dark rule is inverted along with
+    everything else and renders *light* in dark mode -- the exact opposite of
+    what its author asked for. `authoring/style/technical.md` states the rule
+    and records the bug: a page that shipped its own dark palette came out
+    white. This is a rendering fault the reader sees, not a matter of taste,
+    so it is an error rather than a note.
+    """
+    errors = []
+    for raw_css in styles:
+        css = re.sub(r"/\*.*?\*/", "", raw_css, flags=re.S)
+        if PREFERS_DARK.search(css):
+            errors.append(
+                "a '@media (prefers-color-scheme: dark)' rule is inverted along with "
+                "the rest of the page, so it renders light in dark mode; author the "
+                "light look only and let the frame invert it"
+            )
+        if DARK_THEME_SELECTOR.search(css):
+            errors.append(
+                "a rule targeting 'html[data-tdoc-theme=\"dark\"]' fights the frame's "
+                "own dark-mode invert and renders light; author the light look only"
+            )
+    # A dark ground with no dark selector anywhere is the same mistake wearing
+    # plain clothes: the document simply painted itself dark. The frame inverts
+    # it to a light page, which is why this is caught by the value and not by a
+    # selector. A ground given as `var(--x)` is left alone -- only a renderer
+    # can resolve it, and guessing would be worse than staying quiet.
+    body_ground = _css_rules(styles).get("body", {})
+    ground = body_ground.get("background-color") or body_ground.get("background")
+    if ground and _is_dark(ground.split()[0] if ground.split() else ground):
+        errors.append(
+            f"body is painted dark ({ground}); tdoc documents are authored light and "
+            "the frame inverts them for dark mode, so a dark ground renders light "
+            "there. Author the light look only"
+        )
+    # One document says this once however many blocks repeat it.
+    return sorted(set(errors))
 
 
 def check_style_contract(styles, style):
@@ -678,13 +784,16 @@ def validate(path: Path, *, style: str, custom_template: bool) -> tuple[list[str
         css = re.sub(r"/\*.*?\*/", "", raw_css, flags=re.S)
         for match in re.finditer(r"([^{}]+)\{([^{}]*)\}", css, flags=re.S):
             selector_group, declarations_raw = match.groups()
+            selector_group = _after_at_rule_prelude(selector_group)
             if selector_group.strip().startswith("@"):
                 continue
             declarations = split_declarations(declarations_raw)
             for selector in selector_group.split(","):
                 normalized = re.sub(r"\s+", " ", selector.strip().lower())
                 if normalized == "body":
-                    allowed = all(prop in {"background", "background-color"} for prop, _ in declarations)
+                    declares_background = any(
+                        prop in {"background", "background-color"} for prop, _ in declarations
+                    )
                     white = any(
                         prop in {"background", "background-color"}
                         and compact_css_value(value) in HOUSE_BACKGROUNDS[style]
@@ -700,7 +809,24 @@ def validate(path: Path, *, style: str, custom_template: bool) -> tuple[list[str
                         for prop, value in declarations
                     ):
                         body_background = True
-                    if not (allowed and white):
+                    # Name the property that actually broke the rule. One
+                    # message for both halves of that test reported a
+                    # background mismatch for a body that set a correct
+                    # background and one extra property, which reads as a bug in
+                    # this file rather than a fault in the document -- so the
+                    # author stops believing the validator and works around it.
+                    extra = sorted({prop for prop, _ in declarations}
+                                   - {"background", "background-color"})
+                    if extra:
+                        notes.append(
+                            f"'body' sets {', '.join(extra)} - under the '{style}' house style "
+                            "body carries the page ground and nothing else; move the rest to "
+                            "'.wrap' or a class of its own"
+                        )
+                    # A body that names no background at all is already the
+                    # structural error below; calling that a house-style
+                    # mismatch as well would name the wrong fault twice.
+                    if declares_background and not white:
                         notes.append(f"body background does not match the '{style}' house style")
                 elif normalized in {".wrap", ".content", ".container", "main", "article"}:
                     forbidden = sorted({prop for prop, _ in declarations}.intersection(ROOT_LAYOUT_PROPERTIES))
@@ -729,6 +855,7 @@ def validate(path: Path, *, style: str, custom_template: bool) -> tuple[list[str
     # every paragraph around it — a defect the reader sees, not a house-style
     # preference, and visuals.md documents it as a failure.
     errors.extend(inset)
+    errors.extend(check_dark_rules(parser.styles))
     notes.extend(check_style_accent(raw, style))
     # The cell reset is a house-style rule: tdoc tables are ruled, never filled.
     # A caller bringing its own design system returned above with the other

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -169,6 +169,81 @@ t('chat-driven new and edit flows require host validation', () => {
 // `max-width: 100% !important`, so a figure that states no width of its own
 // looks right where tdoc serves it and runs off the right edge anywhere else,
 // with the scroll wrapper hiding the overflow rather than announcing it.
+// A statement at-rule ends at its semicolon and leaves no block behind, so the
+// rule written after it shares one `[^{}]+` run with it. The validator judged
+// that run by its first character, read the whole thing as one `@`-prefixed
+// selector, and skipped it — carrying the following rule out of every check
+// with it. One `@import` line was therefore a general-purpose way to hide any
+// CSS from the validator, which would have let a document past whatever new
+// rules get added here later.
+// tdoc has no per-document dark palette: the frame paints dark by inverting the
+// whole page. A document that writes its own dark rule gets that rule inverted
+// too, so its "dark mode" renders light -- the failure authoring/style/
+// technical.md records. The validator used to let all three spellings through
+// as taste notes, which is how a hand-built dark palette reached a real page.
+t('a document may not write its own dark rules', () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'tdoc-dark-'));
+  const write = (css) => {
+    const f = path.join(dir, 'd' + Math.abs(css.length * 13) + '.html');
+    fs.writeFileSync(f, `<!doctype html><html><head>
+      <meta name="viewport" content="width=device-width, initial-scale=1">
+      <style>${css}</style>
+      </head><body><div class="wrap"><h1>T</h1><p>Body copy.</p></div></body></html>`);
+    return spawnSync(path.join(BIN, 'tdoc-validate-template'), [f], { encoding: 'utf8' });
+  };
+  try {
+    const media = write('body{background:#fff} @media (prefers-color-scheme:dark){body{background:#0d0d0c}}');
+    assert(media.status !== 0, 'a prefers-color-scheme:dark block must be rejected');
+
+    const selector = write('body{background:#fff} html[data-tdoc-theme="dark"] body{background:#111}');
+    assert(selector.status !== 0, 'a dark-theme selector must be rejected');
+
+    // The same mistake with no dark selector at all: the page simply painted
+    // itself dark, and the invert will turn it light.
+    const ground = write('body{background:#0d0d0c}');
+    assert(ground.status !== 0, 'a dark body ground must be rejected');
+
+    // Authoring light is the whole contract, and must still pass.
+    const light = write('body{background:#fff}');
+    assert(light.status === 0, `a light document must pass: ${light.stderr}`);
+
+    // Only the dark half is forbidden -- a light media query is not a dark rule.
+    const lightMedia = write('body{background:#fff} @media (prefers-color-scheme:light){body{background:#fff}}');
+    assert(lightMedia.status === 0, `a light media query must pass: ${lightMedia.stderr}`);
+
+    // A ground only a renderer can resolve is left alone rather than guessed at.
+    const varGround = write(':root{--bg:#fff} body{background:var(--bg)}');
+    assert(varGround.status === 0, `a var() ground must not be guessed at: ${varGround.stderr}`);
+  } finally { fs.rmSync(dir, { recursive: true, force: true }); }
+});
+
+t('a statement at-rule does not hide the rule written after it', () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'tdoc-atrule-'));
+  const write = (css) => {
+    const f = path.join(dir, 'a' + Math.abs(css.length * 17) + '.html');
+    fs.writeFileSync(f, `<!doctype html><html><head>
+      <meta name="viewport" content="width=device-width, initial-scale=1">
+      <style>body { background: #fff; } ${css}</style>
+      </head><body><div class="wrap"><h1>T</h1><p>Body copy.</p></div></body></html>`);
+    return spawnSync(path.join(BIN, 'tdoc-validate-template'), [f], { encoding: 'utf8' });
+  };
+  const RE = /overrides reader layout/;
+  try {
+    const plain = write('.wrap { padding:99px }');
+    assert(RE.test(plain.stdout + plain.stderr),
+      'a .wrap padding override must be rejected on its own');
+
+    const hidden = write('@import url("x.css"); .wrap { padding:99px }');
+    assert(RE.test(hidden.stdout + hidden.stderr),
+      'an @import in front of it must not hide the same override');
+
+    // The at-rule itself is still not a selector to judge.
+    const only = write('@import url("x.css");');
+    assert(!RE.test(only.stdout + only.stderr),
+      'an @import on its own declares no reader-layout override');
+  } finally { fs.rmSync(dir, { recursive: true, force: true }); }
+});
+
 t('a figure with a pixel width but no CSS width is rejected', () => {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'tdoc-fig-'));
   const write = (css, body) => {


### PR DESCRIPTION
Three faults in `bin/tdoc-validate-template`, ordered by how much they matter. The first one is why the other two are worth fixing now: until it is closed, any rule added to this file can be stepped around with a single line.

## 1. One `@import` hid the rule after it from every check

A statement at-rule ends at its semicolon and leaves no block behind, so the rule written after it lands in the same `[^{}]+` run. Two of the three CSS loops judged that run by its first character, read the whole thing as one `@`-prefixed selector, and skipped it — taking the following rule with it.

```css
.wrap{padding:99px}                          /* error, as it should be */
@import url("x.css"); .wrap{padding:99px}    /* silently passed */
```

So one `@import` line was a general-purpose way to hide CSS from this file, including from whatever checks get added to it later. The fix keeps only what follows the last `;`, which leaves an ordinary selector to judge. The third loop already read `_unconditional_css`, which delimits at-rules properly, and was never affected.

**`_unconditional_css` is deliberately left alone.** It strips at-rule blocks on purpose — a size inside `@media` is a different layout, not a second size in the same one — so making the parser recurse into at-rules generally would break responsive layouts that are entitled to differ.

## 2. An error that named the wrong property

`body{background:#fff;margin:0}` reported *"body background does not match the house style"* — but `#fff` **is** the house ground, and `margin` is the fault. One message stood for both halves of `allowed and white`, so it named a property that was correct. That reads as a bug in the validator rather than a fault in the document, and it is how an author learns to work around the tool instead of the rule. It now names the properties that actually broke it.

A body that sets no background at all is left to the structural error below it, rather than called a house-style mismatch as well.

## 3. Dark rules were only taste notes

tdoc has no per-document dark palette. The frame paints dark with `filter: invert(1) hue-rotate(180deg)` over whatever the document painted, so a hand-built dark rule is inverted along with everything else and renders **light** — the failure `authoring/style/technical.md` records against a page that shipped its own dark palette and came out white. The reader sees it, so it is an error, not taste.

All three spellings are caught:

- `@media (prefers-color-scheme: dark){…}`
- `html[data-tdoc-theme="dark"] …`
- a body simply painted dark, which wears no dark marker at all

A ground given as `var(--x)` is left alone — only a renderer can resolve it, and guessing would be worse than staying quiet. That case is what a render-time check would still be needed for.

## Checking

Ran old and new against **every HTML document in the repo (59)**:

- the parsing fix on its own changes **no verdict on any of them**
- with all three fixes, the only verdict that changes is `test/fixtures/tdocs/copy-doc/v1/index.html`

That fixture carries a real `html[data-tdoc-theme="dark"] body{background:#111}` rule, so it is an instance of the mistake rather than a false positive. **I left it as it is** — it is not a validator fixture, and its tests only read the theme attribute — but it should probably be fixed in its own change.

New tests cover all of it; each new assertion was checked to fail on `main` and pass here.

The full suite passes: `npm test` — 80 suites green, locally and on CI. The 8 playwright/network suites are gated off in both, as usual.

`test/fixtures/tdocs/copy-doc/v1/index.html` is used by two of those gated suites, and neither invokes the validator, so this change does not affect them either way. The dark rule in that fixture is vestigial: the test that cares about dark reads the `data-tdoc-default-theme="dark"` attribute, not the CSS. Read, not run — playwright is not installed here.

Found by @Ops, who hit the dark-mode bug while authoring and then traced it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
