### PR TITLE
A reply with no words is not a reply

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -281,6 +281,19 @@ function localTombstone(record) {
   return out;
 }
 
+// A record with no words. Deleting takes the words away; a caller that posted
+// only whitespace never supplied any. Both leave the same thing behind — a slot
+// with a name on it and nothing to read — so the fold treats them alike rather
+// than keeping a second rule beside this one.
+//
+// The shell cannot produce one (it trims, and blocks an empty submit), but the
+// API used to accept "\n" as text, and those replies rendered as a row zero
+// pixels tall: it counted toward the thread and the pin badge, yet had no hit
+// area, so there was no menu and no way to delete it (#532).
+function hasNoWords(record) {
+  return !!record && (record.deleted || !String(record.text || '').trim());
+}
+
 // The Worker gets this for free — it folds, so a tombstone with nothing left
 // under it simply stops being emitted. Local storage is written, not folded,
 // so the collapse has to happen at delete time: drop tombstoned replies that
@@ -293,13 +306,13 @@ function collapseLocalTombstones(comment) {
     changed = false;
     for (let i = replies.length - 1; i >= 0; i--) {
       const r = replies[i];
-      if (!r.deleted) continue;
+      if (!hasNoWords(r)) continue;
       if (replies.some(other => other.parent_id === r.id)) continue;
       replies.splice(i, 1);
       changed = true;
     }
   }
-  return !(comment.deleted && !replies.length);
+  return !(hasNoWords(comment) && !replies.length);
 }
 
 function localRecordAuthor(comments, id) {
@@ -1590,14 +1603,24 @@ const server = http.createServer(async (req, res) => {
     // Fold to the requested version's snapshot so past versions keep their
     // historical status (matches the worker). Missing version → latest state.
     const ver = url.searchParams.get('version');
-    return json(res, 200, ver != null ? foldCommentsAtVersion(all, ver) : all);
+    // The worker folds on every read, so a record with no words stops being
+    // emitted the moment this ships. Local storage is written rather than
+    // folded, and a blank one arrives with no delete to hang the collapse on —
+    // so it has to happen here, or a document that already holds one would keep
+    // serving a row nobody can see or remove (#532). readCommentFile parses
+    // fresh, so collapsing in place touches nothing on disk.
+    const served = all.filter((c) => collapseLocalTombstones(c));
+    return json(res, 200, ver != null ? foldCommentsAtVersion(served, ver) : served);
   }
 
   if (p === '/api/comments' && req.method === 'POST') {
     if (!isLocalMutation(req)) return json(res, 403, { error: 'forbidden' });
     const body = await readBody(req);
     const slug = safeSlug(body.slug);
-    const { version, anchor, text, parent_id } = body;
+    const { version, anchor, parent_id } = body;
+    // Trimmed before the check, the way the edit path already does it: "\n" is
+    // not a comment, and one that gets in cannot be seen or removed (#532).
+    const text = typeof body.text === 'string' ? body.text.trim() : body.text;
     if (!slug || !text) return json(res, 400, { error: 'invalid slug or missing text' });
     const file = path.join(ROOT, slug, 'comments.json');
     const comments = readCommentFile(file);
@@ -1690,7 +1713,8 @@ const server = http.createServer(async (req, res) => {
     if (!isLocalMutation(req)) return json(res, 403, { error: 'forbidden' });
     const body = await readBody(req);
     const slug = safeSlug(body.slug);
-    const { parent_id, text, status: agentStatus, applied_in } = body;
+    const { parent_id, status: agentStatus, applied_in } = body;
+    const text = typeof body.text === 'string' ? body.text.trim() : body.text;
     if (!slug || !parent_id || !text) return json(res, 400, { error: 'invalid slug or missing parent_id/text' });
     const file = path.join(ROOT, slug, 'comments.json');
     const all = readCommentFile(file);

--- a/test/agent-status-emoji.test.js
+++ b/test/agent-status-emoji.test.js
@@ -46,7 +46,7 @@ t('worker.js defines AGENT_STATUS_EMOJI (snapshotAt references it)', () => {
 
 const deps = [
   'isFiniteVersion', 'eventEid', 'backfillEids', 'dedupEvents',
-  'ensureEventLog', 'legacyToEvents', 'snapshotAt', 'keepThread', 'asTombstone', 'snapshotList',
+  'ensureEventLog', 'legacyToEvents', 'snapshotAt', 'keepThread', 'asTombstone', 'hasNoWords', 'snapshotList',
 ].map(sliceFn).join('\n\n');
 
 const sandbox = {};

--- a/test/api.test.js
+++ b/test/api.test.js
@@ -121,6 +121,24 @@ function waitReady(port, ms = 5000) {
     if (!nested || nested.parent_id !== replyId) throw new Error('nested reply missing or wrong parent');
   });
 
+  // The edit route has always trimmed before deciding whether there is anything
+  // to save. Create and agent-reply only checked for the empty string, so "\n"
+  // got in — and what it produced could not be seen or removed (#532).
+  await t('POST /api/comments refuses text that is only whitespace', async () => {
+    const before = (await req('GET', `/api/comments?slug=${SLUG}`)).body.length;
+    for (const text of ['   ', '\n\n', '\u3000']) {
+      const r = await req('POST', '/api/comments', { slug: SLUG, version: 1, text, anchor: null });
+      if (r.status !== 400) throw new Error(`${JSON.stringify(text)} was accepted with ${r.status}`);
+    }
+    const after = (await req('GET', `/api/comments?slug=${SLUG}`)).body.length;
+    if (after !== before) throw new Error(`a blank comment was still written (${before} -> ${after})`);
+  });
+
+  await t('POST /api/agent/reply refuses text that is only whitespace', async () => {
+    const r = await req('POST', '/api/agent/reply', { slug: SLUG, parent_id: topId, text: '\n   \n' });
+    if (r.status !== 400) throw new Error(`a blank agent reply was accepted with ${r.status}`);
+  });
+
   await t('POST /api/reactions adds 👍 to top comment', async () => {
     const r = await req('POST', '/api/reactions', { slug: SLUG, comment_id: topId, emoji: '👍' });
     if (r.status !== 200) throw new Error(`status ${r.status}: ${JSON.stringify(r.body)}`);
@@ -206,6 +224,13 @@ function waitReady(port, ms = 5000) {
     }
     const after = await req('GET', `/api/comments?slug=${SLUG}`);
     if (after.body.length !== 0) throw new Error(`an empty tombstone stayed: ${JSON.stringify(after.body)}`);
+  });
+
+  // Last, because it leaves a record behind and the deletes above read the list.
+  await t('a comment whose text merely has whitespace around it is kept, trimmed', async () => {
+    const r = await req('POST', '/api/comments', { slug: SLUG, version: 1, text: '  real words  ', anchor: null });
+    if (r.status !== 200) throw new Error(`status ${r.status}: ${JSON.stringify(r.body)}`);
+    if (r.body.text !== 'real words') throw new Error(`stored as ${JSON.stringify(r.body.text)}`);
   });
 
   function rawGet(p) {

--- a/test/comment-history.test.js
+++ b/test/comment-history.test.js
@@ -49,7 +49,7 @@ function sliceFn(name) {
 const deps = [
   'isFiniteVersion', 'eventEid', 'backfillEids', 'dedupEvents',
   'ensureEventLog', 'legacyToEvents', 'snapshotAt',
-  'keepThread', 'asTombstone', 'snapshotList', 'historyList',
+  'keepThread', 'asTombstone', 'hasNoWords', 'snapshotList', 'historyList',
 ].map(sliceFn).join('\n\n');
 
 const sandbox = { AGENT_STATUS_EMOJI: { applied: '✅', partial: '🟡', question: '❓' } };

--- a/test/comment-ops.test.js
+++ b/test/comment-ops.test.js
@@ -190,6 +190,50 @@ t('deleting a comment with nothing under it still disappears outright', () => {
   assert(listAt(list, 1).length === 0, 'a tombstone with no thread under it is litter');
 });
 
+// ---- a record with no words at all (#532) ----
+// The API used to take "\n" as text. What came back was a row zero pixels tall:
+// it counted toward the thread and the pin badge, but had no hit area, so there
+// was no menu on it and no way to delete it. It folds out the same way a
+// deleted one does.
+
+t('a reply that is only whitespace disappears', () => {
+  const list = [];
+  apply(list, { kind: 'create', id: 'c1', author: mkAuthor('alice'), text: 'ALICE asks', anchor: { kind: 'text', text: 'x' }, version: 1, at: '2026-01-01' });
+  apply(list, { kind: 'reply', parent_id: 'c1', reply_id: 'r1', author: mkAuthor('claude'), text: '\n   \n', version: 1, at: '2026-01-02' });
+  const [c] = listAt(list, 1);
+  assert(c, 'the comment itself went missing');
+  assert(c.replies.length === 0,
+    `a wordless reply is still on the thread: ${JSON.stringify(c.replies.map(r => r.text))}`);
+});
+
+t('a comment that is only whitespace disappears outright', () => {
+  const list = [];
+  apply(list, { kind: 'create', id: 'c1', author: mkAuthor('claude'), text: '   ', anchor: { kind: 'text', text: 'x' }, version: 1, at: '2026-01-01' });
+  assert(listAt(list, 1).length === 0, 'a comment with nothing to read kept its pin');
+});
+
+t('a wordless reply that holds an answer keeps its slot, so the thread keeps its middle', () => {
+  const list = [];
+  apply(list, { kind: 'create', id: 'c1', author: mkAuthor('alice'), text: 'ALICE asks', anchor: { kind: 'text', text: 'x' }, version: 1, at: '2026-01-01' });
+  apply(list, { kind: 'reply', parent_id: 'c1', reply_id: 'r1', author: mkAuthor('claude'), text: ' ', version: 1, at: '2026-01-02' });
+  apply(list, { kind: 'reply', parent_id: 'r1', reply_id: 'r2', author: mkAuthor('bob'), text: 'BOB answers that', version: 1, at: '2026-01-03' });
+  const [c] = listAt(list, 1);
+  assert(c.replies.length === 2, `expected the slot and the answer, got ${c.replies.length}`);
+  const slot = c.replies.find(r => r.id === 'r1');
+  assert(slot && slot.deleted === true, 'the wordless slot must read as having no words');
+  assert(slot.author && slot.author.login === 'claude', 'the name on the slot must stay');
+  assert(c.replies.some(r => r.id === 'r2' && r.text === 'BOB answers that'),
+    'the answer under it went with it');
+});
+
+t('a reply with words is left alone', () => {
+  const list = [];
+  apply(list, { kind: 'create', id: 'c1', author: mkAuthor('alice'), text: 'ALICE asks', anchor: { kind: 'text', text: 'x' }, version: 1, at: '2026-01-01' });
+  apply(list, { kind: 'reply', parent_id: 'c1', reply_id: 'r1', author: mkAuthor('claude'), text: '  trimmable but real  ', version: 1, at: '2026-01-02' });
+  const [c] = listAt(list, 1);
+  assert(c.replies.length === 1 && !c.replies[0].deleted, 'a real reply was folded away');
+});
+
 t('a tombstone drops what the words earned: reactions, verdict, mentions', () => {
   const list = [];
   apply(list, { kind: 'create', id: 'c1', author: mkAuthor('alice'), text: 'ALICE asks', anchor: { kind: 'text', text: 'x' }, version: 1, at: '2026-01-01' });

--- a/test/coverage.test.js
+++ b/test/coverage.test.js
@@ -34,7 +34,7 @@ const box = { AGENT_STATUS_EMOJI: { applied: '✅', partial: '🟡', question: '
 vm.createContext(box);
 vm.runInContext([
   'isFiniteVersion', 'eventEid', 'backfillEids', 'dedupEvents',
-  'ensureEventLog', 'legacyToEvents', 'snapshotAt', 'keepThread', 'asTombstone', 'snapshotList',
+  'ensureEventLog', 'legacyToEvents', 'snapshotAt', 'keepThread', 'asTombstone', 'hasNoWords', 'snapshotList',
 ].map(sliceFn).join('\n\n'), box);
 const { legacyToEvents, ensureEventLog, snapshotAt } = box;
 

--- a/test/no-drift.test.js
+++ b/test/no-drift.test.js
@@ -100,7 +100,7 @@ t('safeJsonForScript is identical in worker.js and server.js', () => {
 
 // (cyrb53 lives only in worker.js now — its overlay twin died with the monolith.)
 
-for (const name of ['isAnthropicCompanyMark', 'logoForAgentLogin', 'isGenericAgentLogin', 'detectAgentRuntime', 'agentIdentity', 'isValidWidgetName', 'widgetCspHeader', 'isWidgetFrameRequest', 'forceWidgetSandbox', 'blankDocSlug', 'blankDocHtml', 'titleFromDocument', 'syncDocumentTitle', 'stampOnboarding', 'onboardingActionStep', 'seedCommentAnchor', 'duplicateComment']) {
+for (const name of ['isAnthropicCompanyMark', 'logoForAgentLogin', 'isGenericAgentLogin', 'detectAgentRuntime', 'agentIdentity', 'isValidWidgetName', 'widgetCspHeader', 'isWidgetFrameRequest', 'forceWidgetSandbox', 'blankDocSlug', 'blankDocHtml', 'titleFromDocument', 'syncDocumentTitle', 'stampOnboarding', 'onboardingActionStep', 'seedCommentAnchor', 'duplicateComment', 'hasNoWords']) {
   t(`${name} is identical in worker.js and server.js`, () => {
     const a = norm(fnBody(worker, name));
     const b = norm(fnBody(server, name));

--- a/worker/worker.js
+++ b/worker/worker.js
@@ -2789,8 +2789,21 @@ function snapshotAt(c, V) {
     snap.reactions[emoji] = u;
   }
   delete snap._agentVerdict;
-  snap.replies = keepThread(replyOrder, replyById).map(r => (r.deleted ? asTombstone(r) : r));
+  snap.replies = keepThread(replyOrder, replyById).map(r => (hasNoWords(r) ? asTombstone(r) : r));
   return snap;
+}
+
+// A record with no words. Deleting takes the words away; a caller that posted
+// only whitespace never supplied any. Both leave the same thing behind — a slot
+// with a name on it and nothing to read — so the fold treats them alike rather
+// than keeping a second rule beside this one.
+//
+// The shell cannot produce one (it trims, and blocks an empty submit), but the
+// API used to accept "\n" as text, and those replies rendered as a row zero
+// pixels tall: it counted toward the thread and the pin badge, yet had no hit
+// area, so there was no menu and no way to delete it (#532).
+function hasNoWords(record) {
+  return !!record && (record.deleted || !String(record.text || '').trim());
 }
 
 // Which replies survive the fold. An alive reply always does. A DELETED one
@@ -2799,7 +2812,7 @@ function snapshotAt(c, V) {
 // Resolved to a fixpoint, so a deleted reply whose only child was itself
 // deleted-and-dropped goes as well.
 function keepThread(order, byId) {
-  const keep = new Set(order.filter(id => byId.get(id) && !byId.get(id).deleted));
+  const keep = new Set(order.filter(id => byId.get(id) && !hasNoWords(byId.get(id))));
   for (let changed = true; changed;) {
     changed = false;
     for (const id of order) {
@@ -2845,8 +2858,8 @@ function snapshotList(list, V) {
     // A deleted comment that still holds replies stays as a tombstone; deleting
     // your own words must not be a way to take everyone else's off the page.
     // One with nothing under it disappears, as it always has.
-    if (s.deleted && !s.replies.length) continue;
-    out.push(s.deleted ? asTombstone(s) : s);
+    if (hasNoWords(s) && !s.replies.length) continue;
+    out.push(hasNoWords(s) ? asTombstone(s) : s);
   }
   return out;
 }
@@ -6438,7 +6451,10 @@ export default {
       if (!s) return json({ error: 'sign_in_required' }, { status: 401 });
       let body = {};
       try { body = await req.json(); } catch {}
-      const { slug, version, anchor, text: commentText, parent_id } = body;
+      const { slug, version, anchor, parent_id } = body;
+      // Trimmed before the check, the way the edit path already does it: "\n" is
+      // not a comment, and one that gets in cannot be seen or removed (#532).
+      const commentText = typeof body.text === 'string' ? body.text.trim() : body.text;
       if (!slug || !commentText) return json({ error: 'slug and text required' }, { status: 400 });
       if (!isValidSlug(slug)) return json({ error: 'invalid_slug' }, { status: 400 });
       const meta = await loadDocMeta(env, slug);
@@ -6732,8 +6748,9 @@ export default {
       if (!auth.ok) return auth.response;
       let body = {};
       try { body = await req.json(); } catch {}
-      const { slug, parent_id, text: replyText, status: agentStatus, applied_in,
+      const { slug, parent_id, status: agentStatus, applied_in,
               bind_anchor_aid } = body;
+      const replyText = typeof body.text === 'string' ? body.text.trim() : body.text;
       if (!slug || !parent_id || !replyText) return json({ error: 'slug, parent_id, text required' }, { status: 400 });
       if (!isValidSlug(slug)) return json({ error: 'invalid_slug' }, { status: 400 });
       const writeGate = await requireDocWriteAccess(env, auth.actor, slug);


### PR DESCRIPTION
Closes #532

An AI reply whose text was only whitespace was accepted, stored, and drawn as a
row **zero pixels tall**. It counted — the thread read "1 reply", the pin badge
went to 2 — but it had no hit area, so there was no hover, no `⋯` menu, and **no
way to delete it**.

It is not a tombstone. A tombstone says "Comment deleted" and keeps its name;
this said nothing at all.

### How it got in

| path | check | whitespace gets in |
|---|---|---|
| `PATCH /api/comments` (edit) | `body.text.trim()` then falsy-check | no |
| `POST /api/comments` (create) | `!text` | **yes** |
| `POST /api/agent/reply` | `!text` | **yes** |

`!text` rejects `""` but not `"\n"`, `" "`, or `"　"`. Both runtimes had the
same asymmetry, so this was live on tdoc.dev. The shell was never the way in —
it trims before sending and blocks an empty submit — so only an API caller could
produce one, which is why these arrived as AI replies.

### The fix

- **Stop new ones.** Create and agent-reply trim before validating, in both
  runtimes, the way the edit path always has.
- **Clear existing ones.** A record with no words folds out the way a deleted one
  already does. The rule was already written — *a wordless record survives only
  if something still hangs off it* — so this extends "wordless" from `deleted` to
  `deleted || blank` in `keepThread` / `snapshotList` / `collapseLocalTombstones`
  rather than adding a second rule beside it.

A blank reply that holds an answer keeps its slot (a thread must not lose its
middle, rendered as the existing no-words slot); one holding nothing disappears.

The worker folds on every read, so blanks already sitting in documents stop being
emitted as soon as this ships. Local storage is written rather than folded, and a
blank arrives with no delete to hang the collapse on — so the local `GET` collapses
too, or a document already holding one would keep serving an invisible row.

`hasNoWords` joins the drift guard in `test/no-drift.test.js`: it now decides what
survives a fold in both runtimes.

### Verified

On a document holding a pre-existing blank reply:

```
before   c_1 «可以更加critical一点»   r_blank  height 0px  visible chars 0   → "1 reply", badge 2
after    c_1 «可以更加critical一点»   (no second row)                        → no reply link, no badge
```

The new tests fail on the unfixed code — three of the four fold tests, and both
API guards (`POST /api/comments` and `POST /api/agent/reply` each accepted
whitespace with 200).

- offline suite: **80/80**
- `browser-editing`: **18/18**
- `artifact-shell`: **43/0**

🤖 Generated with [Claude Code](https://claude.com/claude-code)